### PR TITLE
Replace internal spark Logging with own class

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
  * Add an ./sbt/sbt script (like with spark) so people don't need to install sbt
 
 1.1.0
+ * Replace internal spark Logging with own class (#245)
  * Accept partition key predicates in CassandraRDD#where. (#37)
  * Add indexedColumn to ColumnDef (#122)
  * Upgrade Spark to version 1.0.2 

--- a/spark-cassandra-connector-demos/src/main/scala/com/datastax/spark/connector/demo/DemoApp.scala
+++ b/spark-cassandra-connector-demos/src/main/scala/com/datastax/spark/connector/demo/DemoApp.scala
@@ -1,6 +1,7 @@
 package com.datastax.spark.connector.demo
 
-import org.apache.spark.{Logging, SparkContext, SparkConf}
+import com.datastax.spark.connector.util.Logging
+import org.apache.spark.{SparkContext, SparkConf}
 
 trait DemoApp extends App with Logging {
 

--- a/spark-cassandra-connector-demos/src/main/scala/com/datastax/spark/connector/demo/streaming/AkkaStreamingDemo.scala
+++ b/spark-cassandra-connector-demos/src/main/scala/com/datastax/spark/connector/demo/streaming/AkkaStreamingDemo.scala
@@ -1,10 +1,12 @@
 package com.datastax.spark.connector.demo.streaming
 
+import com.datastax.spark.connector.util.Logging
+
 import scala.collection.immutable
 import scala.concurrent.duration._
 import akka.actor._
 import org.apache.spark.streaming.{Milliseconds, StreamingContext}
-import org.apache.spark.{Logging, SparkConf, SparkContext, SparkEnv}
+import org.apache.spark.{SparkConf, SparkContext, SparkEnv}
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.streaming.TypedStreamingActor
 import com.datastax.spark.connector.demo.Assertions

--- a/spark-cassandra-connector-demos/src/main/scala/com/datastax/spark/connector/demo/streaming/KafkaStreamingDemo.scala
+++ b/spark-cassandra-connector-demos/src/main/scala/com/datastax/spark/connector/demo/streaming/KafkaStreamingDemo.scala
@@ -1,8 +1,9 @@
 package com.datastax.spark.connector.demo.streaming
 
 import com.datastax.spark.connector.demo.Assertions
+import com.datastax.spark.connector.util.Logging
 import kafka.serializer.StringDecoder
-import org.apache.spark.{SparkEnv, SparkConf, Logging}
+import org.apache.spark.{SparkEnv, SparkConf}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming._
 import org.apache.spark.streaming.StreamingContext._

--- a/spark-cassandra-connector-demos/src/main/scala/com/datastax/spark/connector/demo/streaming/embedded/Embedded.scala
+++ b/spark-cassandra-connector-demos/src/main/scala/com/datastax/spark/connector/demo/streaming/embedded/Embedded.scala
@@ -6,8 +6,7 @@ import java.util.UUID
 import com.datastax.spark.connector.demo.Assertions
 import com.google.common.io.Files
 import org.apache.commons.lang3.SystemUtils
-import org.apache.spark.Logging
-import com.datastax.spark.connector.util.IOUtils
+import com.datastax.spark.connector.util.{Logging, IOUtils}
 
 /** INTERNAL API.
   * Helper class for demos and tests. Useful for quick prototyping. */

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
@@ -5,10 +5,10 @@ import java.net.InetAddress
 
 import com.datastax.driver.core.{Session, Host, Cluster}
 import com.datastax.driver.core.policies._
-import com.datastax.spark.connector.util.IOUtils
+import com.datastax.spark.connector.util.{Logging, IOUtils}
 
 import org.apache.cassandra.thrift.Cassandra
-import org.apache.spark.{Logging, SparkConf}
+import org.apache.spark.SparkConf
 import org.apache.thrift.protocol.TBinaryProtocol
 
 import scala.collection.JavaConversions._

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -2,7 +2,8 @@ package com.datastax.spark.connector.cql
 
 import java.net.InetAddress
 
-import org.apache.spark.{Logging, SparkConf}
+import com.datastax.spark.connector.util.Logging
+import org.apache.spark.SparkConf
 import scala.util.control.NonFatal
 
 /** Stores configuration of a connection to Cassandra.

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/PreparedStatementCache.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/PreparedStatementCache.scala
@@ -1,7 +1,7 @@
 package com.datastax.spark.connector.cql
 
 import com.datastax.driver.core.{RegularStatement, Session, Cluster, PreparedStatement}
-import org.apache.spark.Logging
+import com.datastax.spark.connector.util.Logging
 
 import scala.collection.concurrent.TrieMap
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
@@ -1,8 +1,9 @@
 package com.datastax.spark.connector.cql
 
+import com.datastax.spark.connector.util.Logging
+
 import scala.collection.JavaConversions._
 import scala.language.existentials
-import org.apache.spark.Logging
 import com.datastax.driver.core.{ColumnMetadata, Metadata, TableMetadata, KeyspaceMetadata}
 import com.datastax.spark.connector.types.{CounterType, ColumnType}
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
@@ -9,10 +9,10 @@ import com.datastax.spark.connector.rdd.partitioner.{CassandraRDDPartitioner, Ca
 import com.datastax.spark.connector.rdd.partitioner.dht.TokenFactory
 import com.datastax.spark.connector.rdd.reader._
 import com.datastax.spark.connector.types.{ColumnType, TypeConverter}
-import com.datastax.spark.connector.util.CountingIterator
+import com.datastax.spark.connector.util.{Logging, CountingIterator}
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.{Logging, Partition, SparkContext, TaskContext}
+import org.apache.spark.{Partition, SparkContext, TaskContext}
 
 import scala.collection.JavaConversions._
 import scala.language.existentials
@@ -53,6 +53,22 @@ class CassandraRDD[R] private[connector] (
   implicit
     ct : ClassTag[R], @transient rtf: RowReaderFactory[R])
   extends RDD[R](sc, Seq.empty) with Logging {
+
+  /* Logging classes inheritance conflict fix
+   */
+  override def log = super[Logging].log
+  override def logInfo(msg: => String) = super[Logging].logInfo(msg)
+  override def logDebug(msg: => String) = super[Logging].logDebug(msg)
+  override def logTrace(msg: => String) = super[Logging].logTrace(msg)
+  override def logWarning(msg: => String) = super[Logging].logWarning(msg)
+  override def logError(msg: => String) = super[Logging].logError(msg)
+  override def logInfo(msg: => String, throwable: Throwable) = super[Logging].logInfo(msg, throwable)
+  override def logDebug(msg: => String, throwable: Throwable) = super[Logging].logDebug(msg, throwable)
+  override def logTrace(msg: => String, throwable: Throwable) = super[Logging].logTrace(msg, throwable)
+  override def logWarning(msg: => String, throwable: Throwable) = super[Logging].logWarning(msg, throwable)
+  override def logError(msg: => String, throwable: Throwable) = super[Logging].logError(msg, throwable)
+  override def isTraceEnabled = super[Logging].isTraceEnabled
+
 
   /** How many rows are fetched at once from server */
   val fetchSize = sc.getConf.getInt("spark.cassandra.input.page.row.size", 1000)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/ServerSideTokenRangeSplitter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/ServerSideTokenRangeSplitter.scala
@@ -5,8 +5,8 @@ import java.net.InetAddress
 
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.rdd.partitioner.dht.{Token, TokenFactory, TokenRange}
+import com.datastax.spark.connector.util.Logging
 import org.apache.cassandra.thrift.CfSplit
-import org.apache.spark.Logging
 
 import scala.collection.JavaConversions._
 import scala.util.{Failure, Success, Try}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/AnyObjectFactory.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/AnyObjectFactory.scala
@@ -2,10 +2,10 @@ package com.datastax.spark.connector.rdd.reader
 
 import java.lang.reflect.Constructor
 
+import com.datastax.spark.connector.util.Logging
 import com.google.common.primitives.Primitives
 import com.thoughtworks.paranamer.AdaptiveParanamer
 import org.apache.commons.lang3.reflect.ConstructorUtils
-import org.apache.spark.Logging
 
 import scala.reflect.runtime.universe._
 import scala.util.{Failure, Success, Try}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/StreamingContextFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/StreamingContextFunctions.scala
@@ -1,7 +1,7 @@
 package com.datastax.spark.connector.streaming
 
 import akka.actor.{ActorRef, Actor}
-import org.apache.spark.Logging
+import com.datastax.spark.connector.util.Logging
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.scheduler.StreamingListener
 import org.apache.spark.streaming.receiver.ActorHelper

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/CqlWhereParser.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/CqlWhereParser.scala
@@ -1,9 +1,6 @@
 package com.datastax.spark.connector.util
 
 import java.util.UUID
-
-import org.apache.spark.Logging
-
 import scala.util.parsing.combinator.RegexParsers
 
 object CqlWhereParser extends RegexParsers with Logging {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/Logging.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/Logging.scala
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.spark.connector.util
+
+import org.apache.log4j.{LogManager, PropertyConfigurator}
+import org.apache.spark.SparkContext
+import org.slf4j.impl.StaticLoggerBinder
+import org.slf4j.{Logger, LoggerFactory}
+
+/**
+ * Spark Logging is marked as DeveloperApi.
+ * This is a copy of it for compatibility.
+ */
+trait Logging {
+  // Make the log field transient so that objects with Logging can
+  // be serialized and used on another machine
+  @transient private var log_ : Logger = null
+
+  // Method to get the logger name for this object
+  protected def logName = {
+    // Ignore trailing $'s in the class names for Scala objects
+    this.getClass.getName.stripSuffix("$")
+  }
+
+  // Method to get or create the logger for this object
+  protected def log: Logger = {
+    if (log_ == null) {
+      initializeIfNecessary()
+      log_ = LoggerFactory.getLogger(logName)
+    }
+    log_
+  }
+
+  // Log methods that take only a String
+  protected def logInfo(msg: => String) {
+    if (log.isInfoEnabled) log.info(msg)
+  }
+
+  protected def logDebug(msg: => String) {
+    if (log.isDebugEnabled) log.debug(msg)
+  }
+
+  protected def logTrace(msg: => String) {
+    if (log.isTraceEnabled) log.trace(msg)
+  }
+
+  protected def logWarning(msg: => String) {
+    if (log.isWarnEnabled) log.warn(msg)
+  }
+
+  protected def logError(msg: => String) {
+    if (log.isErrorEnabled) log.error(msg)
+  }
+
+  // Log methods that take Throwables (Exceptions/Errors) too
+  protected def logInfo(msg: => String, throwable: Throwable) {
+    if (log.isInfoEnabled) log.info(msg, throwable)
+  }
+
+  protected def logDebug(msg: => String, throwable: Throwable) {
+    if (log.isDebugEnabled) log.debug(msg, throwable)
+  }
+
+  protected def logTrace(msg: => String, throwable: Throwable) {
+    if (log.isTraceEnabled) log.trace(msg, throwable)
+  }
+
+  protected def logWarning(msg: => String, throwable: Throwable) {
+    if (log.isWarnEnabled) log.warn(msg, throwable)
+  }
+
+  protected def logError(msg: => String, throwable: Throwable) {
+    if (log.isErrorEnabled) log.error(msg, throwable)
+  }
+
+  protected def isTraceEnabled(): Boolean = {
+    log.isTraceEnabled
+  }
+
+  private def initializeIfNecessary() {
+    if (!Logging.initialized) {
+      Logging.initLock.synchronized {
+        if (!Logging.initialized) {
+          initializeLogging()
+        }
+      }
+    }
+  }
+
+  private def initializeLogging() {
+    // Don't use a logger in here, as this is itself occurring during initialization of a logger
+    // If Log4j 1.2 is being used, but is not initialized, load a default properties file
+    val binderClass = StaticLoggerBinder.getSingleton.getLoggerFactoryClassStr
+    // This distinguishes the log4j 1.2 binding, currently
+    // org.slf4j.impl.Log4jLoggerFactory, from the log4j 2.0 binding, currently
+    // org.apache.logging.slf4j.Log4jLoggerFactory
+    val usingLog4j12 = "org.slf4j.impl.Log4jLoggerFactory".equals(binderClass)
+    val log4j12Initialized = LogManager.getRootLogger.getAllAppenders.hasMoreElements
+    if (!log4j12Initialized && usingLog4j12) {
+      val defaultLogProps = "org/apache/spark/log4j-defaults.properties"
+      Option(getSparkClassLoader.getResource(defaultLogProps)) match {
+        case Some(url) =>
+          PropertyConfigurator.configure(url)
+          System.err.println(s"Using Spark's default log4j profile: $defaultLogProps")
+        case None =>
+          System.err.println(s"Spark was unable to load $defaultLogProps")
+      }
+    }
+    Logging.initialized = true
+
+    // Force a call into slf4j to initialize it. Avoids this happening from multiple threads
+    // and triggering this: http://mailman.qos.ch/pipermail/slf4j-dev/2010-April/002956.html
+    log
+  }
+
+  /**
+   * Get the ClassLoader which loaded Spark.
+   */
+  def getSparkClassLoader = SparkContext.getClass.getClassLoader
+}
+
+private object Logging {
+  @volatile private var initialized = false
+  val initLock = new Object()
+  try {
+    // We use reflection here to handle the case where users remove the
+    // slf4j-to-jul bridge order to route their logs to JUL.
+    val bridgeClass = Class.forName("org.slf4j.bridge.SLF4JBridgeHandler")
+    bridgeClass.getMethod("removeHandlersForRootLogger").invoke(null)
+    val installed = bridgeClass.getMethod("isInstalled").invoke(null).asInstanceOf[Boolean]
+    if (!installed) {
+      bridgeClass.getMethod("install").invoke(null)
+    }
+  } catch {
+    case e: ClassNotFoundException => // can't log anything yet so just fail silently
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -5,9 +5,9 @@ import java.io.IOException
 import com.datastax.driver.core.{Session, BatchStatement, PreparedStatement, ConsistencyLevel}
 import com.datastax.spark.connector.{AllColumns, SomeColumns, ColumnSelector}
 import com.datastax.spark.connector.cql.{ColumnDef, Schema, TableDef, CassandraConnector}
-import com.datastax.spark.connector.util.CountingIterator
+import com.datastax.spark.connector.util.{Logging, CountingIterator}
 
-import org.apache.spark.{Logging, TaskContext}
+import org.apache.spark.TaskContext
 
 import scala.collection._
 import scala.reflect.ClassTag


### PR DESCRIPTION
That fixes #245 and allows to run connector with spark 1.0.2 and 1.1 without recompilation
