### PR TITLE
Fix connection problems with fetching token ranges from hosts with rpc_a...

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,10 @@
+1.0.1 (unreleased)
+ * Fix connection problems with fetching token ranges from hosts with
+   rpc_address different than listen_address.
+   Log host address(es) and ports on connection failures.
+   Close thrift transport if connection fails for some reason after opening the transport,
+   e.g. authentication failure.
+
 1.0.0
  * Fix memory leak in PreparedStatementCache leaking PreparedStatements after
    closing Cluster objects. (#183)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraRDDPartitioner.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraRDDPartitioner.scala
@@ -31,7 +31,7 @@ class CassandraRDDPartitioner[V, T <: Token[V]](
   private def unthriftify(tr: thrift.TokenRange): TokenRange = {
     val startToken = tokenFactory.fromString(tr.start_token)
     val endToken = tokenFactory.fromString(tr.end_token)
-    val endpoints = tr.endpoints.map(InetAddress.getByName).toSet
+    val endpoints = tr.rpc_endpoints.map(InetAddress.getByName).toSet
     new TokenRange(startToken, endToken, endpoints, None)
   }
 


### PR DESCRIPTION
...ddress different than listen_address.

Use rpc_endpoints instead of endpoints in CassandraRDDPartitioner.
Log host address(es) and ports on connection failures.
Close thrift transport if connection fails for some reason after opening the transport, e.g. authentication failure.

Fixes #304.
