### PR TITLE
Update 5_saving.md

### DIFF
--- a/doc/5_saving.md
+++ b/doc/5_saving.md
@@ -51,7 +51,7 @@ grouped in unlogged batches. The consistency level for writes is `ONE`.
 ## Tuning
 The following properties set in `SparkConf` can be used to fine-tune the saving process:
 
-  - `spark.cassandra.output.batch.size.rows`: number of rows per single batch; default is 'auto' which means the driver 
+  - `spark.cassandra.output.batch.size.rows`: number of rows per single batch; default is 'auto' which means the connector 
      will adjust the number of rows based on the amount of data in each row  
   - `spark.cassandra.output.batch.size.bytes`: maximum total size of the batch in bytes; defaults to 64 kB.
   - `spark.cassandra.output.concurrent.writes`: maximum number of batches executed in parallel by a single Spark task; defaults to 5


### PR DESCRIPTION
Prefix properties with `spark.`, missed these when fixing #51.
