### PR TITLE
SPARKC-2: Efficient grouping of Cassandra rows by partition key. Useful ...

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,9 +2,10 @@
  * Added support for TTL and timestamp in the writer (#153)
  * Added support for UDT column types (SPARKC-1)
  * Upgraded Spark to version 1.2.0 (SPARKC-15)
- * Upgraded Spark to the latest release version, 1.1.1 (#461)
  * For 1.2.0 release, table name with dot is not supported for Spark SQL,
    it will be fixed in the next release
+ * Added fast spanBy and spanByKey methods to RDDs useful for grouping Cassandra
+   data by partition key / clustering columns. Useful for e.g. time-series data. (SPARKC-2)
 
 1.1.1
  * Fixed NoSuchElementException in SparkSQL predicate pushdown code (SPARKC-7, #454)

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/RDDJavaFunctions.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/RDDJavaFunctions.java
@@ -6,7 +6,11 @@ import com.datastax.spark.connector.cql.CassandraConnector;
 import com.datastax.spark.connector.writer.RowWriterFactory;
 import com.datastax.spark.connector.writer.WriteConf;
 import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.rdd.RDD;
+import scala.Tuple2;
 
 /**
  * A Java API wrapper over {@link org.apache.spark.rdd.RDD} to provide Spark Cassandra Connector functionality.
@@ -40,4 +44,7 @@ public class RDDJavaFunctions<T> extends RDDAndDStreamCommonJavaFunctions<T> {
         rddf.saveToCassandra(keyspace, table, columnNames, conf, connector, rowWriterFactory);
     }
 
+    // TODO: Add spanBy. To do this we need to first refactor RDDJavaFunctions (probably translate to Scala),
+    // because currently ClassTag information is missing and we can't call RDD#map here nor construct a
+    // Scala lambda to pass to Scala API.
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/PairRDDFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/PairRDDFunctions.scala
@@ -1,0 +1,17 @@
+package com.datastax.spark.connector
+
+import com.datastax.spark.connector.rdd.SpannedByKeyRDD
+import org.apache.spark.rdd.RDD
+
+class PairRDDFunctions[K, V](rdd: RDD[(K, V)]) extends Serializable {
+
+  /**
+   * Groups items with the same key, assuming the items with the same key are next to each other
+   * in the collection. It does not perform shuffle, therefore it is much faster than using
+   * much more universal Spark RDD `groupByKey`. For this method to be useful with Cassandra tables,
+   * the key must represent a prefix of the primary key, containing at least the partition key of the
+   * Cassandra table. */
+  def spanByKey: RDD[(K, Seq[V])] =
+    new SpannedByKeyRDD[K, V](rdd)
+
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
@@ -1,9 +1,12 @@
 package com.datastax.spark.connector
 
 import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.rdd.SpannedRDD
 import com.datastax.spark.connector.writer._
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
+
+import scala.reflect.ClassTag
 
 /** Provides Cassandra-specific methods on `RDD` */
 class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializable {
@@ -23,4 +26,12 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
     val writer = TableWriter(connector, keyspaceName, tableName, columns, writeConf)
     rdd.sparkContext.runJob(rdd, writer.write _)
   }
+
+  /** Applies a function to each item, and groups consecutive items having the same value together.
+    * Contrary to `groupBy`, items from the same group must be already next to each other in the
+    * original collection. Works locally on each partition, so items from different
+    * partitions will never be placed in the same group.*/
+  def spanBy[U](f: (T) => U): RDD[(U, Iterable[T])] =
+    new SpannedRDD[U, T](rdd, f)
+
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/package.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/package.scala
@@ -53,8 +53,11 @@ package object connector {
   implicit def toSparkContextFunctions(sc: SparkContext): SparkContextFunctions =
     new SparkContextFunctions(sc)
 
-  implicit def toRDDFunctions[T : ClassTag](rdd: RDD[T]): RDDFunctions[T] =
-    new RDDFunctions[T](rdd)
+  implicit def toRDDFunctions[T](rdd: RDD[T]): RDDFunctions[T] =
+    new RDDFunctions(rdd)
+
+  implicit def toPairRDDFunctions[K, V](rdd: RDD[(K, V)]): PairRDDFunctions[K, V] =
+    new PairRDDFunctions(rdd)
 
   implicit class ColumnNameFunctions(val columnName: String) extends AnyVal {
     def writeTime: WriteTime = WriteTime(columnName)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
@@ -6,6 +6,9 @@ import scala.reflect.ClassTag
 import scala.collection.JavaConversions._
 import scala.language.existentials
 
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{Partition, SparkContext, TaskContext}
+
 import com.datastax.driver.core.{ProtocolVersion, Session, Statement}
 import com.datastax.spark.connector.{SomeColumns, AllColumns, ColumnSelector}
 import com.datastax.spark.connector.cql._
@@ -14,9 +17,6 @@ import com.datastax.spark.connector.rdd.partitioner.dht.TokenFactory
 import com.datastax.spark.connector.rdd.reader._
 import com.datastax.spark.connector.types.{ColumnType, TypeConverter}
 import com.datastax.spark.connector.util.{Logging, CountingIterator}
-
-import org.apache.spark.rdd.RDD
-import org.apache.spark.{Partition, SparkContext, TaskContext}
 import com.datastax.spark.connector._
 
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/SpannedByKeyRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/SpannedByKeyRDD.scala
@@ -1,0 +1,25 @@
+package com.datastax.spark.connector.rdd
+
+import org.apache.spark.{TaskContext, Partition}
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.rdd.RDD
+
+import com.datastax.spark.connector.util.SpanningIterator
+
+/**
+ * Similar to [[SpannedRDD]] but, instead of extracting the key by the given function,
+ * it groups binary tuples by the first element of each tuple.
+ */
+private[connector] class SpannedByKeyRDD[K, V](parent: RDD[(K, V)]) extends RDD[(K, Seq[V])](parent) {
+
+  override protected def getPartitions = parent.partitions
+
+  @DeveloperApi
+  override def compute(split: Partition, context: TaskContext) = {
+    val parentIterator = parent.iterator(split, context)
+    def keyFunction(item: (K, V)) = item._1
+    def extractValues(group: (K, Seq[(K, V)])) = (group._1, group._2.map(_._2))
+    new SpanningIterator(parentIterator, keyFunction).map(extractValues)
+  }
+
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/SpannedRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/SpannedRDD.scala
@@ -1,0 +1,32 @@
+package com.datastax.spark.connector.rdd
+
+import org.apache.spark.{TaskContext, Partition}
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.rdd.RDD
+
+import com.datastax.spark.connector.util.SpanningIterator
+
+/**
+ * Groups items with the same key, assuming items with the same key are next to each other in
+ * the parent collection. Contrary to Spark GroupedRDD, it does not perform shuffle, therefore it
+ * is much faster. A key for each item is obtained by calling a given function.
+ *
+ * This RDD is very useful for grouping data coming out from Cassandra, because they are already
+ * coming in order of partitioning key i.e. it is not possible for two rows
+ * with the same partition key to be in different Spark partitions.
+ *
+ * @param parent parent RDD
+ * @tparam K type of keys
+ * @tparam T type of elements to be grouped together
+ */
+private[connector] class SpannedRDD[K, T](parent: RDD[T], f: T => K)
+  extends RDD[(K, Iterable[T])](parent) {
+
+  override protected def getPartitions = parent.partitions
+
+  @DeveloperApi
+  override def compute(split: Partition, context: TaskContext) =
+    new SpanningIterator(parent.iterator(split, context), f)
+
+}
+

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/BufferedIterator2.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/BufferedIterator2.scala
@@ -1,0 +1,56 @@
+package com.datastax.spark.connector.util
+
+import scala.collection.mutable.ArrayBuffer
+
+/** Serves the same purpose as `BufferedIterator` in Scala, but its `takeWhile` method 
+  * properly doesn't consume the next element. */
+class BufferedIterator2[T](iterator: Iterator[T]) extends Iterator[T] {
+
+  // Instead of a pair of T and Boolean we could use Option, but
+  // this would allocate a new Option object per each item, which might be
+  // too big overhead in tight loops using this iterator.
+  private[this] var headDefined: Boolean = false
+  private[this] var headElement: T = advance()
+
+  def head =
+    if (headDefined) headElement
+    else throw new NoSuchElementException("Head of empty iterator")
+
+  def headOption = headElement
+
+  private def advance(): T = {
+    if (iterator.hasNext) {
+      headDefined = true
+      iterator.next()
+    }
+    else {
+      headDefined = false
+      null.asInstanceOf[T]
+    }
+  }
+
+  override def hasNext = headDefined
+
+  override def next() = {
+    val result = head
+    headElement = advance()
+    result
+  }
+
+
+  override def takeWhile(p: T => Boolean): Iterator[T] = {
+    new Iterator[T]() {
+      override def hasNext = headDefined && p(headElement)
+      override def next() =
+        if (hasNext) BufferedIterator2.this.next()
+        else throw new NoSuchElementException
+    }
+  }
+
+  def appendWhile(p: (T) => Boolean, target: ArrayBuffer[T]): Unit = {
+    while (headDefined && p(headElement)) {
+      target += headElement
+      headElement = advance()
+    }
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/SpanningIterator.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/SpanningIterator.scala
@@ -1,0 +1,31 @@
+package com.datastax.spark.connector.util
+
+import scala.collection.mutable.ArrayBuffer
+
+/** An iterator that groups items having the same value of the given function (key).
+  * To be included in the same group, items with the same key must be next to each other
+  * in the original collection.
+  *
+  * `SpanningIterator` buffers internally one group at a time and the wrapped iterator
+  * is consumed in a lazy way.
+  *
+  * Example:
+  * {{{
+  *   val collection = Seq(1 -> "a", 1 -> "b", 1 -> "c", 2 -> "d", 2 -> "e")
+  *   val iterator = new SpanningIterator(collection.iterator, (x: (Int, String)) => x._1)
+  *   val result = iterator.toSeq  // Seq(1 -> Seq("a", "b", "c"), 2 -> Seq("d", "e"))
+  * }}}
+  */
+class SpanningIterator[K, T](iterator: Iterator[T], f: T => K) extends Iterator[(K, Seq[T])] {
+
+  private[this] val items = new BufferedIterator2(iterator)
+
+  override def hasNext = items.hasNext
+
+  override def next(): (K, Seq[T]) = {
+    val key = f(items.head)
+    val buffer = new ArrayBuffer[T]
+    items.appendWhile(r => f(r) == key, buffer)
+    (key, buffer)
+  }
+}

--- a/spark-cassandra-connector/src/perf/scala/com/datastax/spark/connector/util/BenchmarkUtil.scala
+++ b/spark-cassandra-connector/src/perf/scala/com/datastax/spark/connector/util/BenchmarkUtil.scala
@@ -1,0 +1,66 @@
+package com.datastax.spark.connector.util
+
+import scala.annotation.tailrec
+
+/** Utilities for benchmarking code */
+object BenchmarkUtil {
+
+  private val sampleSize = 5
+  private val minTime = 1000000000  // 1s
+
+  def formatTime(time: Double): String = {
+    if (time < 1e-7)
+      f"${time * 1000000000.0}%.2f ns"
+    else if (time < 1e-4)
+      f"${time * 1000000.0}%.2f us"
+    else if (time < 0.1)
+      f"${time * 1000.0}%.2f ms"
+    else
+      f"$time%.3f s"
+  }
+
+  @inline
+  private def time(loops: Long)(code: => Any): Long = {
+    val start = System.nanoTime()
+    var counter = 0L
+    while (counter < loops) {
+      code
+      counter += 1L
+    }
+    val end = System.nanoTime()
+    end - start
+  }
+
+  @inline
+  private def timeN(loops: Long)(code: => Any): Long = {
+    var i = 0
+    var bestTime = Long.MaxValue
+    while (bestTime >= minTime && i < sampleSize) {
+      val t = time(loops)(code)
+      if (t < bestTime)
+        bestTime = t
+      i += 1
+    }
+    bestTime
+  }
+
+  /** Runs the given code multiple times and prints how long it took. */
+  @tailrec
+  @inline
+  def timeIt[T](loops: Long)(code: => T): T = {
+    val bestTime = timeN(loops)(code)
+    if (bestTime < minTime)
+      timeIt(loops * 10)(code)
+    else {
+      val timePerLoop = bestTime / loops
+      printf("loops: %d, time per loop: %s, loops/s: %.3f\n",
+        loops, formatTime(timePerLoop / 1000000000.0), 1000000000.0 / timePerLoop)
+      code
+    }
+  }
+
+  @inline
+  def timeIt[T](code: => T): T =
+    timeIt(1)(code)
+
+}

--- a/spark-cassandra-connector/src/perf/scala/com/datastax/spark/connector/util/SpanningIteratorBenchmark.scala
+++ b/spark-cassandra-connector/src/perf/scala/com/datastax/spark/connector/util/SpanningIteratorBenchmark.scala
@@ -1,0 +1,25 @@
+package com.datastax.spark.connector.util
+
+object SpanningIteratorBenchmark extends App {
+
+  val iterator = Iterator.from(0)
+  val groupsOf1 = new SpanningIterator(iterator, (i: Int) => i)
+  val groupsOf10 = new SpanningIterator(iterator, (i: Int) => i / 10)
+  val groupsOf1000 = new SpanningIterator(iterator, (i: Int) => i / 1000)
+
+  println("1,000,000 groups of size 1 per each iteration:")
+  BenchmarkUtil.timeIt {
+    groupsOf10.drop(1000000)
+  }
+
+  println("100,000 groups of size 10 per each iteration:")
+  BenchmarkUtil.timeIt {
+    groupsOf10.drop(100000)
+  }
+
+  println("1000 groups of size 1000, per each iteration:")
+  BenchmarkUtil.timeIt {
+    groupsOf1000.drop(1000)
+  }
+
+}

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/util/BufferedIterator2Spec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/util/BufferedIterator2Spec.scala
@@ -1,0 +1,66 @@
+package com.datastax.spark.connector.util
+
+import org.scalatest.{Matchers, FlatSpec}
+
+import scala.collection.mutable.ArrayBuffer
+
+class BufferedIterator2Spec extends FlatSpec with Matchers {
+
+  "BufferedIterator" should "return the same items as the standard Iterator" in {
+    val iterator = new BufferedIterator2(Seq(1, 2, 3, 4, 5).iterator)
+    iterator.hasNext shouldBe true
+    iterator.next() shouldBe 1
+    iterator.hasNext shouldBe true
+    iterator.next() shouldBe 2
+    iterator.hasNext shouldBe true
+    iterator.next() shouldBe 3
+    iterator.hasNext shouldBe true
+    iterator.next() shouldBe 4
+    iterator.hasNext shouldBe true
+    iterator.next() shouldBe 5
+    iterator.hasNext shouldBe false
+  }
+
+  it should "be convertible to a Seq" in {
+    val iterator = new BufferedIterator2(Seq(1, 2, 3, 4, 5).iterator)
+    iterator.toSeq should contain inOrder(1, 2, 3, 4, 5)
+  }
+
+  it should "wrap an empty iterator" in {
+    val iterator = new BufferedIterator2(Iterator.empty)
+    iterator.isEmpty shouldBe true
+    iterator.hasNext shouldBe false
+  }
+
+  it should "offer the head element without consuming the underlying iterator" in {
+    val iterator = new BufferedIterator2(Seq(1, 2, 3, 4, 5).iterator)
+    iterator.head shouldBe 1
+    iterator.next() shouldBe 1
+  }
+
+  it should "offer takeWhile that consumes only the elements matching the predicate" in {
+    val iterator = new BufferedIterator2(Seq(1, 2, 3, 4, 5).iterator)
+    val firstThree = iterator.takeWhile(_ <= 3).toList
+
+    firstThree should contain inOrder (1, 2, 3)
+    iterator.head shouldBe 4
+    iterator.next() shouldBe 4
+  }
+
+  it should "offer appendWhile that copies elements to ArrayBuffer and consumes only the elements matching the predicate" in {
+    val iterator = new BufferedIterator2(Seq(1, 2, 3, 4, 5).iterator)
+    val buffer = new ArrayBuffer[Int]
+    iterator.appendWhile(_ <= 3, buffer)
+
+    buffer should contain inOrder (1, 2, 3)
+    iterator.head shouldBe 4
+    iterator.next() shouldBe 4
+  }
+
+  it should "throw NoSuchElementException if trying to get next() element that doesn't exist" in {
+    val iterator = new BufferedIterator2(Seq(1, 2).iterator)
+    iterator.next()
+    iterator.next()
+    a [NoSuchElementException] should be thrownBy iterator.next()
+  }
+}

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/util/SpanningIteratorSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/util/SpanningIteratorSpec.scala
@@ -1,0 +1,40 @@
+package com.datastax.spark.connector.util
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class SpanningIteratorSpec extends FlatSpec with Matchers {
+
+  "SpanningIterator" should "group an empty collection" in {
+    new SpanningIterator[Int, Int](Iterator.empty, identity).isEmpty shouldBe true
+  }
+
+  it should "group a sequence of elements with the same key into a single item and should preserve order" in {
+    val collection = Seq(1, 2, 3, 4, 5)
+    val grouped = new SpanningIterator(collection.iterator, (_: Int) => 0).toSeq
+    grouped should have length 1
+    grouped.head._2 should contain inOrder(1, 2, 3, 4, 5)
+  }
+
+  it should "group a sequence of elements with distinct keys the same number of groups" in {
+    val collection = Seq(1, 2, 3, 4, 5)
+    val grouped = new SpanningIterator(collection.iterator, identity[Int]).toSeq
+    grouped should have length 5
+    grouped.distinct should have length 5 // to check if something wasn't included more than once
+  }
+
+  it should "group a sequence of elements with two keys into two groups" in {
+    val collection = Seq(1 -> 10, 1 -> 11, 1 -> 12, 2 -> 20, 2 -> 21)
+    val grouped = new SpanningIterator(collection.iterator, (x: (Int, Int)) => x._1).toIndexedSeq
+    grouped should have length 2
+    grouped(0)._1 should be(1)
+    grouped(0)._2 should contain inOrder(1 -> 10, 1 -> 11, 1 -> 12)
+    grouped(1)._1 should be(2)
+    grouped(1)._2 should contain inOrder(2 -> 20, 2 -> 21)
+  }
+
+  it should "be lazy and work with infinite streams" in {
+    val stream = Stream.from(0)
+    val grouped = new SpanningIterator(stream.iterator, identity[Int])
+    grouped.take(5).toSeq.map(_._1) should contain inOrder(0, 1, 2, 3, 4)
+  }
+}


### PR DESCRIPTION
...for working with "wide rows", e.g. time-series data.

This commit introduces new spanBy and spanByKey operations. For data coming out of Cassandra, they can be used as faster equivalent of groupBy / groupByKey, because they take advantage of the fact that data coming out from Cassandra is already grouped by partition key and ordered by clustering columns. Therefore, costly data shuffling can be avoided and it is possible to group several tens of millions of objects per second on a single core. However, those methods are not general replacements for groupBy, as they rely on data order to work correctly. This commit addresses only Scala API.