### PR TITLE
Added support for InSet predicate

### DIFF
--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLSpec.scala
@@ -104,6 +104,13 @@ class CassandraSQLSpec extends FlatSpec with Matchers with SharedEmbeddedCassand
     result should have length 8
   }
 
+  it should "allow to select rows with in clause pushed down" in {
+    val query = cc.sql("SELECT * FROM test2 WHERE a in (1,2)")
+    query.queryExecution.sparkPlan.nodeName should be ("CassandraTableScan")
+    val result = query.collect()
+    result should have length 6
+  }
+
   it should "allow to select rows with or clause" in {
     val result = cc.sql("SELECT * FROM test1 WHERE b = 2 or b = 1").collect()
     result should have length 8

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraStrategies.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraStrategies.scala
@@ -53,7 +53,7 @@ private[cassandra] trait CassandraStrategies {
         predicate.isInstanceOf[EqualTo]
 
       private def isIn(predicate: Expression) : Boolean =
-        predicate.isInstanceOf[In]
+        predicate.isInstanceOf[In] || predicate.isInstanceOf[InSet]
 
       private def isRangeComparison(predicate: Expression) : Boolean = predicate match {
         case _: LessThan           => true


### PR DESCRIPTION
Spark 1.1.1 introduced a new InSet expression which is generated by the optimizer for "IN" filters where the values are literals. This PR was originally made for Spark 1.1.1 but is valid for Spark 1.2 as well. I've tested this on both Spark 1.1.1 and Spark 1.2, using the most recent commits. I added a simple integration test to ensure the predicate is pushed down as part of the CassandraTableScan versus SparkSQL filter.