### PR TITLE
Issue #218 - Move resolving of constructor and parameter names from the ...

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+1.0.0
+ * Fix reading a Cassandra table as an RDD of Scala class objects in REPL
+
 1.0.0 RC 5
  * Added assembly task to the build, in order to build fat jars. (#126)
    - Added a system property flag to enable assembly for the demo module which is disabled by default.

--- a/project/CassandraSparkBuild.scala
+++ b/project/CassandraSparkBuild.scala
@@ -81,6 +81,9 @@ object Dependencies {
       val junit           = "junit"                   % "junit"                 % "4.11"         % "test,it"                 // for now
       val junitInterface  = "com.novocode"            % "junit-interface"       % "0.10"         % "test,it"
       val scalatest       = "org.scalatest"           %% "scalatest"            % ScalaTest      % "test,it"                 // ApacheV2
+      val scalactic       = "org.scalactic"           %% "scalactic"            % Scalactic      % "test,it"                 // ApacheV2
+      val sparkRepl       = "org.apache.spark"        %% "spark-repl"           % Spark          % "test,it"   exclude("com.google.guava", "guava") exclude("org.apache.spark", "spark-core_2.10") exclude("org.apache.spark", "spark-bagel_2.10") exclude("org.apache.spark", "spark-mllib_2.10") exclude("org.scala-lang", "scala-compiler")          // ApacheV2
+      val scalaCompiler   = "org.scala-lang"          % "scala-compiler"        % Scala
     }
   }
 
@@ -91,7 +94,7 @@ object Dependencies {
   // Consider: Metrics.metricsJvm, Metrics.latencyUtils, Metrics.hdrHistogram
   val metrics = Seq(Metrics.metricsJson)
 
-  val testKit = Seq(Test.akkaTestKit, Test.cassandraServer, Test.commonsIO, Test.junit, Test.junitInterface, Test.scalatest)
+  val testKit = Seq(Test.akkaTestKit, Test.cassandraServer, Test.commonsIO, Test.junit, Test.junitInterface, Test.scalatest, Test.sparkRepl, Test.scalaCompiler, Test.scalactic)
 
   val akka = Seq(akkaActor, akkaRemote, akkaSlf4j)
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -26,6 +26,8 @@ import com.typesafe.sbt.SbtScalariform._
 
 import scala.language.postfixOps
 
+import net.virtualvoid.sbt.graph.Plugin.graphSettings
+
 object Settings extends Build {
 
   lazy val buildSettings = Seq(
@@ -46,7 +48,7 @@ object Settings extends Build {
     publish := {}
   )
 
-  lazy val defaultSettings = testSettings ++ mimaSettings ++ releaseSettings ++ Seq(
+  lazy val defaultSettings = testSettings ++ mimaSettings ++ releaseSettings ++ graphSettings ++ Seq(
     scalacOptions in (Compile, doc) ++= Seq("-implicits","-doc-root-content", "rootdoc.txt"),
     scalacOptions ++= Seq("-encoding", "UTF-8", s"-target:jvm-${Versions.JDK}", "-deprecation", "-feature", "-language:_", "-unchecked", "-Xlint"),
     javacOptions in (Compile, doc) := Seq("-encoding", "UTF-8", "-source", Versions.JDK),
@@ -74,11 +76,11 @@ object Settings extends Build {
   val tests = inConfig(Test)(Defaults.testTasks) ++ inConfig(IntegrationTest)(Defaults.itSettings)
 
   val testOptionSettings = Seq(
-    // commented out for now until migrated to: Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
+    Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
     Tests.Argument(TestFrameworks.JUnit, "-oDF", "-v", "-a")
   )
 
-  lazy val testSettings = tests ++ Seq(
+  lazy val testSettings = tests ++ graphSettings ++ Seq(
     parallelExecution in Test := false,
     parallelExecution in IntegrationTest := false,
     testOptions in Test ++= testOptionSettings,

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -30,7 +30,8 @@ object Versions {
   val Lzf             = "0.8.4"
   val MetricsJson     = "3.0.2"
   val Scala           = "2.10.4"
-  val ScalaTest       = "2.2.1"
+  val ScalaTest       = "2.2.2"
+  val Scalactic       = "2.2.2"
   val Slf4j           = "1.7.7"
   val Spark           = "0.9.1"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,5 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.6")
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")

--- a/spark-cassandra-connector/src/it/resources/log4j.properties
+++ b/spark-cassandra-connector/src/it/resources/log4j.properties
@@ -23,7 +23,7 @@ log4j.rootLogger=WARN,stdout
 # stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%5p %d{HH:mm:ss,SSS} %m%n
+log4j.appender.stdout.layout.ConversionPattern=%5p %d{HH:mm:ss,SSS} %C (%F:%L) - %m%n
 
 # Adding this to avoid thrift logging disconnect errors.
 log4j.logger.org.apache.thrift.server.TNonblockingServer=ERROR
@@ -31,3 +31,5 @@ log4j.logger.org.apache.thrift.server.TNonblockingServer=ERROR
 # Avoid "no host ID found" when starting a fresh node
 log4j.logger.org.apache.cassandra.db.SystemKeyspace=ERROR
 
+# Avoid "address already in use" when starting multiple local Spark masters
+log4j.logger.org.eclipse.jetty.util.component.AbstractLifeCycle=ERROR

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/repl/CassandraRDDReplSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/repl/CassandraRDDReplSpec.scala
@@ -1,0 +1,164 @@
+package com.datastax.spark.connector.repl
+
+import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.testkit.{CassandraServer, SparkRepl, SparkServer}
+import org.scalatest.{FlatSpec, Matchers}
+
+class CassandraRDDReplSpec extends FlatSpec with Matchers with CassandraServer with SparkServer with SparkRepl {
+  useCassandraConfig("cassandra-default.yaml.template")
+
+  val conn = CassandraConnector(cassandraHost)
+
+  conn.withSessionDo { session =>
+    session.execute("CREATE KEYSPACE IF NOT EXISTS read_test WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }")
+
+    session.execute("CREATE TABLE IF NOT EXISTS read_test.simple_kv (key INT, value TEXT, PRIMARY KEY (key))")
+    session.execute("INSERT INTO read_test.simple_kv (key, value) VALUES (1, '0001')")
+    session.execute("INSERT INTO read_test.simple_kv (key, value) VALUES (2, '0002')")
+    session.execute("INSERT INTO read_test.simple_kv (key, value) VALUES (3, '0003')")
+  }
+
+  ignore should "allow to read a Cassandra table as Array of Scala class objects in REPL" in {
+    val output = runInterpreter("local",
+      """
+        |import com.datastax.spark.connector._
+        |
+        |case class SampleScalaCaseClass(key: Int, value: String)
+        |val cnt1 = sc.cassandraTable[SampleScalaCaseClass]("read_test", "simple_kv").toArray.length
+        |
+        |class SampleScalaClass(val key: Int, val value: String) extends Serializable
+        |val cnt2 = sc.cassandraTable[SampleScalaClass]("read_test", "simple_kv").toArray.length
+        |
+        |class SampleScalaClassWithNoFields(key: Int, value: String) extends Serializable
+        |val cnt3 = sc.cassandraTable[SampleScalaClassWithNoFields]("read_test", "simple_kv").toArray.length
+        |
+        |class SampleScalaClassWithMultipleCtors(var key: Int, var value: String) extends Serializable {
+        |  def this(key: Int) = this(key, null)
+        |  def this() = this(0, null)
+        |}
+        |val cnt4 = sc.cassandraTable[SampleScalaClassWithMultipleCtors]("read_test", "simple_kv").toArray.length
+        |
+        |class SampleWithNestedScalaCaseClass extends Serializable {
+        |  case class InnerClass(key: Int, value: String)
+        |}
+        |val cnt5 = sc.cassandraTable[SampleWithNestedScalaCaseClass#InnerClass]("read_test", "simple_kv").toArray.length
+        |
+        |class SampleWithDeeplyNestedScalaCaseClass extends Serializable {
+        |  class IntermediateClass extends Serializable {
+        |    case class InnerClass(key: Int, value: String)
+        |  }
+        |}
+        |val cnt6 = sc.cassandraTable[SampleWithDeeplyNestedScalaCaseClass#IntermediateClass#InnerClass]("read_test", "simple_kv").toArray.length
+        |
+        |object SampleObject extends Serializable {
+        |  case class ClassInObject(key: Int, value: String)
+        |}
+        |val cnt7 = sc.cassandraTable[SampleObject.ClassInObject]("read_test", "simple_kv").toArray.length
+      """.stripMargin)
+    output should not include "error:"
+    output should not include "Exception"
+    output should include("cnt1: Int = 3")
+    output should include("cnt2: Int = 3")
+    output should include("cnt3: Int = 3")
+    output should include("cnt4: Int = 3")
+    output should include("cnt5: Int = 3")
+    output should include("cnt6: Int = 3")
+    output should include("cnt7: Int = 3")
+  }
+
+  ignore should "allow to read a Cassandra table as Array of Scala case class objects in REPL" in {
+    val output = runInterpreter("local",
+      """
+        |import com.datastax.spark.connector._
+        |case class SampleScalaCaseClass(key: Int, value: String)
+        |val cnt = sc.cassandraTable[SampleScalaCaseClass]("read_test", "simple_kv").toArray.length
+      """.stripMargin)
+    output should not include "error:"
+    output should not include "Exception"
+    output should include ("cnt: Int = 3")
+  }
+
+  ignore should "allow to read a Cassandra table as Array of ordinary Scala class objects in REPL" in {
+    val output = runInterpreter("local",
+      """
+        |import com.datastax.spark.connector._
+        |class SampleScalaClass(val key: Int, val value: String) extends Serializable
+        |val cnt = sc.cassandraTable[SampleScalaClass]("read_test", "simple_kv").toArray.length
+      """.stripMargin)
+    output should not include "error:"
+    output should not include "Exception"
+    output should include ("cnt: Int = 3")
+  }
+
+  ignore should "allow to read a Cassandra table as Array of Scala class without fields objects in REPL" in {
+    val output = runInterpreter("local",
+      """
+        |import com.datastax.spark.connector._
+        |class SampleScalaClassWithNoFields(key: Int, value: String) extends Serializable
+        |val cnt = sc.cassandraTable[SampleScalaClassWithNoFields]("read_test", "simple_kv").toArray.length
+      """.stripMargin)
+    output should not include "error:"
+    output should not include "Exception"
+    output should include ("cnt: Int = 3")
+  }
+
+  ignore should "allow to read a Cassandra table as Array of Scala class with multiple constructors objects in REPL" in {
+    val output = runInterpreter("local",
+      """
+        |import com.datastax.spark.connector._
+        |class SampleScalaClassWithMultipleCtors(var key: Int, var value: String) extends Serializable {
+        |  def this(key: Int) = this(key, null)
+        |  def this() = this(0, null)
+        |}
+        |val cnt = sc.cassandraTable[SampleScalaClassWithMultipleCtors]("read_test", "simple_kv").toArray.length
+      """.stripMargin)
+    output should not include "error:"
+    output should not include "Exception"
+    output should include ("cnt: Int = 3")
+  }
+
+  ignore should "allow to read a Cassandra table as Array of inner Scala case class objects in REPL" in {
+    val output = runInterpreter("local",
+      """
+        |import com.datastax.spark.connector._
+        |class SampleWithNestedScalaCaseClass extends Serializable {
+        |  case class InnerClass(key: Int, value: String)
+        |}
+        |val cnt = sc.cassandraTable[SampleWithNestedScalaCaseClass#InnerClass]("read_test", "simple_kv").toArray.length
+      """.stripMargin)
+    output should not include "error:"
+    output should not include "Exception"
+    output should include ("cnt: Int = 3")
+  }
+
+  ignore should "allow to read a Cassandra table as Array of deeply nested inner Scala case class objects in REPL" in {
+    val output = runInterpreter("local",
+      """
+        |import com.datastax.spark.connector._
+        |class SampleWithDeeplyNestedScalaCaseClass extends Serializable {
+        |  class IntermediateClass extends Serializable {
+        |    case class InnerClass(key: Int, value: String)
+        |  }
+        |}
+        |val cnt = sc.cassandraTable[SampleWithDeeplyNestedScalaCaseClass#IntermediateClass#InnerClass]("read_test", "simple_kv").toArray.length
+      """.stripMargin)
+    output should not include "error:"
+    output should not include "Exception"
+    output should include ("cnt: Int = 3")
+  }
+
+  ignore should "allow to read a Cassandra table as Array of nested Scala case class objects in REPL" in {
+    val output = runInterpreter("local",
+      """
+        |import com.datastax.spark.connector._
+        |object SampleObject extends Serializable {
+        |  case class ClassInObject(key: Int, value: String)
+        |}
+        |val cnt = sc.cassandraTable[SampleObject.ClassInObject]("read_test", "simple_kv").toArray.length
+      """.stripMargin)
+    output should not include "error:"
+    output should not include "Exception"
+    output should include ("cnt: Int = 3")
+  }
+
+}

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/testkit/SparkRepl.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/testkit/SparkRepl.scala
@@ -1,0 +1,39 @@
+package com.datastax.spark.connector.testkit
+
+import java.io.{PrintWriter, StringWriter, StringReader, BufferedReader}
+import java.net.URLClassLoader
+
+import org.apache.spark.repl.SparkILoop
+
+import scala.collection.mutable.ArrayBuffer
+
+trait SparkRepl {
+  def runInterpreter(master: String, input: String): String = {
+    System.setProperty("spark.cassandra.connection.host", CassandraServer.cassandraHost.getHostAddress)
+    val in = new BufferedReader(new StringReader(input + "\n"))
+    val out = new StringWriter()
+    val cl = getClass.getClassLoader
+    var paths = new ArrayBuffer[String]
+    cl match {
+      case urlLoader: URLClassLoader =>
+        for (url <- urlLoader.getURLs) {
+          if (url.getProtocol == "file") {
+            paths += url.getFile
+          }
+        }
+      case _ =>
+    }
+    val interp = new SparkILoop(in, new PrintWriter(out), master)
+    org.apache.spark.repl.Main.interp = interp
+    val separator = System.getProperty("path.separator")
+    interp.process(Array("-classpath", paths.mkString(separator)))
+    org.apache.spark.repl.Main.interp = null
+    if (interp.sparkContext != null) {
+      interp.sparkContext.stop()
+    }
+    // To avoid Akka rebinding to the same port, since it doesn't unbind immediately on shutdown
+    System.clearProperty("spark.driver.port")
+    out.toString
+  }
+
+}


### PR DESCRIPTION
...code run by the executor back to the application
- AnyObjectFactory computes the resolved constructor parameter type names and stores them in a serializable field. After deserialization, it finds the proper constructor which signature matches the stored type names.
- Added CassandraRDDReplSpec for testing CassandraRDD behaviour in REPL - for now, the tests are ignored because of some problems
- Added Scalactic to the dependencies of tests
- Added SBT plugin which allows to show the dependency tree of a module

Fixes #218
