### PR TITLE
Tag spark dependency as provided.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   "joda-time" % "joda-time" % "2.3",
   "org.apache.cassandra" % "cassandra-thrift" % "2.0.8",
   "org.apache.cassandra" % "cassandra-clientutil" % "2.0.8",
-  "org.apache.spark" %% "spark-core" % "0.9.1",
+  "org.apache.spark" %% "spark-core" % "0.9.1" % "provided",
   "org.joda" % "joda-convert" % "1.2",
   "org.scala-lang" % "scala-reflect" % "2.10.4"
 )


### PR DESCRIPTION
If you tried to create a fatjar to deploy a spark job that used this driver, you would have to manually exclude the spark transitive dependency to not create a massive jar file. I think it should be tagged a "provided" to avoid that problem.
