### PR TITLE
Added support for ignoring non-local nodes in the load balancer

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,6 +22,7 @@
      without requiring a Spark and Cassandra Cluster, local or remote, to get started.
  * Upgraded Apache Spark to 1.1.0.
  * Upgraded to be Cassandra 2.1.0 and Cassandra 2.0 compatible.
+ * Added spark.cassandra.connection.local_dc option
 
 1.0.0
  * Fix memory leak in PreparedStatementCache leaking PreparedStatements after

--- a/doc/1_connecting.md
+++ b/doc/1_connecting.md
@@ -27,6 +27,7 @@ Property name                                        | Description              
 spark.cassandra.connection.keep_alive_ms             | period of time to keep unused connections open                | 250 ms
 spark.cassandra.connection.reconnection_delay_ms.min | minimum period of time to attempt reconnecting to a dead node | 1000 ms 
 spark.cassandra.connection.reconnection_delay_ms.max | maximum period of time to attempt reconnecting to a dead node | 60000 ms 
+spark.cassandra.connection.local_dc                  | the local DC to connect to (other nodes will be ignored)      | none
 spark.cassandra.query.retry.count                    | number of times to retry a timed-out query                    | 10 
   
 Example:

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
@@ -149,6 +149,7 @@ object CassandraConnector extends Logging {
   val keepAliveMillis = System.getProperty("spark.cassandra.connection.keep_alive_ms", "250").toInt
   val minReconnectionDelay = System.getProperty("spark.cassandra.connection.reconnection_delay_ms.min", "1000").toInt
   val maxReconnectionDelay = System.getProperty("spark.cassandra.connection.reconnection_delay_ms.max", "60000").toInt
+  val localDC = System.getProperty("spark.cassandra.connection.local_dc")
   val retryCount = System.getProperty("spark.cassandra.query.retry.count", "10").toInt
 
   implicit final val protocolVersion: Int = -1
@@ -164,7 +165,7 @@ object CassandraConnector extends Logging {
         .withPort(conf.nativePort)
         .withRetryPolicy(new MultipleRetryPolicy(retryCount))
         .withReconnectionPolicy(new ExponentialReconnectionPolicy(minReconnectionDelay, maxReconnectionDelay))
-        .withLoadBalancingPolicy(new LocalNodeFirstLoadBalancingPolicy(conf.hosts))
+        .withLoadBalancingPolicy(new LocalNodeFirstLoadBalancingPolicy(conf.hosts, Option(localDC)))
         .withAuthProvider(conf.authConf.authProvider)
         .build()
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/LocalNodeFirstLoadBalancingPolicy.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/LocalNodeFirstLoadBalancingPolicy.scala
@@ -6,22 +6,40 @@ import java.net.{InetAddress, NetworkInterface}
 import scala.collection.JavaConversions._
 import scala.util.Random
 
+import org.apache.spark.Logging
+
 /** Selects local node first and then nodes in local DC in random order. Never selects nodes from other DCs. */
-class LocalNodeFirstLoadBalancingPolicy(contactPoints: Set[InetAddress]) extends LoadBalancingPolicy {
+class LocalNodeFirstLoadBalancingPolicy(contactPoints: Set[InetAddress], localDC: Option[String] = None) extends LoadBalancingPolicy with Logging {
 
   import LocalNodeFirstLoadBalancingPolicy._
 
   private var liveNodes = Set.empty[Host]
+  private var dcToUse = ""
   private val random = new Random
 
   override def distance(host: Host): HostDistance =
-    if (isLocalHost(host))
-      HostDistance.LOCAL
-    else
-      HostDistance.REMOTE
+    if (host.getDatacenter == dcToUse) {
+      logInfo(s"Adding host ${host.getAddress.getHostAddress} (${host.getDatacenter})")
+      sameDCHostDistance(host)
+    } else {
+      // this insures we keep remote hosts out of our list entirely, even when we get notified of newly joined nodes
+      logInfo(s"Ignoring remote host ${host.getAddress.getHostAddress} (${host.getDatacenter})")
+      HostDistance.IGNORED
+    }
 
   override def init(cluster: Cluster, hosts: java.util.Collection[Host]) {
     liveNodes = hosts.filter(_.isUp).toSet
+    // use explicitly set DC if available, otherwise see if all contact points have same DC
+    // if so, use that DC; if not, throw an error
+    dcToUse = localDC match { 
+      case Some(local) => local
+      case None => 
+        val dcList = dcs(nodesInTheSameDC(contactPoints, hosts.toSet))
+        if (dcList.size == 1) 
+          dcList.head
+        else 
+          throw new IllegalArgumentException(s"Contact points contain multiple data centers: ${dcList.mkString(", ")}")
+    }
   }
 
   override def newQueryPlan(query: String, statement: Statement): java.util.Iterator[Host] = {
@@ -40,6 +58,14 @@ class LocalNodeFirstLoadBalancingPolicy(contactPoints: Set[InetAddress]) extends
   override def onUp(host: Host) = { }
   override def onDown(host: Host) = { }
   override def onSuspected(host: Host) = { liveNodes += host }
+
+  private def sameDCHostDistance(host: Host) =
+    if (isLocalHost(host))
+      HostDistance.LOCAL
+    else
+      HostDistance.REMOTE
+
+  private def dcs(hosts: Set[Host]) = hosts.map(_.getDatacenter).toSet
 }
 
 object LocalNodeFirstLoadBalancingPolicy {


### PR DESCRIPTION
In some multi-DC configurations it's advantageous to block port 9042 externally. This breaks the Java driver, since nodes in other DCs are set to `HostDistance.REMOTE`, which still causes the driver to try to connect to them when it receives an `onAdd` event. The result is a fatal exception.

This allows the user to set the name of the local DC in an optional config key, `spark.cassandra.connection.local_dc`. If set, this value is used to filter out non-local DCs. Otherwise I get a unique list of DCs from the contact points, and if there's only one I use that; if not I throw an exception. The distance function always returns `HostDistance.IGNORED` if the host DC doesn't match the local DC. So this makes it work correctly out of the box, but gives you the option of being explicit.
