### PR TITLE
Stub implementation for UDTs (Cassandra 2.1).

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,6 @@
  * Fixed bug in Java API which might cause ClassNotFoundException
+ * Added stubs for UDTs. It is possible to read tables with UDTs, but
+   values of UDTs will come out as java driver UDTValue objects (#374)
 
 1.1.0 beta 1
  * Redesigned Java API, some refactorings (#300)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/PrimitiveColumnType.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/PrimitiveColumnType.scala
@@ -68,7 +68,6 @@ case object TimestampType extends PrimitiveColumnType[Date] {
 }
 
 case object InetType extends PrimitiveColumnType[InetAddress] {
-  
   def converterToCassandra = new OptionToNullConverter(TypeConverter.forType[InetAddress])
   def scalaTypeTag = implicitly[TypeTag[InetAddress]]
 }
@@ -92,4 +91,3 @@ case object BlobType extends PrimitiveColumnType[ByteBuffer] {
   def converterToCassandra = new OptionToNullConverter(TypeConverter.forType[ByteBuffer])
   def scalaTypeTag = implicitly[TypeTag[ByteBuffer]]
 }
-

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
@@ -11,6 +11,8 @@ import scala.reflect.runtime.universe._
 import org.apache.cassandra.utils.ByteBufferUtil
 import org.joda.time.DateTime
 
+import com.datastax.driver.core.UDTValue
+
 
 class TypeConversionException(val message: String, cause: Exception = null) extends Exception(message, cause)
 
@@ -282,6 +284,16 @@ object TypeConverter {
     }
   }
 
+  val UDTValueTypeTag = implicitly[TypeTag[UDTValue]]
+
+  // TODO: This is a stub. Currently doesn't do any conversion at all.
+  implicit object UDTValueConverter extends TypeConverter[UDTValue] {
+    def targetTypeTag = UDTValueTypeTag
+    def convertPF = {
+      case x: UDTValue => x
+    }
+  }
+
   class TupleConverter[K, V](implicit kc: TypeConverter[K], vc: TypeConverter[V])
     extends TypeConverter[(K, V)] {
 
@@ -544,7 +556,8 @@ object TypeConverter {
     InetAddressConverter,
     UUIDConverter,
     ByteBufferConverter,
-    ByteArrayConverter
+    ByteArrayConverter,
+    UDTValueConverter
   )
 
   private def forCollectionType(tpe: Type): TypeConverter[_] = synchronized {


### PR DESCRIPTION
A proper implementation is going to be added later. Currently UDTs will come in and out as java driver core UDTValues which are not Serializable, which means you must map them into something Serializable before sending between Spark nodes or from Spark to the client. Mapping UDTValues to and from case class objects is unsupported as well.

Fixes #374.
