### PR TITLE
Update 1_connecting.md

### DIFF
--- a/doc/1_connecting.md
+++ b/doc/1_connecting.md
@@ -19,6 +19,7 @@ spark.cassandra.connection.native.port   | Cassandra native port                
 spark.cassandra.auth.username            | login name for password authentication            |
 spark.cassandra.auth.password            | password for password authentication              |
 spark.cassandra.auth.conf.factory.class  | name of the class implementing `AuthConfFactory` providing custom authentication | `DefaultAuthConfFactory`
+spark.cassandra.connection.keep_alive_ms | period of time to keep unused connections open    | 250 ms
   
 Example:
 


### PR DESCRIPTION
Add `spark.cassandra.connection.keep_alive_ms` to list of options that can be set for use by spark-shell.

Should these also be included here as well?

`spark.cassandra.output.batch.size.rows`: number of rows per single batch; default is 'auto' which means the connector will adjust the number of rows based on the amount of data in each row
`spark.cassandra.output.batch.size.bytes`: maximum total size of the batch in bytes; defaults to 64 kB.
`spark.cassandra.output.concurrent.writes`: maximum number of batches executed in parallel by a single Spark task; defaults to 5
