### PR TITLE
wip-435: fixed a bug with setting batch size in bytes in WriteConf, adde...

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+* Fixed problem with setting a batch size in bytes (#435)
+
 1.1.0 beta 2
  * Fixed bug in Java API which might cause ClassNotFoundException
  * Added stubs for UDTs. It is possible to read tables with UDTs, but

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -151,9 +151,7 @@ class TableWriter[T] private (
 
 object TableWriter {
 
-  val DefaultParallelismLevel = 5
   val MeasuredInsertsCount = 128
-  val DefaultBatchSizeInBytes = 64 * 1024
 
   def apply[T : RowWriterFactory](
       connector: CassandraConnector,

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
@@ -1,6 +1,6 @@
 package com.datastax.spark.connector.writer
 
-import com.datastax.spark.connector.{RowsInBatch, BatchSize}
+import com.datastax.spark.connector.{BytesInBatch, RowsInBatch, BatchSize}
 import org.apache.commons.configuration.ConfigurationException
 import org.apache.spark.SparkConf
 
@@ -40,7 +40,7 @@ object WriteConf {
     val batchSize = {
       val Number = "([0-9]+)".r
       batchSizeInRowsStr match {
-        case "auto" => BatchSize.Automatic
+        case "auto" => BytesInBatch(batchSizeInBytes)
         case Number(x) => RowsInBatch(x.toInt)
         case other =>
           throw new ConfigurationException(

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/WriteConfTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/WriteConfTest.scala
@@ -1,0 +1,59 @@
+package com.datastax.spark.connector.writer
+
+import com.datastax.driver.core.ConsistencyLevel
+import com.datastax.spark.connector.{RowsInBatch, BytesInBatch}
+import org.apache.spark.SparkConf
+import org.scalatest.{FlatSpec, Matchers}
+
+class WriteConfTest extends FlatSpec with Matchers {
+
+  "WriteConf" should "be configured with proper defaults" in {
+    val conf = new SparkConf(false)
+    val writeConf = WriteConf.fromSparkConf(conf)
+
+    writeConf.batchSize should be(BytesInBatch(WriteConf.DefaultBatchSizeInBytes))
+    writeConf.consistencyLevel should be(WriteConf.DefaultConsistencyLevel)
+    writeConf.parallelismLevel should be(WriteConf.DefaultParallelismLevel)
+  }
+
+  it should "allow to set consistency level" in {
+    val conf = new SparkConf(false)
+      .set("spark.cassandra.output.consistency.level", "THREE")
+    val writeConf = WriteConf.fromSparkConf(conf)
+
+    writeConf.consistencyLevel should be(ConsistencyLevel.THREE)
+  }
+
+  it should "allow to set parallelism level" in {
+    val conf = new SparkConf(false)
+      .set("spark.cassandra.output.concurrent.writes", "17")
+    val writeConf = WriteConf.fromSparkConf(conf)
+
+    writeConf.parallelismLevel should be(17)
+  }
+
+  it should "allow to set batch size in bytes" in {
+    val conf = new SparkConf(false)
+      .set("spark.cassandra.output.batch.size.bytes", "12345")
+    val writeConf = WriteConf.fromSparkConf(conf)
+
+    writeConf.batchSize should be(BytesInBatch(12345))
+  }
+
+  it should "allow to set batch size in bytes when rows are set to auto" in {
+    val conf = new SparkConf(false)
+      .set("spark.cassandra.output.batch.size.bytes", "12345")
+      .set("spark.cassandra.output.batch.size.rows", "auto")
+    val writeConf = WriteConf.fromSparkConf(conf)
+
+    writeConf.batchSize should be(BytesInBatch(12345))
+  }
+
+  it should "allow to set batch size in rows" in {
+    val conf = new SparkConf(false)
+      .set("spark.cassandra.output.batch.size.rows", "12345")
+    val writeConf = WriteConf.fromSparkConf(conf)
+
+    writeConf.batchSize should be(RowsInBatch(12345))
+  }
+}


### PR DESCRIPTION
...d tests, and removed some obsolete constants, fixed #435
