### PR TITLE
wip-467: Moved several connection settings from system properties to Spa...

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 1.1.1 (unreleased)
  * Merged bug fix for #463 from b1.0
+ * Fixed the problem with passing additional connection settings to executors (#467)
 
 1.1.0
  * Switch to java driver 2.1.3 and Guava 14.0.1 (yay!).

--- a/doc/1_connecting.md
+++ b/doc/1_connecting.md
@@ -21,27 +21,31 @@ spark.cassandra.auth.username                  | login name for password authent
 spark.cassandra.auth.password                  | password for password authentication              |
 spark.cassandra.auth.conf.factory              | name of a Scala module or class implementing `AuthConfFactory` providing custom authentication configuration | `com.datastax.spark.connector.cql.DefaultAuthConfFactory`
 
-Additionally, the following global system properties are available:
+Additionally, the following properties can be set in `SparkConf` (previously they were set as system properties).
 
 Property name                                        | Description                                                   | Default value
 -----------------------------------------------------|---------------------------------------------------------------|--------------------
-spark.cassandra.connection.keep_alive_ms             | period of time to keep unused connections open                | 250 ms
 spark.cassandra.connection.timeout_ms                | maximum period of time to attempt connecting to a node        | 5000 ms
 spark.cassandra.connection.reconnection_delay_ms.min | minimum period of time to attempt reconnecting to a dead node | 1000 ms 
 spark.cassandra.connection.reconnection_delay_ms.max | maximum period of time to attempt reconnecting to a dead node | 60000 ms 
 spark.cassandra.connection.local_dc                  | the local DC to connect to (other nodes will be ignored)      | none
 spark.cassandra.query.retry.count                    | number of times to retry a timed-out query                    | 10 
 spark.cassandra.read.timeout_ms                      | maximum period of time to wait for a read to return           | 12000 ms
-  
+
+There is also one global system property `cassandra.connection.keep_alive_ms` which denotes the period of
+time to keep unused connections open (250 ms by default). It cannot be distributed as normal `SparkConf`
+and you have to pass it by attaching `-Dcassandra.connection.keep_alive_ms=some_value` to JVM properties.
+This can be done by specifying the aforementioned setting in `--driver-java-options "..."` for the driver
+program and in `--conf spark.executor.extraJavaOptions="..."` for executors (at least for Spark 1.1.x).
+
 Example:
 
 ```scala
-System.setProperty("spark.cassandra.query.retry.count", "1")  // don't retry
-
 val conf = new SparkConf(true)
         .set("spark.cassandra.connection.host", "192.168.123.10")
         .set("spark.cassandra.auth.username", "cassandra")            
-        .set("spark.cassandra.auth.password", "cassandra") 
+        .set("spark.cassandra.auth.password", "cassandra")
+        .set("spark.cassandra.query.retry.count", "1")  // don't retry
                      
 val sc = new SparkContext("spark://192.168.123.10:7077", "test", conf)
 ```
@@ -73,7 +77,7 @@ represented by the underlying Java Driver `Cluster` object.
 
 Eventually, when all the tasks needing Cassandra connectivity terminate,
 the connection to the Cassandra cluster will be closed shortly thereafter. The period of time for keeping unused connections
-open is controlled by the global `spark.cassandra.connection.keep_alive_ms` system property, which defaults to 250 ms. 
+open is controlled by the global `cassandra.connection.keep_alive_ms` system property, which defaults to 250 ms.
 
 
 ### Connecting manually to Cassandra

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -8,22 +8,22 @@ import scala.util.control.NonFatal
 
 /** Stores configuration of a connection to Cassandra.
   * Provides information about cluster nodes, ports and optional credentials for authentication. */
-case class CassandraConnectorConf(
-  hosts: Set[InetAddress],
-  nativePort: Int = CassandraConnectorConf.DefaultNativePort,
-  rpcPort: Int = CassandraConnectorConf.DefaultRpcPort,
-  authConf: AuthConf = NoAuthConf,
-  connectionFactory: CassandraConnectionFactory = DefaultConnectionFactory)
+case class CassandraConnectorConf(hosts: Set[InetAddress],
+                                  nativePort: Int = CassandraConnectorConf.DefaultNativePort,
+                                  rpcPort: Int = CassandraConnectorConf.DefaultRpcPort,
+                                  authConf: AuthConf = NoAuthConf,
+                                  connectionOptions: ConnectionOptions = ConnectionOptions(),
+                                  connectionFactory: CassandraConnectionFactory = DefaultConnectionFactory)
 
 /** A factory for `CassandraConnectorConf` objects.
   * Allows for manually setting connection properties or reading them from `SparkConf` object.
   * By embedding connection information in `SparkConf`, `SparkContext` can offer Cassandra specific methods
-  * which require establishing connections to a Cassandra cluster.*/
+  * which require establishing connections to a Cassandra cluster. */
 object CassandraConnectorConf extends Logging {
 
   val DefaultRpcPort = 9160
   val DefaultNativePort = 9042
-  
+
   val CassandraConnectionHostProperty = "spark.cassandra.connection.host"
   val CassandraConnectionRpcPortProperty = "spark.cassandra.connection.rpc.port"
   val CassandraConnectionNativePortProperty = "spark.cassandra.connection.native.port"
@@ -47,7 +47,29 @@ object CassandraConnectorConf extends Logging {
     val rpcPort = conf.getInt(CassandraConnectionRpcPortProperty, DefaultRpcPort)
     val nativePort = conf.getInt(CassandraConnectionNativePortProperty, DefaultNativePort)
     val authConf = AuthConf.fromSparkConf(conf)
+    val connectionOptions = ConnectionOptions(conf)
     val connectionFactory = CassandraConnectionFactory.fromSparkConf(conf)
-    CassandraConnectorConf(hosts, nativePort, rpcPort, authConf, connectionFactory)
+    CassandraConnectorConf(hosts, nativePort, rpcPort, authConf, connectionOptions, connectionFactory)
+  }
+}
+
+case class ConnectionOptions(minReconnectionDelay: Int = 1000,
+                             maxReconnectionDelay: Int = 60000,
+                             localDC: String = null,
+                             retryCount: Int = 10,
+                             connectTimeout: Int = 5000,
+                             readTimeout: Int = 12000)
+
+object ConnectionOptions {
+  def apply(conf: SparkConf): ConnectionOptions = {
+    val minReconnectionDelay = conf.getInt("spark.cassandra.connection.reconnection_delay_ms.min", 1000)
+    val maxReconnectionDelay = conf.getInt("spark.cassandra.connection.reconnection_delay_ms.max", 60000)
+    val localDC = conf.get("spark.cassandra.connection.local_dc", null)
+    val retryCount = conf.getInt("spark.cassandra.query.retry.count", 10)
+    val connectTimeout = conf.getInt("spark.cassandra.connection.timeout_ms", 5000)
+    val readTimeout = conf.getInt("spark.cassandra.read.timeout_ms", 12000)
+
+    ConnectionOptions(minReconnectionDelay, maxReconnectionDelay,
+      localDC, retryCount, connectTimeout, readTimeout)
   }
 }


### PR DESCRIPTION
...rk configuration and renamed spark.cassandra.connection.keep_alive_ms property

spark.cassandra.connection.keep_alive_ms has been renamed to cassandra.connection.keep_alive_ms because one could not pass this setting with `-Dprop=value` otherwise.

Fixes #467