### PR TITLE
Changed the way EmbeddedCassandra finds the classpath

### DIFF
--- a/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/EmbeddedCassandra.scala
+++ b/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/EmbeddedCassandra.scala
@@ -72,8 +72,13 @@ private[connector] class CassandraRunner(val configTemplate: String) extends Emb
       copyTextFileWithVariableSubstitution(input, output, properties)
     }
   }
+  private def makeJarPath() : String ={
+    var sysClassLoader : ClassLoader = ClassLoader.getSystemClassLoader();
+    sysClassLoader.asInstanceOf[java.net.URLClassLoader].getURLs().
+                                map( e => e.getFile).mkString(":")
+  }  
 
-  private val classPath = System.getProperty("java.class.path")
+  private val classPath = makeJarPath()
   private val javaBin = System.getProperty("java.home") + "/bin/java"
   private val cassandraConfProperty = "-Dcassandra.config=file:" + confFile.toString
   private val superuserSetupDelayProperty = "-Dcassandra.superuser_setup_delay_ms=0"

--- a/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/EmbeddedCassandra.scala
+++ b/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/EmbeddedCassandra.scala
@@ -78,7 +78,7 @@ private[connector] class CassandraRunner(val configTemplate: String) extends Emb
     sysClassLoader.asInstanceOf[java.net.URLClassLoader].getURLs().map( e => e.getFile).mkString(":")
   }
 
-  private val classPath = jarpath()
+  private val classPath = jarpath
   private val javaBin = System.getProperty("java.home") + "/bin/java"
   private val cassandraConfProperty = "-Dcassandra.config=file:" + confFile.toString
   private val superuserSetupDelayProperty = "-Dcassandra.superuser_setup_delay_ms=0"

--- a/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/EmbeddedCassandra.scala
+++ b/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/EmbeddedCassandra.scala
@@ -72,13 +72,13 @@ private[connector] class CassandraRunner(val configTemplate: String) extends Emb
       copyTextFileWithVariableSubstitution(input, output, properties)
     }
   }
-  private def makeJarPath() : String ={
-    var sysClassLoader : ClassLoader = ClassLoader.getSystemClassLoader();
-    sysClassLoader.asInstanceOf[java.net.URLClassLoader].getURLs().
-                                map( e => e.getFile).mkString(":")
-  }  
 
-  private val classPath = makeJarPath()
+  private def jarpath = {
+    val sysClassLoader : ClassLoader = ClassLoader.getSystemClassLoader()
+    sysClassLoader.asInstanceOf[java.net.URLClassLoader].getURLs().map( e => e.getFile).mkString(":")
+  }
+
+  private val classPath = jarpath()
   private val javaBin = System.getProperty("java.home") + "/bin/java"
   private val cassandraConfProperty = "-Dcassandra.config=file:" + confFile.toString
   private val superuserSetupDelayProperty = "-Dcassandra.superuser_setup_delay_ms=0"


### PR DESCRIPTION
When running from Eclipse / ScalaTest java.class.path was often not setup.