### PR TITLE
Fix issue #180  by adding a shell script to download sbt for developers

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+ * Add an ./sbt/sbt script (like with spark) so people don't need to install sbt
+
 1.1.0
  * Accept partition key predicates in CassandraRDD#where. (#37)
  * Allow multiple comma-separated hosts in spark.cassandra.connection.host

--- a/README.md
+++ b/README.md
@@ -32,11 +32,10 @@ If you want to access the functionality of Connector from Java, you may want to 
     libraryDependencies += "com.datastax.spark" %% "spark-cassandra-connector-java" % "1.0.0-rc5" withSources() withJavadoc()
 
 ## Building
-You need to install SBT version 0.13 or newer to build this project.
 In the project root directory run:
 
-    sbt package
-    sbt doc
+    ./sbt/sbt package
+    ./sbt/sbt doc
     
 The library package jars will be placed in:
   - `spark-cassandra-connector/target/scala-2.10/`
@@ -80,17 +79,17 @@ end of each commit message (where *xx* is the number of the issue).
 ## Testing
 To run unit and integration tests:
 
-    sbt test
-    sbt it:test
+    ./sbt/sbt test
+    ./sbt/sbt it:test
 
 By default, integration tests start up a separate, single Cassandra instance and run Spark in local mode.
 It is possible to run integration tests with your own Cassandra and/or Spark cluster.
 First, prepare a jar with testing code:
     
-    sbt test:package
+    ./sbt/sbt test:package
     
 Then copy the generated test jar to your Spark nodes and run:    
 
     export IT_TEST_CASSANDRA_HOST=<IP of one of the Cassandra nodes>
     export IT_TEST_SPARK_MASTER=<Spark Master URL>
-    sbt it:test    
+    ./sbt/sbt it:test    

--- a/sbt/sbt
+++ b/sbt/sbt
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script launches sbt for this project. If present it uses the system 
+# version of sbt. If there is no system version of sbt it attempts to download
+# sbt locally.
+SBT_VERSION=0.13.1
+URL1=http://typesafe.artifactoryonline.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch.jar
+URL2=http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch.jar
+JAR=sbt/sbt-launch-${SBT_VERSION}.jar
+
+# Download sbt launch jar if it hasn't been downloaded yet
+if [ ! -f ${JAR} ]; then
+  # Download
+  printf "Attempting to fetch sbt\n"
+  JAR_DL=${JAR}.part
+  if hash curl 2>/dev/null; then
+    (curl --progress-bar ${URL1} > ${JAR_DL} || curl --progress-bar ${URL2} > ${JAR_DL}) && mv ${JAR_DL} ${JAR}
+  elif hash wget 2>/dev/null; then
+    (wget --progress=bar ${URL1} -O ${JAR_DL} || wget --progress=bar ${URL2} -O ${JAR_DL}) && mv ${JAR_DL} ${JAR}
+  else
+    printf "You do not have curl or wget installed, please install sbt manually from http://www.scala-sbt.org/\n"
+    exit -1
+  fi
+fi
+if [ ! -f ${JAR} ]; then
+  # We failed to download
+  printf "Our attempt to download sbt locally to ${JAR} failed. Please install sbt manually from http://www.scala-sbt.org/\n"
+  exit -1
+fi
+printf "Launching sbt from ${JAR}\n"
+java \
+  -Xmx1200m -XX:MaxPermSize=350m -XX:ReservedCodeCacheSize=256m \
+  -jar ${JAR} \
+  "$@"


### PR DESCRIPTION
This isn't an exact match to issue #180 which asks for a pure documentation change, but this adds a shell script which downloads and launches sbt and references it in the README. This is the approach we have taken in both Spark & with the examples in the Learning Spark book.
