### PR TITLE
259 Updated the streaming doc, removed stale status.

### DIFF
--- a/doc/8_streaming.md
+++ b/doc/8_streaming.md
@@ -3,9 +3,12 @@
 Spark Streaming extends the core API to allow high-throughput, fault-tolerant stream processing of live data streams.
 Data can be ingested from many sources such as Akka, Kafka, Flume, Twitter, ZeroMQ, TCP sockets, etc. Results can be stored in Cassandra.
 
-For our initial streaming release, due to time constraints, we started with Akka integration of Spark Streaming. 
-However coming soon is Kafka, ZeroMQ, then Twitter Streaming.
+There is support for Akka with Spark Streaming, and a demo covering this usage. There is also a demo showing how to use
+Kafka with Spark Streaming, for which we also have exposed an Embedded Kafka and ZooKeeper server for quick user prototyping. 
+See the 'demos' module, 'streaming' package.
 
+Similar demos for Twitter and ZeroMQ with Spark Streaming are coming soon.
+ 
 ### The Basic Idea
 
 #### Spark Streaming


### PR DESCRIPTION
Resolves https://github.com/datastax/spark-cassandra-connector/issues/259
