### PR TITLE
Make  SparkContextFunctions Serializable or implicits will make the spark context useless inside rdds!!

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/SparkContextFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/SparkContextFunctions.scala
@@ -8,7 +8,7 @@ import org.apache.spark.SparkContext
 import scala.reflect.ClassTag
 
 /** Provides Cassandra-specific methods on `SparkContext` */
-class SparkContextFunctions(sc: SparkContext) {
+class SparkContextFunctions(@transient val sc: SparkContext) extends Serializable {
 
   /** Returns a view of a Cassandra table as `CassandraRDD`.
     * This method is made available on `SparkContext` by importing `com.datastax.spark.connector._`


### PR DESCRIPTION
To make it Serializable 
take a look at this http://stackoverflow.com/questions/23737804/enriching-sparkcontext-without-incurring-in-serialization-issues
