### PR TITLE
Expose both RPC and private addresses of every Cassandra node in spark p...

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/TokenRangeClusterer.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/TokenRangeClusterer.scala
@@ -2,9 +2,10 @@ package com.datastax.spark.connector.rdd.partitioner
 
 import java.net.InetAddress
 
+import Ordering.Implicits._
+
 import com.datastax.spark.connector.rdd.partitioner.dht.{Token, TokenRange}
 
-import scala.Ordering.Implicits._
 import scala.annotation.tailrec
 
 /** Divides a set of token ranges into groups containing not more than `maxRowCountPerGroup` rows

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/dht/TokenRange.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/dht/TokenRange.scala
@@ -2,8 +2,17 @@ package com.datastax.spark.connector.rdd.partitioner.dht
 
 import java.net.InetAddress
 
+
+case class CassandraNode(rpcAddress: InetAddress, localAddress: InetAddress) {
+  def allAddresses = Set(rpcAddress, localAddress)
+}
+
+object CassandraNode {
+  implicit def ordering: Ordering[CassandraNode] = Ordering.by(_.rpcAddress.toString)
+}
+
 case class TokenRange[V, T <: Token[V]] (
-    start: T, end: T, endpoints: Set[InetAddress], rowCount: Option[Long]) {
+    start: T, end: T, endpoints: Set[CassandraNode], rowCount: Option[Long]) {
 
   def isWrapAround: Boolean =
     start >= end

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/partitioner/Murmur3PartitionerTokenRangeSplitterTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/partitioner/Murmur3PartitionerTokenRangeSplitterTest.scala
@@ -2,7 +2,7 @@ package com.datastax.spark.connector.rdd.partitioner
 
 import java.net.InetAddress
 
-import com.datastax.spark.connector.rdd.partitioner.dht.LongToken
+import com.datastax.spark.connector.rdd.partitioner.dht.{CassandraNode, LongToken}
 import com.datastax.spark.connector.rdd.partitioner.dht.TokenFactory.Murmur3TokenFactory
 import org.junit.Assert._
 import org.junit.Test
@@ -18,9 +18,12 @@ class Murmur3PartitionerTokenRangeSplitterTest {
 
   @Test
   def testSplit() {
+    val node = CassandraNode(InetAddress.getLocalHost, InetAddress.getLocalHost)
     val splitter = new Murmur3PartitionerTokenRangeSplitter(2.0)
     val range = new TokenRange(
-      new com.datastax.spark.connector.rdd.partitioner.dht.LongToken(0), new com.datastax.spark.connector.rdd.partitioner.dht.LongToken(100), Set(InetAddress.getLocalHost), None)
+      new com.datastax.spark.connector.rdd.partitioner.dht.LongToken(0),
+      new com.datastax.spark.connector.rdd.partitioner.dht.LongToken(100),
+      Set(node), None)
     val out = splitter.split(range, 20)
 
     // 2 rows per token on average; to so 10 tokens = 20 rows; therefore 10 splits
@@ -28,7 +31,7 @@ class Murmur3PartitionerTokenRangeSplitterTest {
     assertEquals(0L, out.head.start.value)
     assertEquals(100L, out.last.end.value)
     assertTrue(out.forall(s => s.end.value - s.start.value == 10))
-    assertTrue(out.forall(_.endpoints == Set(InetAddress.getLocalHost)))
+    assertTrue(out.forall(_.endpoints == Set(node)))
     assertNoHoles(out)
   }
 

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/partitioner/RandomPartitionerTokenRangeSplitterTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/partitioner/RandomPartitionerTokenRangeSplitterTest.scala
@@ -2,7 +2,7 @@ package com.datastax.spark.connector.rdd.partitioner
 
 import java.net.InetAddress
 
-import com.datastax.spark.connector.rdd.partitioner.dht.{BigIntToken, TokenFactory}
+import com.datastax.spark.connector.rdd.partitioner.dht.{CassandraNode, BigIntToken, TokenFactory}
 import org.junit.Assert._
 import org.junit.Test
 
@@ -18,19 +18,20 @@ class RandomPartitionerTokenRangeSplitterTest {
 
   @Test
   def testSplit() {
+    val node = CassandraNode(InetAddress.getLocalHost, InetAddress.getLocalHost)
     val splitter = new RandomPartitionerTokenRangeSplitter(2.0)
     val rangeLeft = BigInt("0")
     val rangeRight = BigInt("100")
     val range = new TokenRange(
       new BigIntToken(rangeLeft),
-      new BigIntToken(rangeRight), Set(InetAddress.getLocalHost), None)
+      new BigIntToken(rangeRight), Set(node), None)
     val out = splitter.split(range, 20)
 
     // 2 rows per token on average; to so 10 tokens = 20 rows; therefore 10 splits
     assertEquals(10, out.size)
     assertEquals(rangeLeft, out.head.start.value)
     assertEquals(rangeRight, out.last.end.value)
-    assertTrue(out.forall(_.endpoints == Set(InetAddress.getLocalHost)))
+    assertTrue(out.forall(_.endpoints == Set(node)))
     assertNoHoles(out)
   }
 

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/partitioner/TokenRangeClustererTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/partitioner/TokenRangeClustererTest.scala
@@ -2,7 +2,7 @@ package com.datastax.spark.connector.rdd.partitioner
 
 import java.net.InetAddress
 
-import com.datastax.spark.connector.rdd.partitioner.dht.LongToken
+import com.datastax.spark.connector.rdd.partitioner.dht.{CassandraNode, LongToken}
 import org.junit.Assert._
 import org.junit.Test
 
@@ -16,6 +16,12 @@ class TokenRangeClustererTest {
   val addr4 = InetAddress.getByName("192.168.123.4")
   val addr5 = InetAddress.getByName("192.168.123.5")
 
+  val node1 = CassandraNode(addr1, addr1)
+  val node2 = CassandraNode(addr2, addr2)
+  val node3 = CassandraNode(addr3, addr3)
+  val node4 = CassandraNode(addr4, addr4)
+  val node5 = CassandraNode(addr5, addr5)
+
   private def token(x: Long) = new com.datastax.spark.connector.rdd.partitioner.dht.LongToken(x)
 
   @Test
@@ -27,8 +33,8 @@ class TokenRangeClustererTest {
 
   @Test
   def testTrivialClustering() {
-    val tr1 = new TokenRange(token(0), token(10), Set(addr1), Some(5))
-    val tr2 = new TokenRange(token(10), token(20), Set(addr1), Some(5))
+    val tr1 = new TokenRange(token(0), token(10), Set(node1), Some(5))
+    val tr2 = new TokenRange(token(10), token(20), Set(node1), Some(5))
     val trc = new TokenRangeClusterer[Long, LongToken](10)
     val groups = trc.group(Seq(tr1, tr2))
     assertEquals(1, groups.size)
@@ -37,10 +43,10 @@ class TokenRangeClustererTest {
 
   @Test
   def testSplitByHost() {
-    val tr1 = new TokenRange(token(0), token(10), Set(addr1), Some(2))
-    val tr2 = new TokenRange(token(10), token(20), Set(addr1), Some(2))
-    val tr3 = new TokenRange(token(20), token(30), Set(addr2), Some(2))
-    val tr4 = new TokenRange(token(30), token(40), Set(addr2), Some(2))
+    val tr1 = new TokenRange(token(0), token(10), Set(node1), Some(2))
+    val tr2 = new TokenRange(token(10), token(20), Set(node1), Some(2))
+    val tr3 = new TokenRange(token(20), token(30), Set(node2), Some(2))
+    val tr4 = new TokenRange(token(30), token(40), Set(node2), Some(2))
 
     val trc = new TokenRangeClusterer[Long, LongToken](10)
     val groups = trc.group(Seq(tr1, tr2, tr3, tr4)).map(_.toSet).toSet
@@ -51,10 +57,10 @@ class TokenRangeClustererTest {
 
   @Test
   def testSplitByCount() {
-    val tr1 = new TokenRange(token(0), token(10), Set(addr1), Some(5))
-    val tr2 = new TokenRange(token(10), token(20), Set(addr1), Some(5))
-    val tr3 = new TokenRange(token(20), token(30), Set(addr1), Some(5))
-    val tr4 = new TokenRange(token(30), token(40), Set(addr1), Some(5))
+    val tr1 = new TokenRange(token(0), token(10), Set(node1), Some(5))
+    val tr2 = new TokenRange(token(10), token(20), Set(node1), Some(5))
+    val tr3 = new TokenRange(token(20), token(30), Set(node1), Some(5))
+    val tr4 = new TokenRange(token(30), token(40), Set(node1), Some(5))
 
     val trc = new TokenRangeClusterer[Long, LongToken](10)
     val groups = trc.group(Seq(tr1, tr2, tr3, tr4)).map(_.toSet).toSet
@@ -65,8 +71,8 @@ class TokenRangeClustererTest {
 
   @Test
   def testTooLargeRanges() {
-    val tr1 = new TokenRange(token(0), token(10), Set(addr1), Some(100000))
-    val tr2 = new TokenRange(token(10), token(20), Set(addr1), Some(100000))
+    val tr1 = new TokenRange(token(0), token(10), Set(node1), Some(100000))
+    val tr2 = new TokenRange(token(10), token(20), Set(node1), Some(100000))
     val trc = new TokenRangeClusterer[Long, LongToken](10)
     val groups = trc.group(Seq(tr1, tr2)).map(_.toSet).toSet
     assertEquals(2, groups.size)
@@ -76,10 +82,10 @@ class TokenRangeClustererTest {
 
   @Test
   def testMultipleEndpoints() {
-    val tr1 = new TokenRange(token(0), token(10), Set(addr2, addr1, addr3), Some(1))
-    val tr2 = new TokenRange(token(10), token(20), Set(addr1, addr3, addr4), Some(1))
-    val tr3 = new TokenRange(token(20), token(30), Set(addr3, addr1, addr5), Some(1))
-    val tr4 = new TokenRange(token(30), token(40), Set(addr3, addr1, addr4), Some(1))
+    val tr1 = new TokenRange(token(0), token(10), Set(node2, node1, node3), Some(1))
+    val tr2 = new TokenRange(token(10), token(20), Set(node1, node3, node4), Some(1))
+    val tr3 = new TokenRange(token(20), token(30), Set(node3, node1, node5), Some(1))
+    val tr4 = new TokenRange(token(30), token(40), Set(node3, node1, node4), Some(1))
     val trc = new TokenRangeClusterer[Long, LongToken](10)
     val groups = trc.group(Seq(tr1, tr2, tr3, tr4))
     assertEquals(1, groups.size)
@@ -89,9 +95,9 @@ class TokenRangeClustererTest {
 
   @Test
   def testMaxClusterSize() {
-    val tr1 = new TokenRange(token(0), token(10), Set(addr1, addr2, addr3), Some(1))
-    val tr2 = new TokenRange(token(10), token(20), Set(addr1, addr2, addr3), Some(1))
-    val tr3 = new TokenRange(token(20), token(30), Set(addr1, addr2, addr3), Some(1))
+    val tr1 = new TokenRange(token(0), token(10), Set(node1, node2, node3), Some(1))
+    val tr2 = new TokenRange(token(10), token(20), Set(node1, node2, node3), Some(1))
+    val tr3 = new TokenRange(token(20), token(30), Set(node1, node2, node3), Some(1))
     val trc = new TokenRangeClusterer[Long, LongToken](maxRowCountPerGroup = 10, maxGroupSize = 1)
     val groups = trc.group(Seq(tr1, tr2, tr3))
     assertEquals(3, groups.size)


### PR DESCRIPTION
...artitions. This way spark workers can be setup with either the private or public IP addresses and data locality should still work.
