### PR TITLE
Pluggable mechanism for obtaining connections to Cassandra.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@
  * Added spark.cassandra.read.timeout_ms option
  * Added support for SparkSQL (#197)
  * Fixed problems with saving DStreams to Cassandra directly (#280)
+ * Pluggable mechanism for obtaining connections to Cassandra. Ability to pass custom CassandraConnector to CassandraRDD. (#192)
 
 1.1.0 alpha 1
  * Add an ./sbt/sbt script (like with spark) so people don't need to install sbt

--- a/doc/1_connecting.md
+++ b/doc/1_connecting.md
@@ -11,15 +11,16 @@ To connect your Spark application to Cassandra, set connection options in the
 from the spark-shell and set within the $SPARK_HOME/conf/spark-default.conf.
 The following options are available on `SparkConf` object:
 
-Property name                            | Description                                       | Default value
------------------------------------------|---------------------------------------------------|--------------------
-spark.cassandra.connection.host          | contact point to connect to the Cassandra cluster | address of the Spark master host
-spark.cassandra.connection.rpc.port      | Cassandra thrift port                             | 9160
-spark.cassandra.connection.native.port   | Cassandra native port                             | 9042
-spark.cassandra.auth.username            | login name for password authentication            |
-spark.cassandra.auth.password            | password for password authentication              |
-spark.cassandra.auth.conf.factory.class  | name of the class implementing `AuthConfFactory` providing custom authentication | `DefaultAuthConfFactory`
-  
+Property name                                  | Description                                       | Default value
+-----------------------------------------------|---------------------------------------------------|--------------------
+spark.cassandra.connection.host                | contact point to connect to the Cassandra cluster | address of the Spark master host
+spark.cassandra.connection.rpc.port            | Cassandra thrift port                             | 9160
+spark.cassandra.connection.native.port         | Cassandra native port                             | 9042
+spark.cassandra.connection.conf.factory        | name of a Scala module or class implementing `CassandraConnectionFactory` providing connections to the Cassandra cluster | `com.datastax.spark.connector.cql.DefaultConnectionFactory`
+spark.cassandra.auth.username                  | login name for password authentication            |
+spark.cassandra.auth.password                  | password for password authentication              |
+spark.cassandra.auth.conf.factory              | name of a Scala module or class implementing `AuthConfFactory` providing custom authentication configuration | `com.datastax.spark.connector.cql.DefaultAuthConfFactory`
+
 Additionally, the following global system properties are available:
 
 Property name                                        | Description                                                   | Default value
@@ -95,3 +96,4 @@ CassandraConnector(conf).withSessionDo { session =>
 ```
 
 [Next - Accessing data](2_loading.md)                                        
+

--- a/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/CassandraJavaUtilSpec.scala
+++ b/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/CassandraJavaUtilSpec.scala
@@ -10,7 +10,7 @@ import scala.collection.JavaConversions._
 class CassandraJavaUtilSpec extends FlatSpec with Matchers with BeforeAndAfter with SharedEmbeddedCassandra with SparkTemplate {
 
   useCassandraConfig("cassandra-default.yaml.template")
-  val conn = CassandraConnector(cassandraHost)
+  val conn = CassandraConnector(Set(cassandraHost))
 
   before {
     conn.withSessionDo { session =>

--- a/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaRDDSpec.scala
+++ b/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaRDDSpec.scala
@@ -11,7 +11,7 @@ class CassandraJavaRDDSpec extends FlatSpec with Matchers with BeforeAndAfter wi
 
   useCassandraConfig("cassandra-default.yaml.template")
 
-  val conn = CassandraConnector(EmbeddedCassandra.cassandraHost)
+  val conn = CassandraConnector(Set(EmbeddedCassandra.cassandraHost))
 
   before {
     conn.withSessionDo { session =>

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/SparkContextJavaFunctions.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/SparkContextJavaFunctions.java
@@ -1,5 +1,6 @@
 package com.datastax.spark.connector;
 
+import com.datastax.spark.connector.cql.CassandraConnector;
 import com.datastax.spark.connector.mapper.ColumnMapper;
 import com.datastax.spark.connector.rdd.CassandraJavaRDD;
 import com.datastax.spark.connector.rdd.CassandraRDD;
@@ -43,8 +44,8 @@ public class SparkContextJavaFunctions {
     public <T extends Serializable> CassandraJavaRDD<T> cassandraTable(String keyspace, String table,
             RowReaderFactory<T> rowReaderFactory, Class<T> targetClass) {
         ClassTag<T> ct = getClassTag(targetClass);
-
-        return toJavaRDD(scf.cassandraTable(keyspace, table, ct, rowReaderFactory), targetClass);
+        CassandraConnector connector = CassandraConnector.apply(sparkContext.getConf());
+        return toJavaRDD(scf.cassandraTable(keyspace, table, connector, ct, rowReaderFactory), targetClass);
     }
 
     /**

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraAuthenticatedConnectorSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraAuthenticatedConnectorSpec.scala
@@ -5,8 +5,9 @@ import org.scalatest.{Matchers, FlatSpec}
 
 class CassandraAuthenticatedConnectorSpec  extends FlatSpec with Matchers with SharedEmbeddedCassandra {
 
-  useCassandraConfig("cassandra-password-auth.yaml.template")
-  val conn = CassandraConnector(cassandraHost, authConf = PasswordAuthConf("cassandra", "cassandra"))
+  useCassandraConfig("cassandra-password-auth.yaml" +
+    ".template")
+  val conn = CassandraConnector(Set(cassandraHost), authConf = PasswordAuthConf("cassandra", "cassandra"))
 
   // Wait for the default user to be created in Cassandra.
   Thread.sleep(1000)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraConnectorSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraConnectorSpec.scala
@@ -10,7 +10,7 @@ case class KeyValueWithConversion(key: String, group: Int, value: Long)
 class CassandraConnectorSpec extends FlatSpec with Matchers with SharedEmbeddedCassandra {
 
   useCassandraConfig("cassandra-default.yaml.template")
-  val conn = CassandraConnector(cassandraHost)
+  val conn = CassandraConnector(Set(cassandraHost))
 
   val createKeyspaceCql = "CREATE KEYSPACE IF NOT EXISTS test WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }"
 
@@ -80,7 +80,7 @@ class CassandraConnectorSpec extends FlatSpec with Matchers with SharedEmbeddedC
   }
 
   it should "share internal Cluster object between multiple logical sessions created by different connectors to the same cluster" in {
-    val conn2 = CassandraConnector(EmbeddedCassandra.cassandraHost)
+    val conn2 = CassandraConnector(Set(EmbeddedCassandra.cassandraHost))
     val session1 = conn.openSession()
     val threadCount1 = Thread.activeCount()
     val session2 = conn2.openSession()

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraPartitionKeyWhereSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraPartitionKeyWhereSpec.scala
@@ -1,20 +1,14 @@
 package com.datastax.spark.connector.cql
 
-import java.io.IOException
-import java.util.Date
-
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.testkit.SharedEmbeddedCassandra
-import com.datastax.spark.connector.types.TypeConverter
 import com.datastax.spark.connector.embedded._
 import org.scalatest.{FlatSpec, Matchers}
-
-import scala.reflect.runtime.universe._
 
 class CassandraPartitionKeyWhereSpec extends FlatSpec with Matchers with SharedEmbeddedCassandra with SparkTemplate {
 
   useCassandraConfig("cassandra-default.yaml.template")
-  val conn = CassandraConnector(cassandraHost)
+  val conn = CassandraConnector(Set(cassandraHost))
 
   conn.withSessionDo { session =>
     session.execute("CREATE KEYSPACE IF NOT EXISTS where_test WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }")

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -29,7 +29,7 @@ class MutableKeyValueWithConversion(var key: String, var group: Int) extends Ser
 class CassandraRDDSpec extends FlatSpec with Matchers with SharedEmbeddedCassandra with SparkTemplate {
 
   useCassandraConfig("cassandra-default.yaml.template")
-  val conn = CassandraConnector(cassandraHost)
+  val conn = CassandraConnector(Set(cassandraHost))
 
   conn.withSessionDo { session =>
     session.execute("CREATE KEYSPACE IF NOT EXISTS read_test WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }")

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/repl/CassandraRDDReplSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/repl/CassandraRDDReplSpec.scala
@@ -8,7 +8,7 @@ import com.datastax.spark.connector.embedded._
 class CassandraRDDReplSpec extends FlatSpec with Matchers with SharedEmbeddedCassandra with SparkTemplate with SparkRepl {
   useCassandraConfig("cassandra-default.yaml.template")
 
-  val conn = CassandraConnector(cassandraHost)
+  val conn = CassandraConnector(Set(cassandraHost))
 
   conn.withSessionDo { session =>
     session.execute("CREATE KEYSPACE IF NOT EXISTS read_test WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }")

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class CassandraSQLSpec extends FlatSpec with Matchers with SharedEmbeddedCassandra with SparkTemplate {
   useCassandraConfig("cassandra-default.yaml.template")
-  val conn = CassandraConnector(cassandraHost)
+  val conn = CassandraConnector(Set(cassandraHost))
 
   conn.withSessionDo { session =>
     session.execute("CREATE KEYSPACE IF NOT EXISTS sql_test WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }")

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterColumnNamesSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterColumnNamesSpec.scala
@@ -9,7 +9,7 @@ import com.datastax.spark.connector.embedded._
 class TableWriterColumnNamesSpec extends AbstractSpec with SharedEmbeddedCassandra with SparkTemplate {
 
   useCassandraConfig("cassandra-default.yaml.template")
-  val conn = CassandraConnector(cassandraHost)
+  val conn = CassandraConnector(Set(cassandraHost))
 
   before {
     conn.withSessionDo { session =>

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
@@ -20,7 +20,7 @@ case class CustomerId(id: String)
 class TableWriterSpec extends FlatSpec with Matchers with BeforeAndAfter with SharedEmbeddedCassandra with SparkTemplate {
 
   useCassandraConfig("cassandra-default.yaml.template")
-  val conn = CassandraConnector(cassandraHost)
+  val conn = CassandraConnector(Set(cassandraHost))
 
   before {
     conn.withSessionDo { session =>

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/SparkContextFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/SparkContextFunctions.scala
@@ -2,6 +2,7 @@ package com.datastax.spark.connector
 
 import java.io.{Serializable => JavaSerializable}
 
+import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.rdd.CassandraRDD
 import com.datastax.spark.connector.rdd.reader.RowReaderFactory
 import org.apache.spark.SparkContext
@@ -44,6 +45,7 @@ class SparkContextFunctions(sc: SparkContext) {
     *   rdd3.first.word  // foo
     *   rdd3.first.count // 20
     * }}}*/
-  def cassandraTable[T <: JavaSerializable : ClassTag : RowReaderFactory](keyspace: String, table: String): CassandraRDD[T] =
-    new CassandraRDD[T](sc, keyspace, table)
+  def cassandraTable[T <: JavaSerializable](keyspace: String, table: String)
+  (implicit connector: CassandraConnector = CassandraConnector(sc.getConf), ct: ClassTag[T], rrf: RowReaderFactory[T]) =
+    new CassandraRDD[T](sc, CassandraConnector(sc.getConf), keyspace, table)
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
@@ -1,0 +1,83 @@
+package com.datastax.spark.connector.cql
+
+import java.net.InetAddress
+
+import com.datastax.driver.core.Cluster.Builder
+import com.datastax.driver.core.policies.ExponentialReconnectionPolicy
+import com.datastax.driver.core.{SocketOptions, AuthProvider, Cluster, PlainTextAuthProvider}
+import com.datastax.spark.connector.util.ReflectionUtil
+import org.apache.cassandra.thrift.{AuthenticationRequest, Cassandra, TFramedTransportFactory}
+import org.apache.spark.SparkConf
+import org.apache.thrift.protocol.TBinaryProtocol
+import org.apache.thrift.transport.TTransport
+
+import scala.collection.JavaConversions._
+
+/** Creates both native and Thrift connections to Cassandra.
+  * The connector provides a DefaultConnectionFactory.
+  * Other factories can be plugged in by setting `spark.cassandra.connection.factory` option.*/
+trait CassandraConnectionFactory extends Serializable {
+
+  /** Creates and configures a Thrift client.
+    * To be removed in the near future, when the dependency from Thrift will be completely dropped. */
+  def createThriftClient(conf: CassandraConnectorConf, hostAddress: InetAddress): (Cassandra.Iface, TTransport)
+
+  /** Creates and configures native Cassandra connection */
+  def createCluster(conf: CassandraConnectorConf): Cluster
+
+}
+
+/** Performs no authentication. Use with `AllowAllAuthenticator` in Cassandra. */
+object DefaultConnectionFactory extends CassandraConnectionFactory {
+
+  val minReconnectionDelay = System.getProperty("spark.cassandra.connection.reconnection_delay_ms.min", "1000").toInt
+  val maxReconnectionDelay = System.getProperty("spark.cassandra.connection.reconnection_delay_ms.max", "60000").toInt
+  val localDC = System.getProperty("spark.cassandra.connection.local_dc")
+  val retryCount = System.getProperty("spark.cassandra.query.retry.count", "10").toInt
+  val connectTimeout = System.getProperty("spark.cassandra.connection.timeout_ms", "5000").toInt
+  val readTimeout = System.getProperty("spark.cassandra.read.timeout_ms", "12000").toInt
+  
+  
+  /** Creates and configures a Thrift client.
+    * To be removed in the near future, when the dependency from Thrift will be completely dropped. */
+  override def createThriftClient(conf: CassandraConnectorConf, hostAddress: InetAddress) = {
+    val transportFactory = conf.authConf.transportFactory
+    val transport = transportFactory.openTransport(hostAddress.getHostAddress, conf.rpcPort)
+    val client = new Cassandra.Client(new TBinaryProtocol(transport))
+    conf.authConf.configureThriftClient(client)
+    (client, transport)
+  }
+
+  /** Returns the Cluster.Builder object used to setup Cluster instance. */
+  def clusterBuilder(conf: CassandraConnectorConf): Cluster.Builder = {
+    val options = new SocketOptions()
+      .setConnectTimeoutMillis(connectTimeout)
+      .setReadTimeoutMillis(readTimeout)
+
+    Cluster.builder()
+      .addContactPoints(conf.hosts.toSeq: _*)
+      .withPort(conf.nativePort)
+      .withRetryPolicy(new MultipleRetryPolicy(retryCount))
+      .withReconnectionPolicy(new ExponentialReconnectionPolicy(minReconnectionDelay, maxReconnectionDelay))
+      .withLoadBalancingPolicy(new LocalNodeFirstLoadBalancingPolicy(conf.hosts, Option(localDC)))
+      .withAuthProvider(conf.authConf.authProvider)
+      .withSocketOptions(options)
+  }
+
+  /** Creates and configures native Cassandra connection */
+  override def createCluster(conf: CassandraConnectorConf): Cluster =
+    clusterBuilder(conf).build()
+
+}
+
+/** Entry point for obtaining `CassandraConnectionFactory` object from `SparkConf`,
+  * used when establishing connections to Cassandra. */
+object CassandraConnectionFactory {
+  val ConnectionFactoryProperty = "spark.cassandra.connection.factory"
+
+  def fromSparkConf(conf: SparkConf): CassandraConnectionFactory = {
+    conf.getOption(ConnectionFactoryProperty)
+      .map(ReflectionUtil.findGlobalObject[CassandraConnectionFactory])
+      .getOrElse(DefaultConnectionFactory)
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
@@ -29,12 +29,13 @@ import com.datastax.spark.connector.util.Logging
   * A `CassandraConnector` object is configured from [[CassandraConnectorConf]] object which
   * can be either given explicitly or automatically configured from `SparkConf`.
   * The connection options are:
-  *   - `spark.cassandra.connection.host`:         contact point to connect to the Cassandra cluster, defaults to spark master host
-  *   - `spark.cassandra.connection.rpc.port`:     Cassandra thrift port, defaults to 9160
-  *   - `spark.cassandra.connection.native.port`:  Cassandra native port, defaults to 9042
-  *   - `spark.cassandra.auth.username`:           login for password authentication
-  *   - `spark.cassandra.auth.password`:           password for password authentication
-  *   - `spark.cassandra.auth.conf.factory.class`: name of the class implementing [[AuthConfFactory]] that allows to plugin custom authentication
+  *   - `spark.cassandra.connection.host`:               contact point to connect to the Cassandra cluster, defaults to spark master host
+  *   - `spark.cassandra.connection.rpc.port`:           Cassandra thrift port, defaults to 9160
+  *   - `spark.cassandra.connection.native.port`:        Cassandra native port, defaults to 9042
+      - `spark.cassandra.connection.factory`:            name of a Scala module or class implementing [[CassandraConnectionFactory]] that allows to plugin custom code for connecting to Cassandra
+  *   - `spark.cassandra.auth.username`:                 login for password authentication
+  *   - `spark.cassandra.auth.password`:                 password for password authentication
+  *   - `spark.cassandra.auth.conf.factory`:             name of a Scala module or class implementing [[AuthConfFactory]] that allows to plugin custom authentication configuration
   *
   * Additionally this object uses the following global System properties:
   *   - `spark.cassandra.connection.keep_alive_ms`: the number of milliseconds to keep unused `Cluster` object before destroying it (default 100 ms)
@@ -58,8 +59,8 @@ class CassandraConnector(conf: CassandraConnectorConf)
   /** Configured thrift client port */
   def rpcPort = _config.rpcPort
 
-  /** Authentication configuration */
-  def authConf = _config.authConf
+  /** Connection configurator */
+  def configurator = _config.connectionFactory
 
   /** Returns a shared session to Cassandra and increases the internal open
     * reference counter. It does not release the session automatically,
@@ -120,11 +121,8 @@ class CassandraConnector(conf: CassandraConnectorConf)
 
   /** Opens a Thrift client to the given host. Don't use it unless you really know what you are doing. */
   def createThriftClient(host: InetAddress): CassandraClientProxy = {
-    val transportFactory = conf.authConf.transportFactory
     logDebug("Attempting to create thrift client to %s:%d".format(host.getHostAddress, rpcPort))
-    val transport = transportFactory.openTransport(host.getHostAddress, rpcPort)
-    val client = new Cassandra.Client(new TBinaryProtocol.Factory().getProtocol(transport))
-    conf.authConf.configureThriftClient(client)
+    val (client, transport) = conf.connectionFactory.createThriftClient(conf, host)
     CassandraClientProxy.wrap(client, transport)
   }
 
@@ -147,37 +145,16 @@ class CassandraConnector(conf: CassandraConnectorConf)
 }
 
 object CassandraConnector extends Logging {
-  val keepAliveMillis = System.getProperty("spark.cassandra.connection.keep_alive_ms", "250").toInt
-  val minReconnectionDelay = System.getProperty("spark.cassandra.connection.reconnection_delay_ms.min", "1000").toInt
-  val maxReconnectionDelay = System.getProperty("spark.cassandra.connection.reconnection_delay_ms.max", "60000").toInt
-  val localDC = System.getProperty("spark.cassandra.connection.local_dc")
-  val retryCount = System.getProperty("spark.cassandra.query.retry.count", "10").toInt
 
-  implicit final val protocolVersion: Int = -1
-  val connectTimeout = System.getProperty("spark.cassandra.connection.timeout_ms", "5000").toInt
-  val readTimeout = System.getProperty("spark.cassandra.read.timeout_ms", "12000").toInt
+  implicit val protocolVersion: Int = -1
+  val keepAliveMillis = System.getProperty("spark.cassandra.connection.keep_alive_ms", "250").toInt
 
   private val sessionCache = new RefCountedCache[CassandraConnectorConf, Session](
     createSession, destroySession, alternativeConnectionConfigs, releaseDelayMillis = keepAliveMillis)
 
   private def createSession(conf: CassandraConnectorConf): Session = {
     logDebug(s"Connecting to cluster: ${conf.hosts.mkString("{", ",", "}")}:${conf.nativePort}")
-
-    val options = new SocketOptions()
-      .setConnectTimeoutMillis(connectTimeout)
-      .setReadTimeoutMillis(readTimeout)
-
-    val cluster =
-      Cluster.builder()
-        .addContactPoints(conf.hosts.toSeq: _*)
-        .withPort(conf.nativePort)
-        .withRetryPolicy(new MultipleRetryPolicy(retryCount))
-        .withReconnectionPolicy(new ExponentialReconnectionPolicy(minReconnectionDelay, maxReconnectionDelay))
-        .withLoadBalancingPolicy(new LocalNodeFirstLoadBalancingPolicy(conf.hosts, Option(localDC)))
-        .withAuthProvider(conf.authConf.authProvider)
-        .withSocketOptions(options)
-        .build()
-
+    val cluster = conf.connectionFactory.createCluster(conf)
     try {
       val clusterName = cluster.getMetadata.getClusterName
       logInfo(s"Connected to Cassandra cluster: $clusterName")
@@ -214,16 +191,17 @@ object CassandraConnector extends Logging {
 
   /** Returns a CassandraConnector created from properties found in the `SparkConf` object */
   def apply(conf: SparkConf): CassandraConnector = {
-    new CassandraConnector(CassandraConnectorConf.apply(conf))
+    new CassandraConnector(CassandraConnectorConf(conf))
   }
 
   /** Returns a CassandraConnector created from explicitly given connection configuration. */
-  def apply(host: InetAddress,
+  def apply(hosts: Set[InetAddress],
             nativePort: Int = CassandraConnectorConf.DefaultNativePort,
             rpcPort: Int = CassandraConnectorConf.DefaultRpcPort,
-            authConf: AuthConf = NoAuthConf) = {
+            authConf: AuthConf = NoAuthConf,
+            connectionFactory: CassandraConnectionFactory = DefaultConnectionFactory) = {
 
-    val config = CassandraConnectorConf.apply(host, nativePort, rpcPort, authConf)
+    val config = CassandraConnectorConf(hosts, nativePort, rpcPort, authConf, connectionFactory)
     new CassandraConnector(config)
   }
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
@@ -46,6 +46,7 @@ import scala.reflect._
   */
 class CassandraRDD[R] private[connector] (
     @transient sc: SparkContext,
+    val connector: CassandraConnector,
     val keyspaceName: String,
     val tableName: String,
     val columnNames: ColumnSelector = AllColumns,
@@ -80,10 +81,10 @@ class CassandraRDD[R] private[connector] (
   val inputConsistencyLevel =  ConsistencyLevel.valueOf(
     sc.getConf.get("spark.cassandra.input.consistency.level", ConsistencyLevel.LOCAL_ONE.name))
 
-  private val connector = CassandraConnector(sc.getConf)
 
-  private def copy(columnNames: ColumnSelector = columnNames, where: CqlWhereClause = where): CassandraRDD[R] =
-    new CassandraRDD(sc, keyspaceName, tableName, columnNames, where)
+  private def copy(columnNames: ColumnSelector = columnNames,
+                   where: CqlWhereClause = where): CassandraRDD[R] =
+    new CassandraRDD(sc, connector, keyspaceName, tableName, columnNames, where)
 
   /** Adds a CQL `WHERE` predicate(s) to the query.
     * Useful for leveraging secondary indexes in Cassandra.
@@ -136,69 +137,69 @@ class CassandraRDD[R] private[connector] (
     * }}}*/
   def as[B : ClassTag, A0 : TypeConverter](f: A0 => B): CassandraRDD[B] = {
     implicit val ft = new FunctionBasedRowReader1(f)
-    new CassandraRDD[B](sc, keyspaceName, tableName, columnNames)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter](f: (A0, A1) => B) = {
     implicit val ft = new FunctionBasedRowReader2(f)
-    new CassandraRDD[B](sc, keyspaceName, tableName, columnNames)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter](f: (A0, A1, A2) => B) = {
     implicit val ft = new FunctionBasedRowReader3(f)
-    new CassandraRDD[B](sc, keyspaceName, tableName, columnNames)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter,
   A3 : TypeConverter](f: (A0, A1, A2, A3) => B) = {
     implicit val ft = new FunctionBasedRowReader4(f)
-    new CassandraRDD[B](sc, keyspaceName, tableName, columnNames)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
   A4 : TypeConverter](f: (A0, A1, A2, A3, A4) => B) = {
     implicit val ft = new FunctionBasedRowReader5(f)
-    new CassandraRDD[B](sc, keyspaceName, tableName, columnNames)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
   A4 : TypeConverter, A5 : TypeConverter](f: (A0, A1, A2, A3, A4, A5) => B) = {
     implicit val ft = new FunctionBasedRowReader6(f)
-    new CassandraRDD[B](sc, keyspaceName, tableName, columnNames)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
   A4 : TypeConverter, A5 : TypeConverter, A6 : TypeConverter](f: (A0, A1, A2, A3, A4, A5, A6) => B) = {
     implicit val ft = new FunctionBasedRowReader7(f)
-    new CassandraRDD[B](sc, keyspaceName, tableName, columnNames)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
   A4 : TypeConverter, A5 : TypeConverter, A6 : TypeConverter,
   A7 : TypeConverter](f: (A0, A1, A2, A3, A4, A5, A6, A7) => B) = {
     implicit val ft = new FunctionBasedRowReader8(f)
-    new CassandraRDD[B](sc, keyspaceName, tableName, columnNames)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
   A4 : TypeConverter, A5 : TypeConverter, A6 : TypeConverter, A7: TypeConverter,
   A8 : TypeConverter](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) => B) = {
     implicit val ft = new FunctionBasedRowReader9(f)
-    new CassandraRDD[B](sc, keyspaceName, tableName, columnNames)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
   A4 : TypeConverter, A5 : TypeConverter, A6 : TypeConverter, A7: TypeConverter,
   A8 : TypeConverter, A9 : TypeConverter](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => B) = {
     implicit val ft = new FunctionBasedRowReader10(f)
-    new CassandraRDD[B](sc, keyspaceName, tableName, columnNames)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
   A4 : TypeConverter, A5 : TypeConverter, A6 : TypeConverter, A7: TypeConverter, A8: TypeConverter,
   A9 : TypeConverter, A10 : TypeConverter](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => B) = {
     implicit val ft = new FunctionBasedRowReader11(f)
-    new CassandraRDD[B](sc, keyspaceName, tableName, columnNames)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
@@ -206,7 +207,7 @@ class CassandraRDD[R] private[connector] (
   A9 : TypeConverter, A10: TypeConverter, A11 : TypeConverter](
   f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => B) = {
     implicit val ft = new FunctionBasedRowReader12(f)
-    new CassandraRDD[B](sc, keyspaceName, tableName, columnNames)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where)
   }
 
   // ===================================================================

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/CassandraStreamingRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/CassandraStreamingRDD.scala
@@ -1,5 +1,6 @@
 package com.datastax.spark.connector.streaming
 
+import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.{ColumnSelector, AllColumns}
 
 import scala.reflect.ClassTag
@@ -8,14 +9,15 @@ import com.datastax.spark.connector.rdd.{CassandraRDD, CqlWhereClause}
 import com.datastax.spark.connector.rdd.reader._
 
 /** RDD representing a Cassandra table for Spark Streaming.
-  * @see [[com.datastax.spark.connector.rdd.CassandraRDD]]
-  */
+  * @see [[com.datastax.spark.connector.rdd.CassandraRDD]] */
 class CassandraStreamingRDD[R] private[connector] (
-                                                    sctx: StreamingContext,
-                                                    keyspace: String,
-                                                    table: String,
-                                                    columns: ColumnSelector = AllColumns,
-                                                    where: CqlWhereClause = CqlWhereClause.empty)(
-                                                    implicit
-                                                    ct : ClassTag[R], @transient rtf: RowReaderFactory[R])
-  extends CassandraRDD[R](sctx.sparkContext, keyspace, table, columns, where)
+    sctx: StreamingContext,
+    connector: CassandraConnector,
+    keyspace: String,
+    table: String,
+    columns: ColumnSelector = AllColumns,
+    where: CqlWhereClause = CqlWhereClause.empty)(
+  implicit
+    ct : ClassTag[R],
+    @transient rrf: RowReaderFactory[R])
+  extends CassandraRDD[R](sctx.sparkContext, connector, keyspace, table, columns, where)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/StreamingContextFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/StreamingContextFunctions.scala
@@ -1,6 +1,7 @@
 package com.datastax.spark.connector.streaming
 
 import akka.actor.{ActorRef, Actor}
+import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.util.Logging
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.scheduler.StreamingListener
@@ -17,9 +18,12 @@ class StreamingContextFunctions (ssc: StreamingContext) extends SparkContextFunc
   import java.io.{ Serializable => JSerializable }
   import scala.reflect.ClassTag
 
-  override def cassandraTable[T <: JSerializable : ClassTag : RowReaderFactory](keyspace: String, table: String): CassandraStreamingRDD[T] =
-    new CassandraStreamingRDD[T](ssc, keyspace, table)
-
+  override def cassandraTable[T <: JSerializable](keyspace: String, table: String)(
+    implicit
+      connector: CassandraConnector = CassandraConnector(ssc.sparkContext.getConf),
+      ct: ClassTag[T],
+      rrf: RowReaderFactory[T]): CassandraStreamingRDD[T] =
+    new CassandraStreamingRDD[T](ssc, connector, keyspace, table)
 }
 
 /** Simple akka.actor.Actor mixin. */

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/ReflectionUtil.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/ReflectionUtil.scala
@@ -1,0 +1,55 @@
+package com.datastax.spark.connector.util
+
+import scala.collection.concurrent.TrieMap
+import scala.reflect.runtime.universe._
+import scala.util.{Try, Success, Failure}
+
+object ReflectionUtil {
+  private val rm = runtimeMirror(getClass.getClassLoader)
+  private val singletonCache = TrieMap[String, Any]()
+
+  private def findScalaObject[T : TypeTag](objectName: String): Try[T] = {
+    Try {
+      val targetType = implicitly[TypeTag[T]].tpe
+      val module = rm.staticModule(objectName)
+      if (!(module.typeSignature <:< targetType))
+        throw new IllegalArgumentException(s"Object $objectName is not instance of $targetType")
+
+      val moduleMirror = rm.reflectModule(module)
+      moduleMirror.instance.asInstanceOf[T]
+    }
+  }
+
+  private def findSingletonClassInstance[T : TypeTag](className: String): Try[T] = {
+    Try {
+      val targetType = implicitly[TypeTag[T]].tpe
+      val targetClass = rm.runtimeClass(targetType.typeSymbol.asClass)
+      val instance =
+        singletonCache.get(className) match {
+          case Some(obj) => obj
+          case None =>
+            val newInstance = Class.forName(className).getConstructor(Array.empty[Class[_]]: _*).newInstance()
+            singletonCache.putIfAbsent(className, newInstance) match {
+              case None => newInstance
+              case Some(previousInstance) => previousInstance
+            }
+        }
+
+      if (!targetClass.isInstance(instance))
+        throw new IllegalArgumentException(s"Class $className is not $targetType")
+      instance.asInstanceOf[T]
+    }
+  }
+
+  /** Returns either a global Scala object by its fully qualified name or a singleton
+    * instance of a Java class identified by its fully qualified class name.
+    * Java class instances are cached. The Java class must provide a default constructor. */
+  def findGlobalObject[T : TypeTag](objectName: String): T = {
+    val scalaObject: Try[T] = findScalaObject[T](objectName)
+    val classInstance: Try[T] = findSingletonClassInstance[T](objectName)
+    scalaObject orElse classInstance match {
+      case Success(obj) => obj
+      case Failure(e) => throw new IllegalArgumentException(s"Singleton object not available: $objectName", e)
+    }
+  }
+}

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/util/ReflectionUtilSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/util/ReflectionUtilSpec.scala
@@ -1,0 +1,44 @@
+package com.datastax.spark.connector.util
+
+import com.datastax.spark.connector.cql.{CassandraConnectorConf, DefaultConnectionFactory, CassandraConnectionFactory}
+import org.scalatest.{FlatSpec, Matchers}
+
+class ReflectionUtilSpec extends FlatSpec with Matchers {
+
+  "ReflectionUtil.findGlobalObject" should "be able to find DefaultConnectionFactory" in {
+    val factory = ReflectionUtil.findGlobalObject[CassandraConnectionFactory](
+      "com.datastax.spark.connector.cql.DefaultConnectionFactory")
+    factory should be(DefaultConnectionFactory)
+  }
+
+  it should "be able to instantiate a singleton object based on Java class name" in {
+    val obj = ReflectionUtil.findGlobalObject[String]("java.lang.String")
+    obj should be ("")
+  }
+
+  it should "cache Java class instances" in {
+    val obj1 = ReflectionUtil.findGlobalObject[String]("java.lang.String")
+    val obj2 = ReflectionUtil.findGlobalObject[String]("java.lang.String")
+    obj1 shouldBe theSameInstanceAs (obj2)
+  }
+
+  it should "throw IllegalArgumentException when asked for a Scala object of wrong type" in {
+    intercept[IllegalArgumentException] {
+      ReflectionUtil.findGlobalObject[CassandraConnectorConf](
+        "com.datastax.spark.connector.cql.DefaultConnectionFactory")
+    }
+  }
+
+  it should "throw IllegalArgumentException when asked for class instance of wrong type" in {
+    intercept[IllegalArgumentException] {
+      ReflectionUtil.findGlobalObject[Integer]("java.lang.String")
+    }
+  }
+
+  it should "throw IllegalArgumentException when object does not exist" in {
+    intercept[IllegalArgumentException] {
+      ReflectionUtil.findGlobalObject[CassandraConnectorConf]("NoSuchObject")
+    }
+  }
+
+}


### PR DESCRIPTION
The changes introduced with this fix include:
- Introduction of CassandraConnectionFactory, responsible for creating Cluster.Builder, Cluster and Thrift client objects.
- Adjusting CassandraConnector and CassandraConnectionConf to the new interface.
- Ability to specify custom CassandraConnector when creating CassandraRDD and CassandraStreamingRDD.
- Updated tests and docs.

Fixes #192.
