### PR TITLE
SPARKC-25: Initial work to allow RDD's to be used as Keys for C*

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,8 @@ Unreleased
  * Fixed some Java API problems and refactored its internals (SPARKC-77)
  * Allowing specification of column to property map (aliases) for reading and writing objects
    (SPARKC-9)
+ * Added interface for doing primary key joins between arbitrary RDDs and Cassandra (SPARKC-25)
+ * Added method for repartitioning an RDD based upon the replication of a Cassandra Table (SPARKC-25)
 
 1.2.0 alpha 3
  * Exposed spanBy and spanByKey in Java API (SPARKC-39)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ execute arbitrary CQL queries in your Spark applications.
  - Maps table rows to CassandraRow objects or tuples
  - Offers customizable object mapper for mapping rows to objects of user-defined classes
  - Saves RDDs back to Cassandra by implicit `saveToCassandra` call
+ - Join with a subset of Cassandra data using `joinWithCassandraTable` call
+ - Partition RDDs according to Cassandra replication using `repartitionByCassandraReplica` call
  - Converts data types between Cassandra and Scala
  - Supports all Cassandra data types including collections
  - Filters rows on the server side via the CQL `WHERE` clause 

--- a/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaRDDSpec.scala
+++ b/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaRDDSpec.scala
@@ -2,20 +2,18 @@ package com.datastax.spark.connector.rdd
 
 import java.io.IOException
 
-import scala.collection.JavaConversions._
-
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.embedded._
-import com.datastax.spark.connector.japi.CassandraRow
 import com.datastax.spark.connector.japi.CassandraJavaUtil._
-import com.datastax.spark.connector.rdd.ClusteringOrder.{Descending, Ascending}
+import com.datastax.spark.connector.japi.CassandraRow
 import com.datastax.spark.connector.testkit._
 import com.datastax.spark.connector.types.TypeConverter
-
 import org.apache.commons.lang3.tuple
 import org.apache.spark.api.java.function.{Function => JFunction}
 import org.scalatest._
+
+import scala.collection.JavaConversions._
 
 class CassandraJavaRDDSpec extends FlatSpec with Matchers with BeforeAndAfter with BeforeAndAfterAll
 with ShouldMatchers with SharedEmbeddedCassandra with SparkTemplate {
@@ -366,17 +364,20 @@ with ShouldMatchers with SharedEmbeddedCassandra with SparkTemplate {
   }
 
   it should "allow to set limit" in {
-    val rdd = javaFunctions(sc).cassandraTable("java_api_test", "test_table").limit(10)
-    rdd.rdd.limit shouldBe Some(10L)
+    val rdd = javaFunctions(sc).cassandraTable("java_api_test", "test_table").limit(1)
+    val result = rdd.collect
+    result should have size (1)
   }
 
   it should "allow to set ascending ordering" in {
-    val rdd = javaFunctions(sc).cassandraTable("java_api_test", "test_table").withAscOrder
-    rdd.rdd.clusteringOrder shouldBe Some(Ascending)
+    val rdd = javaFunctions(sc).cassandraTable("java_api_test", "wide_rows").where("key=10").withAscOrder
+    val result = rdd.collect
+    result(0).getInt("group") should be(10)
   }
 
   it should "allow to set descending ordering" in {
-    val rdd = javaFunctions(sc).cassandraTable("java_api_test", "test_table").withDescOrder
-    rdd.rdd.clusteringOrder shouldBe Some(Descending)
+    val rdd = javaFunctions(sc).cassandraTable("java_api_test", "wide_rows").where("key=20").withDescOrder
+    val result = rdd.collect
+    result(0).getInt("group") should be(22)
   }
 }

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/SparkContextJavaFunctions.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/SparkContextJavaFunctions.java
@@ -6,7 +6,7 @@ import org.apache.spark.SparkContext;
 import com.datastax.spark.connector.japi.rdd.CassandraJavaPairRDD;
 import com.datastax.spark.connector.japi.rdd.CassandraJavaRDD;
 import com.datastax.spark.connector.rdd.CassandraRDD;
-import com.datastax.spark.connector.rdd.CassandraRDD$;
+import com.datastax.spark.connector.rdd.CassandraTableScanRDD$;
 import com.datastax.spark.connector.rdd.reader.KeyValueRowReaderFactory;
 import com.datastax.spark.connector.rdd.reader.RowReaderFactory;
 
@@ -85,7 +85,8 @@ public class SparkContextJavaFunctions {
      * @since 1.1.0
      */
     public <T> CassandraJavaRDD<T> cassandraTable(String keyspace, String table, RowReaderFactory<T> rrf) {
-        CassandraRDD<T> rdd = CassandraRDD$.MODULE$.apply(sparkContext, keyspace, table, getClassTag(rrf.targetClass()), rrf);
+        CassandraRDD<T> rdd = CassandraTableScanRDD$.MODULE$
+                .apply(sparkContext, keyspace, table, getClassTag(rrf.targetClass()), rrf);
         return new CassandraJavaRDD<>(rdd, rrf.targetClass());
     }
 
@@ -110,7 +111,7 @@ public class SparkContextJavaFunctions {
     public <K, V> CassandraJavaPairRDD<K, V> cassandraTable(String keyspace, String table, RowReaderFactory<K> keyRRF, RowReaderFactory<V> valueRRF) {
         KeyValueRowReaderFactory<K, V> rrf = new KeyValueRowReaderFactory<>(keyRRF, valueRRF);
 
-        CassandraRDD<Tuple2<K, V>> rdd = CassandraRDD$.MODULE$.apply(sparkContext, keyspace, table,
+        CassandraRDD<Tuple2<K, V>> rdd = CassandraTableScanRDD$.MODULE$.apply(sparkContext, keyspace, table,
                 getClassTag(keyRRF.targetClass()), getClassTag(valueRRF.targetClass()), rrf);
 
         return new CassandraJavaPairRDD<>(rdd, getClassTag(keyRRF.targetClass()), getClassTag(valueRRF.targetClass()));

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
@@ -1,0 +1,403 @@
+package com.datastax.spark.connector.rdd
+
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.embedded._
+import com.datastax.spark.connector.rdd.partitioner.EndpointPartition
+import com.datastax.spark.connector.testkit.SharedEmbeddedCassandra
+import org.scalatest.{FlatSpec, Matchers}
+
+
+case class KVRow(key: Int)
+
+case class FullRow(key: Int, group: Long, value: String)
+
+case class NotWholePartKey(pk1: Int)
+
+case class MissingClustering(pk1: Int, pk2: Int, pk3: Int, cc2: Int)
+
+case class MissingClustering2(pk1: Int, pk2: Int, pk3: Int, cc3: Int, cc1: Int)
+
+case class MissingClustering3(pk1: Int, pk2: Int, pk3: Int, cc1: Int, cc3: Int)
+
+case class DataCol(pk1: Int, pk2: Int, pk3: Int, d1: Int)
+
+class RDDSpec extends FlatSpec with Matchers with SharedEmbeddedCassandra with SparkTemplate {
+
+  useCassandraConfig("cassandra-default.yaml.template")
+
+  val conn = CassandraConnector(Set(cassandraHost))
+  implicit val protocolVersion = conn.withClusterDo(_.getConfiguration.getProtocolOptions.getProtocolVersionEnum)
+  val keyspace = "rdd_test"
+  val tableName = "key_value"
+  val otherTable = "other_table"
+  val wideTable = "wide_table"
+  val manyColsTable = "many_cols_table"
+  val keys = 0 to 200
+  val total = 0 to 10000
+
+  conn.withSessionDo { session =>
+    session.execute(s"CREATE KEYSPACE IF NOT EXISTS $keyspace WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }")
+    session.execute(s"CREATE TABLE IF NOT EXISTS $keyspace.$tableName (key INT, group BIGINT, value TEXT, PRIMARY KEY (key, group))")
+    for (value <- total) {
+      session.execute(s"INSERT INTO $keyspace.$tableName (key, group, value) VALUES ($value, ${value * 100}, '${value.toString}')")
+    }
+
+    session.execute(s"CREATE TABLE IF NOT EXISTS $keyspace.$otherTable (key INT, group BIGINT,  PRIMARY KEY (key))")
+    for (value <- keys) {
+      session.execute(s"INSERT INTO $keyspace.$otherTable (key, group) VALUES ($value, ${value * 100})")
+    }
+
+    session.execute(s"CREATE TABLE IF NOT EXISTS $keyspace.$wideTable (key INT, group BIGINT, value TEXT, PRIMARY KEY (key, group))")
+    for (value <- keys) {
+      for (cconeValue <- value * 100 until value * 100 + 5) {
+        session.execute(s"INSERT INTO $keyspace.$wideTable (key, group, value) VALUES ($value, ${cconeValue}, '${value.toString}')")
+      }
+    }
+
+    session.execute(s"CREATE TABLE IF NOT EXISTS $keyspace.$manyColsTable (pk1 int, pk2 int, pk3 int, cc1 int, cc2 int, cc3 int, cc4 int, d1 int, PRIMARY KEY ((pk1, pk2, pk3), cc1, cc2, cc3, cc4))")
+  }
+
+  def checkLeftSide[T, S](leftSideSource: Array[T], result: Array[(T, S)]) = {
+    markup("Checking LeftSide")
+    val leftSideResults = result.map(_._1)
+    for (element <- leftSideSource) {
+      leftSideResults should contain(element)
+    }
+  }
+
+  def checkArrayCassandraRow[T](result: Array[(T, CassandraRow)]) = {
+    markup("Checking RightSide Join Results")
+    result.length should be(keys.length)
+    for (key <- keys) {
+      val sorted_result = result.map(_._2).sortBy(_.getInt(0))
+      sorted_result(key).getInt("key") should be(key)
+      sorted_result(key).getLong("group") should be(key * 100)
+      sorted_result(key).getString("value") should be(key.toString)
+    }
+  }
+
+  def checkArrayTuple[T](result: Array[(T, (Int, Long, String))]) = {
+    markup("Checking RightSide Join Results")
+    result.length should be(keys.length)
+    for (key <- keys) {
+      val sorted_result = result.map(_._2).sortBy(_._1)
+    sorted_result(key)._1 should be(key)
+    sorted_result(key)._2 should be(key * 100)
+    sorted_result(key)._3 should be(key.toString)
+  }
+  }
+
+  def checkArrayFullRow[T](result: Array[(T, FullRow)]) = {
+    markup("Checking RightSide Join Results")
+    result.length should be(keys.length)
+    for (key <- keys) {
+      val sorted_result = result.map(_._2).sortBy(_.key)
+      sorted_result(key).key should be(key)
+      sorted_result(key).group should be(key * 100)
+      sorted_result(key).value should be(key.toString)
+    }
+  }
+
+  "A Tuple RDD specifying partition keys" should "be joinable with Cassandra" in {
+    val source = sc.parallelize(keys).map(Tuple1(_))
+    val someCass = source.joinWithCassandraTable(keyspace, tableName)
+    val result = someCass.collect
+    val leftSide = source.collect
+    checkArrayCassandraRow(result)
+    checkLeftSide(leftSide, result)
+  }
+
+  it should "be retreivable as a tuple from Cassandra" in {
+    val source = sc.parallelize(keys).map(Tuple1(_))
+    val someCass = source.joinWithCassandraTable[(Int, Long, String)](keyspace, tableName)
+    val result = someCass.collect
+    val leftSide = source.collect
+    checkArrayTuple(result)
+    checkLeftSide(leftSide, result)
+  }
+
+  it should "be retreivable as a case class from cassandra" in {
+    val source = sc.parallelize(keys).map(Tuple1(_))
+    val someCass = source.joinWithCassandraTable[FullRow](keyspace, tableName)
+    val result = someCass.collect
+    val leftSide = source.collect
+    checkArrayFullRow(result)
+    checkLeftSide(leftSide, result)
+  }
+
+  it should "be repartitionable" in {
+    val source = sc.parallelize(keys).map(Tuple1(_))
+    val repart = source.repartitionByCassandraReplica(keyspace, tableName, 10)
+    repart.partitions.length should be(conn.hosts.size * 10)
+    val someCass = repart.joinWithCassandraTable(keyspace, tableName)
+    someCass.partitions.foreach {
+      case e: EndpointPartition =>
+        conn.hosts should contain(e.endpoints.head)
+      case _ =>
+        fail("Unable to get endpoints on repartitioned RDD, This means preferred locations will be broken")
+    }
+    val result = someCass.collect
+    checkArrayCassandraRow(result)
+  }
+
+  "A case-class RDD specifying partition keys" should "be retrievable from Cassandra" in {
+    val source = sc.parallelize(keys).map(x => new KVRow(x))
+    val someCass = source.joinWithCassandraTable(keyspace, tableName)
+    val result = someCass.collect
+    val leftSide = source.collect
+    checkArrayCassandraRow(result)
+    checkLeftSide(leftSide, result)
+  }
+
+  it should "be retreivable as a tuple from Cassandra" in {
+    val source = sc.parallelize(keys).map(x => new KVRow(x))
+    val someCass = source.joinWithCassandraTable[(Int, Long, String)](keyspace, tableName)
+    val result = someCass.collect
+    val leftSide = source.collect
+    checkArrayTuple(result)
+    checkLeftSide(leftSide, result)
+  }
+
+  it should "be retreivable as a case class from cassandra" in {
+    val source = sc.parallelize(keys).map(x => new KVRow(x))
+    val someCass = source.joinWithCassandraTable[FullRow](keyspace, tableName)
+    val result = someCass.collect
+    val leftSide = source.collect
+    checkArrayFullRow(result)
+    checkLeftSide(leftSide, result)
+  }
+
+  it should "be repartitionable" in {
+    val source = sc.parallelize(keys).map(x => new KVRow(x))
+    val repart = source.repartitionByCassandraReplica(keyspace, tableName, 10)
+    repart.partitions.length should be(conn.hosts.size * 10)
+    val someCass = repart.joinWithCassandraTable(keyspace, tableName)
+    someCass.partitions.foreach {
+      case e: EndpointPartition =>
+        conn.hosts should contain(e.endpoints.head)
+      case _ =>
+        fail("Unable to get endpoints on repartitioned RDD, This means preferred locations will be broken")
+    }
+    val result = someCass.collect
+    checkArrayCassandraRow(result)
+  }
+
+
+  "A Tuple RDD specifying partitioning keys and clustering keys " should "be retrievable from Cassandra" in {
+    val source = sc.parallelize(keys).map(x => (x, x * 100: Long))
+    val someCass = source.joinWithCassandraTable(keyspace, tableName)
+    val result = someCass.collect
+    val leftSide = source.collect
+    checkArrayCassandraRow(result)
+    checkLeftSide(leftSide, result)
+  }
+
+  it should "be retreivable as a tuple from Cassandra" in {
+    val source = sc.parallelize(keys).map(x => (x, x * 100: Long))
+    val someCass = source.joinWithCassandraTable[(Int, Long, String)](keyspace, tableName)
+    val result = someCass.collect
+    val leftSide = source.collect
+    checkArrayTuple(result)
+    checkLeftSide(leftSide, result)
+  }
+
+  it should "be retreivable as a case class from cassandra" in {
+    val source = sc.parallelize(keys).map(x => (x, x * 100: Long))
+    val someCass = source.joinWithCassandraTable[FullRow](keyspace, tableName)
+    val result = someCass.collect
+    val leftSide = source.collect
+    checkArrayFullRow(result)
+    checkLeftSide(leftSide, result)
+  }
+
+  it should "be repartitionable" in {
+    val source = sc.parallelize(keys).map(x => (x, x * 100: Long))
+    val repart = source.repartitionByCassandraReplica(keyspace, tableName, 10)
+    repart.partitions.length should be(conn.hosts.size * 10)
+    val someCass = repart.joinWithCassandraTable(keyspace, tableName)
+    someCass.partitions.foreach {
+      case e: EndpointPartition =>
+        conn.hosts should contain(e.endpoints.head)
+      case _ =>
+        fail("Unable to get endpoints on repartitioned RDD, This means preferred locations will be broken")
+    }
+    val result = someCass.collect
+    checkArrayCassandraRow(result)
+  }
+
+  it should "be joinable on both partitioning key and clustering key" in {
+    val source = sc.parallelize(keys).map(x => (x, x * 100))
+    val someCass = source.joinWithCassandraTable(keyspace, wideTable, joinColumns = SomeColumns("key", "group"))
+    val result = someCass.collect
+    val leftSide = source.collect
+    checkArrayCassandraRow(result)
+    checkLeftSide(leftSide, result)
+  }
+
+  it should "be joinable on both partitioning key and clustering key using on" in {
+    val source = sc.parallelize(keys).map(x => (x, x * 100))
+    val someCass = source.joinWithCassandraTable(keyspace, wideTable).on(SomeColumns("key", "group"))
+    val result = someCass.collect
+    val leftSide = source.collect
+    checkArrayCassandraRow(result)
+    checkLeftSide(leftSide, result)
+  }
+
+  it should "be be able to be limited" in {
+    val source = sc.parallelize(keys).map(x => (x, x * 100))
+    val someCass = source.joinWithCassandraTable(keyspace, wideTable).on(SomeColumns("key", "group")).limit(3)
+    val result = someCass.collect
+    result should have size (3 * someCass.partitions.size)
+  }
+
+  it should "have be able to be counted" in {
+    val source = sc.parallelize(keys).map(x => (x, x * 100))
+    val someCass = source.joinWithCassandraTable(keyspace, wideTable).on(SomeColumns("key", "group")).count()
+    someCass should be (201)
+
+  }
+
+
+  "A CassandraRDD " should "be joinable with Cassandra" in {
+    val source = sc.cassandraTable(keyspace, otherTable)
+    val someCass = source.joinWithCassandraTable(keyspace, tableName)
+    val result = someCass.collect
+    val leftSide = source.collect
+    checkArrayCassandraRow(result)
+    checkLeftSide(leftSide, result)
+  }
+
+  it should "be retreivable as a tuple from Cassandra" in {
+    val source = sc.cassandraTable(keyspace, otherTable)
+    val someCass = source.joinWithCassandraTable[(Int, Long, String)](keyspace, tableName)
+    val result = someCass.collect
+    val leftSide = source.collect
+    checkArrayTuple(result)
+    checkLeftSide(leftSide, result)
+  }
+
+  it should "be retreivable as a case class from cassandra" in {
+    val source = sc.cassandraTable(keyspace, otherTable)
+    val someCass = source.joinWithCassandraTable[FullRow](keyspace, tableName)
+    val result = someCass.collect
+    val leftSide = source.collect
+    checkArrayFullRow(result)
+    checkLeftSide(leftSide, result)
+  }
+
+  it should " be retreivable without repartitioning" in {
+    val someCass = sc.cassandraTable(keyspace, otherTable).joinWithCassandraTable(keyspace, tableName)
+    someCass.toDebugString should not contain "ShuffledRDD"
+    val result = someCass.collect
+    checkArrayCassandraRow(result)
+  }
+
+  it should "be repartitionable" in {
+    val source = sc.cassandraTable(keyspace, otherTable)
+    val repart = source.repartitionByCassandraReplica(keyspace, tableName, 10)
+    repart.partitions.length should be(conn.hosts.size * 10)
+    val someCass = repart.joinWithCassandraTable(keyspace, tableName)
+    someCass.partitions.foreach {
+      case e: EndpointPartition =>
+        conn.hosts should contain(e.endpoints.head)
+      case _ =>
+        fail("Unable to get endpoints on repartitioned RDD, This means preferred locations will be broken")
+    }
+    val result = someCass.collect
+    checkArrayCassandraRow(result)
+  }
+
+  "A Joined CassandraRDD " should " support select clauses " in {
+    val someCass = sc.cassandraTable(keyspace, otherTable).joinWithCassandraTable(keyspace, tableName).select("value")
+    val results = someCass.collect.map(_._2).map(_.getInt("value")).sorted
+    results should be(keys.toArray)
+  }
+
+  it should " support where clauses" in {
+    val someCass = sc.parallelize(keys).map(x => new KVRow(x)).joinWithCassandraTable(keyspace, tableName).where("group >= 500")
+    val results = someCass.collect.map(_._2)
+    results should have length (keys.filter(_ >= 5).length)
+  }
+
+  it should " throw an exception if using where on a column in the Partition key" in {
+    intercept[IllegalArgumentException] {
+      val someCass = sc.parallelize(keys)
+        .map(x => new KVRow(x))
+        .joinWithCassandraTable(keyspace, tableName)
+        .where("key = 200")
+        .collect()
+    }
+  }
+
+  it should " throw an exception if you don't have all Partition Keys available" in {
+    intercept[IllegalArgumentException] {
+      val someCass = sc.parallelize(keys)
+        .map(x => new NotWholePartKey(x))
+        .joinWithCassandraTable(keyspace, manyColsTable)
+        .collect()
+    }
+  }
+
+  it should " throw an exception if you try to join on later clustering columns without earlier ones" in {
+    intercept[IllegalArgumentException] {
+      val someCass = sc.parallelize(keys)
+        .map(x => new MissingClustering(x, x, x, x))
+        .joinWithCassandraTable(keyspace, manyColsTable)
+        .on(SomeColumns("pk1", "pk2", "pk3", "cc2"))
+        .collect()
+    }
+  }
+
+  it should " throw an exception if you try to join on later clustering columns without earlier ones even when out of order" in {
+    intercept[IllegalArgumentException] {
+      val someCass = sc.parallelize(keys)
+        .map(x => new MissingClustering2(x, x, x, x, x))
+        .joinWithCassandraTable(keyspace, manyColsTable)
+        .on(SomeColumns("pk1", "pk2", "pk3", "cc3", "cc1"))
+        .collect()
+    }
+  }
+
+  it should " throw an exception if you try to join on later clustering columns without earlier ones even when reversed" in {
+    intercept[IllegalArgumentException] {
+      val someCass = sc.parallelize(keys)
+        .map(x => new MissingClustering3(x, x, x, x, x))
+        .joinWithCassandraTable(keyspace, manyColsTable)
+        .on(SomeColumns("pk1", "pk2", "pk3", "cc1", "cc3"))
+        .collect()
+    }
+  }
+
+  it should " throw an exception if you try to join with a data column" in {
+    intercept[IllegalArgumentException] {
+      val someCass = sc.parallelize(keys)
+        .map(x => new DataCol(x, x, x, x))
+        .joinWithCassandraTable(keyspace, manyColsTable)
+        .on(SomeColumns("pk1", "pk2", "pk3", "d1")).collect()
+    }
+  }
+
+  it should "allow to use empty RDD on undefined table" in {
+    val result = sc.parallelize(keys)
+      .joinWithCassandraTable("unknown_ks", "unknown_table")
+      .toEmptyCassandraRDD
+      .collect()
+    result should have length 0
+  }
+
+  it should "allow to use empty RDD on defined table" in {
+    val result = sc.parallelize(keys)
+      .joinWithCassandraTable(keyspace, manyColsTable)
+      .toEmptyCassandraRDD
+      .collect()
+    result should have length 0
+  }
+
+  it should " be lazy and not throw an exception if the table is not found at initializaiton time" in {
+    val someCass = sc.parallelize(keys).map(x => new DataCol(x, x, x, x)).joinWithCassandraTable("unknown_keyspace", "unknown_table")
+  }
+
+
+
+}

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/GroupingBatchBuilderSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/GroupingBatchBuilderSpec.scala
@@ -34,7 +34,9 @@ class GroupingBatchBuilderSpec extends FlatSpec with Matchers with BeforeAndAfte
   }
 
   def staticBatchKeyGen(bs: BoundStatement): Int = 0
+
   def dynamicBatchKeyGen(bs: BoundStatement): Int = bs.getInt(0) % 2
+
   def dynamicBatchKeyGen5(bs: BoundStatement): Int = bs.getInt(0) % 5
 
   "GroupingBatchBuilder in fixed batch key mode" should "make bound statements when batch size is specified as RowsInBatch(1)" in {
@@ -271,7 +273,7 @@ class GroupingBatchBuilderSpec extends FlatSpec with Matchers with BeforeAndAfte
       val size = 10000
       val data = (1 to size).map(x => (Random.nextInt().abs, Random.nextString(Random.nextInt(20))))
       val statements = bm(dynamicBatchKeyGen5, RowsInBatch(10), 4, data.toIterator).toList
-      val batches = statements.collect { case bs: BatchStatement => bs.size() }
+      val batches = statements.collect { case bs: BatchStatement => bs.size()}
       statements.flatMap {
         case s: BoundStatement => List(s)
         case s: BatchStatement =>

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/AbstractGettableData.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/AbstractGettableData.scala
@@ -60,6 +60,15 @@ trait AbstractGettableData {
     .mkString("{", ", ", "}")
 
   override def toString = dataAsString
+
+  override def equals(o: Any) = o match {
+    case o: AbstractGettableData =>
+      if (this.fieldValues.length == o.length) {
+        this.fieldValues.zip(o.fieldValues).forall { case (mine, yours) => mine == yours}
+      } else
+        false
+    case _ => false
+  }
 }
 
 object AbstractGettableData {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ColumnSelector.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ColumnSelector.scala
@@ -10,6 +10,10 @@ case object AllColumns extends ColumnSelector {
   override def aliases: Map[String, String] = Map.empty.withDefault(x => x)
 }
 
+case object PartitionKeyColumns extends ColumnSelector {
+  override def aliases: Map[String, String] = Map.empty.withDefault(x => x)
+}
+
 case class SomeColumns(columns: SelectableColumnRef*) extends ColumnSelector {
   override def aliases: Map[String, String] = columns.map {
     case ref => (ref.alias.getOrElse(ref.selectedFromCassandraAs), ref.selectedFromCassandraAs)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
@@ -1,13 +1,20 @@
 package com.datastax.spark.connector
 
-import com.datastax.spark.connector.cql.{TableDef, CassandraConnector}
+
+import java.net.InetAddress
+
+import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.mapper.ColumnMapper
-import com.datastax.spark.connector.rdd.SpannedRDD
-import com.datastax.spark.connector.writer._
+import com.datastax.spark.connector.rdd.partitioner.{CassandraPartitionedRDD, ReplicaPartitioner}
+import com.datastax.spark.connector.rdd.reader._
+import com.datastax.spark.connector.rdd.{CassandraJoinRDD, SpannedRDD, ValidRDDType}
+import com.datastax.spark.connector.writer.{ReplicaMapper, _}
 import org.apache.spark.SparkContext
+import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
 
 import scala.reflect.ClassTag
+
 
 /** Provides Cassandra-specific methods on `RDD` */
 class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializable {
@@ -87,8 +94,71 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
   /** Applies a function to each item, and groups consecutive items having the same value together.
     * Contrary to `groupBy`, items from the same group must be already next to each other in the
     * original collection. Works locally on each partition, so items from different
-    * partitions will never be placed in the same group.*/
+    * partitions will never be placed in the same group. */
   def spanBy[U](f: (T) => U): RDD[(U, Iterable[T])] =
     new SpannedRDD[U, T](rdd, f)
+
+  /**
+   * Uses the data from `RDD` to join with a Cassandra table without retrieving the entire table.
+   * Any RDD which can be used to saveToCassandra can be used to joinWithCassandra as well as any
+   * RDD which only specifies the partition Key of a Cassandra Table. This method executes single
+   * partition requests against the Cassandra Table and accepts the functional modifiers that a
+   * normal [[com.datastax.spark.connector.rdd.CassandraTableScanRDD]] takes.
+   *
+   * By default this method only uses the Partition Key for joining but any combination of columns
+   * which are acceptable to C* can be used in the join. Specify columns using joinColumns as a parameter
+   * or the on() method.
+   *
+   * Example With Prior Repartitioning: {{{
+   * val source = sc.parallelize(keys).map(x => new KVRow(x))
+   * val repart = source.repartitionByCassandraReplica(keyspace, tableName, 10)
+   * val someCass = repart.joinWithCassandraTable(keyspace, tableName)
+   * }}}
+   *
+   * Example Joining on Clustering Columns: {{{
+   * val source = sc.parallelize(keys).map(x => (x, x * 100))
+   * val someCass = source.joinWithCassandraTable(keyspace, wideTable).on(SomeColumns("key", "group"))
+   * }}}
+   **/
+  def joinWithCassandraTable[R](keyspaceName: String, tableName: String,
+                                selectedColumns: ColumnSelector = AllColumns,
+                                joinColumns: ColumnSelector = PartitionKeyColumns)
+                               (implicit connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+                                newType: ClassTag[R], rrf: RowReaderFactory[R], ev: ValidRDDType[R],
+                                currentType: ClassTag[T], rwf: RowWriterFactory[T]): CassandraJoinRDD[T, R] = {
+    new CassandraJoinRDD[T, R](rdd, keyspaceName, tableName, connector, columnNames = selectedColumns, joinColumns = joinColumns)
+  }
+
+
+  /**
+   * Repartitions the data (via a shuffle) based upon the replication of the given `keyspaceName` and `tableName`. 
+   * Calling this method before using joinWithCassandraTable will ensure that requests will be coordinator
+   * local. `partitionsPerHost` Controls the number of Spark Partitions that will be created in this repartitioning
+   * event.
+   * The calling RDD must have rows that can be converted into the partition key of the given Cassandra Table.
+   **/
+  def repartitionByCassandraReplica(keyspaceName: String, tableName: String, partitionsPerHost: Int = 10)
+                                   (implicit connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+                                    currentType: ClassTag[T], rwf: RowWriterFactory[T]) = {
+    val part = new ReplicaPartitioner(partitionsPerHost, connector)
+    val repart = rdd.keyByCassandraReplica(keyspaceName, tableName).partitionBy(part)
+    val output = repart.mapPartitions(_.map(_._2), preservesPartitioning = true)
+    new CassandraPartitionedRDD[T](output)
+  }
+
+  /**
+   * Key every row in the RDD by with the IP Adresses of all of the Cassandra nodes which a contain a replica
+   * of the data specified by that row.
+   * The calling RDD must have rows that can be converted into the partition key of the given Cassandra Table.
+   */
+  def keyByCassandraReplica(keyspaceName: String, tableName: String)
+                           (implicit connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+                            currentType: ClassTag[T], rwf: RowWriterFactory[T]): RDD[(Set[InetAddress], T)] = {
+    val converter = ReplicaMapper[T](connector, keyspaceName, tableName)
+    rdd.mapPartitions(primaryKey =>
+      converter.keyByReplicas(primaryKey)
+    )
+  }
+
 
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/SparkContextFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/SparkContextFunctions.scala
@@ -1,8 +1,8 @@
 package com.datastax.spark.connector
 
 import com.datastax.spark.connector.cql.CassandraConnector
-import com.datastax.spark.connector.rdd.{ReadConf, ValidRDDType, CassandraRDD}
 import com.datastax.spark.connector.rdd.reader.RowReaderFactory
+import com.datastax.spark.connector.rdd.{CassandraTableScanRDD, EmptyCassandraRDD, ReadConf, ValidRDDType}
 import org.apache.spark.SparkContext
 
 import scala.reflect.ClassTag
@@ -47,7 +47,7 @@ class SparkContextFunctions(@transient val sc: SparkContext) extends Serializabl
                        (implicit connector: CassandraConnector = CassandraConnector(sc.getConf),
                         ct: ClassTag[T], rrf: RowReaderFactory[T],
                         ev: ValidRDDType[T]) =
-    new CassandraRDD[T](sc, connector, keyspace, table, readConf = ReadConf.fromSparkConf(sc.getConf))
+    new CassandraTableScanRDD[T](sc, connector, keyspace, table, readConf = ReadConf.fromSparkConf(sc.getConf))
 
   /** Produces the empty CassandraRDD which does not perform any validation and it does not even
     * try to return any rows. */
@@ -55,5 +55,5 @@ class SparkContextFunctions(@transient val sc: SparkContext) extends Serializabl
                             (implicit connector: CassandraConnector = CassandraConnector(sc.getConf),
                              ct: ClassTag[T], rrf: RowReaderFactory[T],
                              ev: ValidRDDType[T]) =
-    new CassandraRDD[T](sc, connector, keyspace, table, readConf = ReadConf.fromSparkConf(sc.getConf), empty = true)
+    new EmptyCassandraRDD[T](sc, keyspace, table, readConf = ReadConf.fromSparkConf(sc.getConf))
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/package.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/package.scala
@@ -4,14 +4,13 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
 import scala.language.implicitConversions
-import scala.reflect.ClassTag
 
 /**
  * The root package of Cassandra connector for Apache Spark.
  * Offers handy implicit conversions that add Cassandra-specific methods to `SparkContext` and `RDD`.
  *
  * Call [[com.datastax.spark.connector.SparkContextFunctions#cassandraTable cassandraTable]] method on the `SparkContext` object
- * to create a [[com.datastax.spark.connector.rdd.CassandraRDD CassandraRDD]] exposing Cassandra tables as Spark RDDs.
+ * to create a [[com.datastax.spark.connector.rdd.CassandraTableScanRDD CassandraRDD]] exposing Cassandra tables as Spark RDDs.
  *
  * Call [[com.datastax.spark.connector.RDDFunctions]] `saveToCassandra`
  * function on any `RDD` to save distributed collection to a Cassandra table.

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
@@ -1,0 +1,180 @@
+package com.datastax.spark.connector.rdd
+
+import com.datastax.driver.core.Session
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.cql._
+import com.datastax.spark.connector.metrics.InputMetricsUpdater
+import com.datastax.spark.connector.rdd.reader._
+import com.datastax.spark.connector.util.CqlWhereParser.{EqPredicate, InListPredicate, InPredicate, RangePredicate}
+import com.datastax.spark.connector.util.{CountingIterator, CqlWhereParser}
+import com.datastax.spark.connector.writer._
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{Partition, TaskContext}
+
+import scala.reflect.ClassTag
+
+/**
+ * An RDD that will do a selecting join between `prev:RDD` and the specified Cassandra Table
+ * This will perform individual selects to retrieve the rows from Cassandra and will take
+ * advantage of RDD's that have been partitioned with the [[com.datastax.spark.connector.rdd.partitioner.ReplicaPartitioner]]
+ */
+class CassandraJoinRDD[Left, Right] private[connector](prev: RDD[Left],
+                                                val keyspaceName: String,
+                                                val tableName: String,
+                                                val connector: CassandraConnector,
+                                                val columnNames: ColumnSelector = AllColumns,
+                                                val joinColumns: ColumnSelector = PartitionKeyColumns,
+                                                val where: CqlWhereClause = CqlWhereClause.empty,
+                                                val limit: Option[Long] = None,
+                                                val clusteringOrder: Option[ClusteringOrder] = None,
+                                                val readConf: ReadConf = ReadConf())
+                                                      (implicit oldTag: ClassTag[Left], val rct: ClassTag[Right],
+                                                       @transient val rwf: RowWriterFactory[Left], @transient val rtf: RowReaderFactory[Right])
+  extends CassandraRDD[(Left, Right)](prev.sparkContext, prev.dependencies) with CassandraTableRowReaderProvider[Right] {
+
+  //Make sure copy operations make new CJRDDs and not CRDDs
+  override protected def copy(columnNames: ColumnSelector = columnNames,
+                              where: CqlWhereClause = where,
+                              limit: Option[Long] = limit,
+                              clusteringOrder: Option[ClusteringOrder] = None,
+                              readConf: ReadConf = readConf,
+                              connector: CassandraConnector = connector) =
+    new CassandraJoinRDD[Left, Right](prev, keyspaceName, tableName, connector, columnNames, joinColumns, where, limit, clusteringOrder, readConf).asInstanceOf[this.type]
+
+  lazy val joinColumnNames: Seq[NamedColumnRef] = joinColumns match {
+    case AllColumns => throw new IllegalArgumentException("Unable to join against all columns in a Cassandra Table. Only primary key columns allowed.")
+    case PartitionKeyColumns => tableDef.partitionKey.map(col => col.columnName: NamedColumnRef).toSeq
+    case SomeColumns(cs@_*) => {
+      checkColumnsExistence(cs)
+      cs.map {
+        case c: NamedColumnRef => c
+        case _ => throw new IllegalArgumentException("Unable to join against unnamed columns. No CQL Functions allowed.")
+      }
+    }
+  }
+
+  override def count(): Long = {
+    columnNames match {
+      case SomeColumns(_) => logWarning("You are about to count rows but an explicit projection has been specified.")
+      case _ =>
+    }
+    new CassandraJoinRDD[Left, Long](prev, keyspaceName, tableName, connector, SomeColumns(RowCountRef), joinColumns, where, limit, clusteringOrder, readConf).map(_._2).reduce(_ + _)
+  }
+
+  /**
+   * This method will create the RowWriter required before the RDD is serialized. This is called during getPartitions
+   */
+  protected def checkValidJoin(): Seq[NamedColumnRef] = {
+    val regularColumnNames = tableDef.regularColumns.map(_.columnName).toSet
+    val partitionKeyColumnNames = tableDef.partitionKey.map(_.columnName).toSet
+    val colNames = joinColumnNames.map(_.columnName).toSet
+
+    //Initialize RowWriter and Query to be used for accessing Cassandra
+    rowWriter.columnNames
+    singleKeyCqlQuery.size
+
+    def checkSingleColumn(column: NamedColumnRef): Unit = {
+      if (regularColumnNames.contains(column.columnName))
+        throw new IllegalArgumentException(s"Can't pushdown join on column $column because it is not part of the PRIMARY KEY")
+    }
+
+    //Make sure we have all of the clustering indexes between the 0th position and the max requested in the join
+    val chosenClusteringColumns = tableDef.clusteringColumns
+      .filter(cc => colNames.contains(cc.columnName))
+    if (!tableDef.clusteringColumns.startsWith(chosenClusteringColumns)) {
+      val maxCol = chosenClusteringColumns.last
+      val maxIndex = maxCol.componentIndex.get
+      val requiredColumns = tableDef.clusteringColumns.takeWhile(_.componentIndex.get <= maxIndex)
+      val missingColumns = requiredColumns.toSet -- chosenClusteringColumns.toSet
+      if (!missingColumns.isEmpty)
+        throw new IllegalArgumentException(s"Can't pushdown join on column $maxCol without also specifying [ $missingColumns ]")
+      }
+    val missingPartitionKeys = partitionKeyColumnNames -- colNames
+    if (missingPartitionKeys.size != 0) {
+      throw new IllegalArgumentException(s"Can't join without the full partition key. Missing: [ ${missingPartitionKeys} ]")
+    }
+    joinColumnNames.foreach { case c: NamedColumnRef => checkSingleColumn(c)}
+    joinColumnNames
+  }
+
+  lazy val rowWriter = implicitly[RowWriterFactory[Left]].rowWriter(
+    tableDef,
+    joinColumnNames.map {
+      _.columnName
+    },
+    joinColumns.aliases
+  )
+
+  def on(joinColumns: ColumnSelector): CassandraJoinRDD[Left, Right] = {
+    new CassandraJoinRDD[Left, Right](prev, keyspaceName, tableName, connector, columnNames, joinColumns, where, limit, clusteringOrder, readConf).asInstanceOf[this.type]
+  }
+
+  //We need to make sure we get selectedColumnRefs before serialization so that our RowReader is
+  //built
+  lazy val singleKeyCqlQuery: (String) = {
+    val whereClauses = where.predicates.flatMap(CqlWhereParser.parse)
+    val partitionKeys = tableDef.partitionKey.map(_.columnName)
+    val partitionKeyPredicates = whereClauses.collect {
+      case EqPredicate(c, _) if partitionKeys.contains(c) => c
+      case InPredicate(c) if partitionKeys.contains(c) => c
+      case InListPredicate(c, _) if partitionKeys.contains(c) => c
+      case RangePredicate(c, _, _) if partitionKeys.contains(c) => c
+    }.toSet
+    require(partitionKeyPredicates.isEmpty, s"No partition keys allowed in where on joins with Cassandra. Found : $partitionKeyPredicates")
+
+    logDebug("Generating Single Key Query Prepared Statement String")
+    logDebug(s"SelectedColumns : $selectedColumnRefs -- JoinColumnNames : $joinColumnNames")
+    val columns = selectedColumnRefs.map(_.cql).mkString(", ")
+    val joinWhere = joinColumnNames.map(_.columnName).map(name => s"${quote(name)} = :$name")
+    val limitClause = limit.map(limit => s"LIMIT $limit").getOrElse("")
+    val orderBy = clusteringOrder.map(_.toCql(tableDef)).getOrElse("")
+    val filter = (where.predicates ++ joinWhere).mkString(" AND ")
+    val quotedKeyspaceName = quote(keyspaceName)
+    val quotedTableName = quote(tableName)
+    val query = s"SELECT $columns FROM $quotedKeyspaceName.$quotedTableName WHERE $filter $limitClause $orderBy"
+    logDebug(s"Query : $query")
+    query
+  }
+
+  /**
+   * When computing a CassandraPartitionKeyRDD the data is selected via single CQL statements
+   * from the specified C* Keyspace and Table. This will be preformed on whatever data is
+   * avaliable in the previous RDD in the chain.
+   */
+  override def compute(split: Partition, context: TaskContext): Iterator[(Left, Right)] = {
+    val session = connector.openSession()
+    implicit val pv = protocolVersion(session)
+    val stmt = session.prepare(singleKeyCqlQuery).setConsistencyLevel(consistencyLevel)
+    val bsb = new BoundStatementBuilder[Left](rowWriter, stmt, pv)
+    val metricsUpdater = InputMetricsUpdater(context, 20)
+    val rowIterator = fetchIterator(session, bsb, prev.iterator(split, context))
+    val countingIterator = new CountingIterator(rowIterator, limit)
+    context.addTaskCompletionListener { (context) =>
+      val duration = metricsUpdater.finish() / 1000000000d
+      logDebug(f"Fetched ${countingIterator.count} rows from $keyspaceName.$tableName for partition ${split.index} in $duration%.3f s.")
+      session.close()
+    }
+    countingIterator
+  }
+
+  private def fetchIterator(session: Session, bsb: BoundStatementBuilder[Left], lastIt: Iterator[Left]): Iterator[(Left, Right)] = {
+    val columnNamesArray = selectedColumnRefs.map(_.selectedFromCassandraAs).toArray
+    implicit val pv = protocolVersion(session)
+    for (leftSide <- lastIt;
+         rightSide <- {
+           val rs = session.execute(bsb.bind(leftSide))
+           val iterator = new PrefetchingResultSetIterator(rs, fetchSize)
+           iterator.map(rowReader.read(_, columnNamesArray))
+         }) yield (leftSide, rightSide)
+  }
+
+  override protected def getPartitions: Array[Partition] = {
+    verify()
+    checkValidJoin()
+    prev.partitions
+  }
+
+  override def getPreferredLocations(split: Partition): Seq[String] = prev.preferredLocations(split)
+
+  override def toEmptyCassandraRDD(): EmptyCassandraRDD[(Left, Right)] = new EmptyCassandraRDD[(Left, Right)](prev.sparkContext, keyspaceName, tableName, columnNames, where, limit, clusteringOrder, readConf)
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
@@ -1,148 +1,61 @@
 package com.datastax.spark.connector.rdd
 
-import java.io.IOException
-
-import com.datastax.spark.connector.rdd.ClusteringOrder.{Descending, Ascending}
-
-import scala.reflect.ClassTag
-import scala.collection.JavaConversions._
-import scala.language.existentials
-
-import com.datastax.spark.connector.metrics.InputMetricsUpdater
-import org.apache.spark.rdd.RDD
-import org.apache.spark.{Logging, Partition, SparkContext, TaskContext}
-
-import com.datastax.driver.core._
-import com.datastax.spark.connector.{SomeColumns, AllColumns, ColumnSelector}
 import com.datastax.spark.connector.cql._
-import com.datastax.spark.connector.rdd.partitioner.{CassandraRDDPartitioner, CassandraPartition, CqlTokenRange}
-import com.datastax.spark.connector.rdd.partitioner.dht.TokenFactory
+import com.datastax.spark.connector.rdd.ClusteringOrder.{Ascending, Descending}
 import com.datastax.spark.connector.rdd.reader._
-import com.datastax.spark.connector.types.{ColumnType, TypeConverter}
-import com.datastax.spark.connector.util.CountingIterator
-import com.datastax.spark.connector._
+import com.datastax.spark.connector.types.TypeConverter
+import com.datastax.spark.connector.{ColumnSelector, NamedColumnRef, SomeColumns, _}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{Dependency, SparkContext}
 
+import scala.language.existentials
+import scala.reflect.ClassTag
 
-/** RDD representing a Cassandra table.
-  * This class is the main entry point for analyzing data in Cassandra database with Spark.
-  * Obtain objects of this class by calling [[com.datastax.spark.connector.SparkContextFunctions#cassandraTable cassandraTable]].
-  *
-  * Configuration properties should be passed in the `SparkConf` configuration of `SparkContext`.
-  * `CassandraRDD` needs to open connection to Cassandra, therefore it requires appropriate connection property values
-  * to be present in `SparkConf`. For the list of required and available properties, see
-  * [[com.datastax.spark.connector.cql.CassandraConnector CassandraConnector]].
-  *
-  * `CassandraRDD` divides the dataset into smaller partitions, processed locally on every cluster node.
-  * A data partition consists of one or more contiguous token ranges.
-  * To reduce the number of roundtrips to Cassandra, every partition is fetched in batches. The following
-  * properties control the number of partitions and the fetch size:
-  *
-  *   - spark.cassandra.input.split.size:        approx number of Cassandra partitions in a Spark partition, default 100000
-  *   - spark.cassandra.input.page.row.size:     number of CQL rows fetched per roundtrip, default 1000
-  *
-  * A `CassandraRDD` object gets serialized and sent to every Spark executor.
-  *
-  * By default, reads are performed at ConsistencyLevel.LOCAL_ONE in order to leverage data-locality and minimize network traffic.
-  * This read consistency level is controlled by the following property:
-  *
-  *   - spark.cassandra.input.consistency.level: consistency level for RDD reads, string matching the ConsistencyLevel enum name.
-  *
-  * If a Cassandra node fails or gets overloaded during read, queries are retried to a different node.
-  */
-class CassandraRDD[R] private[connector] (
-    @transient val sc: SparkContext,
-    val connector: CassandraConnector,
-    val keyspaceName: String,
-    val tableName: String,
-    val columnNames: ColumnSelector = AllColumns,
-    val where: CqlWhereClause = CqlWhereClause.empty,
-    val empty: Boolean = false,
-    val limit: Option[Long] = None,
-    val clusteringOrder: Option[ClusteringOrder] = None,
-    val readConf: ReadConf = ReadConf())(
-  implicit
-    ct : ClassTag[R], @transient val rtf: RowReaderFactory[R])
-  extends RDD[R](sc, Seq.empty) with Logging {
+abstract class CassandraRDD[R](_sc: SparkContext, dep: Seq[Dependency[_]])(implicit ct: ClassTag[R]) extends RDD[R](_sc, dep) {
+
+  protected def keyspaceName: String
+
+  protected def tableName: String
+
+  protected def columnNames: ColumnSelector
+
+  protected def where: CqlWhereClause
+
+  protected def readConf: ReadConf
+
+  protected def limit: Option[Long]
 
   require(limit.isEmpty || limit.get > 0, "Limit must be greater than 0")
 
-  private def fetchSize = readConf.fetchSize
-  private def splitSize = readConf.splitSize
-  private def consistencyLevel = readConf.consistencyLevel
+  protected def clusteringOrder: Option[ClusteringOrder]
 
-  private def copy(columnNames: ColumnSelector = columnNames,
-                   clusteringOrder: Option[ClusteringOrder] = clusteringOrder,
-                   where: CqlWhereClause = where,
-                   empty: Boolean = empty,
-                   limit: Option[Long] = limit,
-                   readConf: ReadConf = readConf,
-                   connector: CassandraConnector = connector): CassandraRDD[R] = {
-    require(sc != null,
-      "RDD transformation requires a non-null SparkContext. Unfortunately SparkContext in this CassandraRDD is null. " +
-      "This can happen after CassandraRDD has been deserialized. SparkContext is not Serializable, therefore it deserializes to null." +
-      "RDD transformations are not allowed inside lambdas used in other RDD transformations.")
-    new CassandraRDD(sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
-  }
+  protected def connector: CassandraConnector
 
-  /** Returns a copy of this Cassandra RDD with specified connector */
-  def withConnector(connector: CassandraConnector): CassandraRDD[R] =
-    copy(connector = connector)
-
-  /** Adds a CQL `WHERE` predicate(s) to the query.
-    * Useful for leveraging secondary indexes in Cassandra.
-    * Implicitly adds an `ALLOW FILTERING` clause to the WHERE clause, however beware that some predicates
-    * might be rejected by Cassandra, particularly in cases when they filter on an unindexed, non-clustering column.*/
-  def where(cql: String, values: Any*): CassandraRDD[R] = {
-    copy(where = where and CqlWhereClause(Seq(cql), values))
-  }
-
-  /** Adds a CQL `ORDER BY` clause to the query.
-    * It can be applied only in case there are clustering columns and primary key predicate is
-    * pushed down in `where`.
-    * It is useful when the default direction of ordering rows within a single Cassandra partition
-    * needs to be changed. */
-  def clusteringOrder(order: ClusteringOrder): CassandraRDD[R] = {
-    copy(clusteringOrder = Some(order))
-  }
-
-  def withAscOrder: CassandraRDD[R] = clusteringOrder(Ascending)
-  def withDescOrder: CassandraRDD[R] = clusteringOrder(Descending)
+  def toEmptyCassandraRDD(): EmptyCassandraRDD[R]
 
   /** Allows to set custom read configuration, e.g. consistency level or fetch size. */
   def withReadConf(readConf: ReadConf) = {
     copy(readConf = readConf)
   }
 
-  /** Produces the empty CassandraRDD which has the same signature and properties, but it does not
-    * perform any validation and it does not even try to return any rows. */
-  def toEmptyCassandraRDD = {
-    copy(empty = true)
+  protected def copy(columnNames: ColumnSelector = columnNames,
+                     where: CqlWhereClause = where,
+                     limit: Option[Long] = limit,
+                     clusteringOrder: Option[ClusteringOrder] = None,
+                     readConf: ReadConf = readConf,
+                     connector: CassandraConnector = connector): CassandraRDD[R]
+
+  /** Returns a copy of this Cassandra RDD with specified connector */
+  def withConnector(connector: CassandraConnector): CassandraRDD[R] = {
+    copy(connector = connector)
   }
 
-  /** Throws IllegalArgumentException if columns sequence contains unavailable columns */
-  private def checkColumnsAvailable(columns: Seq[SelectableColumnRef], availableColumns: Seq[SelectableColumnRef]) {
-    val availableColumnsSet = availableColumns.toSet
-
-    val notFound = columns.find {
-      case column => !availableColumnsSet.contains(column)
-    }
-
-    if (notFound.isDefined)
-      throw new IllegalArgumentException(
-        s"Column not found in selection: ${notFound.get}. " +
-          s"Available columns: [${availableColumns.mkString(",")}].")
-  }
-
-  /** Filters currently selected set of columns with a new set of columns */
-  private def narrowColumnSelection(columns: Seq[SelectableColumnRef]): Seq[SelectableColumnRef] = {
-    columnNames match {
-      case SomeColumns(cs @ _*) =>
-        checkColumnsAvailable(columns, cs)
-      case AllColumns =>
-        // we do not check for column existence yet as it would require fetching schema and a call to C*
-        // columns existence will be checked by C* once the RDD gets computed.
-    }
-    columns
+  /** Adds a CQL `WHERE` predicate(s) to the query.
+    * Useful for leveraging secondary indexes in Cassandra.
+    * Implicitly adds an `ALLOW FILTERING` clause to the WHERE clause, however beware that some predicates
+    * might be rejected by Cassandra, particularly in cases when they filter on an unindexed, non-clustering column. */
+  def where(cql: String, values: Any*): CassandraRDD[R] = {
+    copy(where = where and CqlWhereClause(Seq(cql), values))
   }
 
   /** Narrows down the selected set of columns.
@@ -161,14 +74,6 @@ class CassandraRDD[R] private[connector] (
     copy(columnNames = SomeColumns(narrowColumnSelection(columns): _*))
   }
 
-  override def count(): Long = {
-    columnNames match {
-      case SomeColumns(_) => logWarning("You are about to count rows but an explicit projection has been specified.")
-      case _ =>
-    }
-    new CassandraRDD[Long](sc, connector, keyspaceName, tableName, SomeColumns(RowCountRef), where, empty, limit, clusteringOrder, readConf).reduce(_ + _)
-  }
-
   /** Adds the limit clause to CQL select statement. The limit will be applied for each created
     * Spark partition. In other words, unless the data are fetched from a single Cassandra partition
     * the number of results is unpredictable.
@@ -180,6 +85,35 @@ class CassandraRDD[R] private[connector] (
     copy(limit = Some(rowLimit))
   }
 
+  /** Adds a CQL `ORDER BY` clause to the query.
+    * It can be applied only in case there are clustering columns and primary key predicate is
+    * pushed down in `where`.
+    * It is useful when the default direction of ordering rows within a single Cassandra partition
+    * needs to be changed. */
+  def clusteringOrder(order: ClusteringOrder): CassandraRDD[R] = {
+    copy(clusteringOrder = Some(order))
+  }
+
+  def withAscOrder: CassandraRDD[R] = clusteringOrder(Ascending)
+
+  def withDescOrder: CassandraRDD[R] = clusteringOrder(Descending)
+
+  override def take(num: Int): Array[R] = {
+    limit match {
+      case Some(_) => super.take(num)
+      case None => limit(num).take(num)
+    }
+  }
+
+  protected def narrowColumnSelection(columns: Seq[SelectableColumnRef]): Seq[SelectableColumnRef]
+
+  // Needed to be public for JavaAPI
+  val selectedColumnRefs: Seq[SelectableColumnRef]
+
+  //convertTo must be implmented for classes which wish to support `.as`
+  protected def convertTo[B](implicit ct: ClassTag[B], rrf: RowReaderFactory[B]): CassandraRDD[B] =
+    throw new NotImplementedError(s"convertTo not implemented for this class")
+
   /** Maps each row into object of a different type using provided function taking column value(s) as argument(s).
     * Can be used to convert each row to a tuple or a case class object:
     * {{{
@@ -188,292 +122,81 @@ class CassandraRDD[R] private[connector] (
     *
     * case class MyRow(key: String, value: Long)
     * sc.cassandraTable("ks", "table").select("column1", "column2").as(MyRow)                 // yields CassandraRDD[MyRow]
-    * }}}*/
-  def as[B : ClassTag, A0 : TypeConverter](f: A0 => B): CassandraRDD[B] = {
+    * }}} */
+  def as[B: ClassTag, A0: TypeConverter](f: A0 => B): CassandraRDD[B] = {
     implicit val ft = new FunctionBasedRowReader1(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
+    convertTo[B]
   }
 
-  def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter](f: (A0, A1) => B) = {
+  def as[B: ClassTag, A0: TypeConverter, A1: TypeConverter](f: (A0, A1) => B) = {
     implicit val ft = new FunctionBasedRowReader2(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
+    convertTo[B]
   }
 
-  def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter](f: (A0, A1, A2) => B) = {
+  def as[B: ClassTag, A0: TypeConverter, A1: TypeConverter, A2: TypeConverter](f: (A0, A1, A2) => B) = {
     implicit val ft = new FunctionBasedRowReader3(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
+    convertTo[B]
   }
 
-  def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter,
-  A3 : TypeConverter](f: (A0, A1, A2, A3) => B) = {
+  def as[B: ClassTag, A0: TypeConverter, A1: TypeConverter, A2: TypeConverter,
+  A3: TypeConverter](f: (A0, A1, A2, A3) => B) = {
     implicit val ft = new FunctionBasedRowReader4(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
+    convertTo[B]
   }
 
-  def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
-  A4 : TypeConverter](f: (A0, A1, A2, A3, A4) => B) = {
+  def as[B: ClassTag, A0: TypeConverter, A1: TypeConverter, A2: TypeConverter, A3: TypeConverter,
+  A4: TypeConverter](f: (A0, A1, A2, A3, A4) => B) = {
     implicit val ft = new FunctionBasedRowReader5(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
+    convertTo[B]
   }
 
-  def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
-  A4 : TypeConverter, A5 : TypeConverter](f: (A0, A1, A2, A3, A4, A5) => B) = {
+  def as[B: ClassTag, A0: TypeConverter, A1: TypeConverter, A2: TypeConverter, A3: TypeConverter,
+  A4: TypeConverter, A5: TypeConverter](f: (A0, A1, A2, A3, A4, A5) => B) = {
     implicit val ft = new FunctionBasedRowReader6(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
+    convertTo[B]
   }
 
-  def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
-  A4 : TypeConverter, A5 : TypeConverter, A6 : TypeConverter](f: (A0, A1, A2, A3, A4, A5, A6) => B) = {
+  def as[B: ClassTag, A0: TypeConverter, A1: TypeConverter, A2: TypeConverter, A3: TypeConverter,
+  A4: TypeConverter, A5: TypeConverter, A6: TypeConverter](f: (A0, A1, A2, A3, A4, A5, A6) => B) = {
     implicit val ft = new FunctionBasedRowReader7(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
+    convertTo[B]
   }
 
-  def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
-  A4 : TypeConverter, A5 : TypeConverter, A6 : TypeConverter,
-  A7 : TypeConverter](f: (A0, A1, A2, A3, A4, A5, A6, A7) => B) = {
+  def as[B: ClassTag, A0: TypeConverter, A1: TypeConverter, A2: TypeConverter, A3: TypeConverter,
+  A4: TypeConverter, A5: TypeConverter, A6: TypeConverter,
+  A7: TypeConverter](f: (A0, A1, A2, A3, A4, A5, A6, A7) => B) = {
     implicit val ft = new FunctionBasedRowReader8(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
+    convertTo[B]
   }
 
-  def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
-  A4 : TypeConverter, A5 : TypeConverter, A6 : TypeConverter, A7: TypeConverter,
-  A8 : TypeConverter](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) => B) = {
+  def as[B: ClassTag, A0: TypeConverter, A1: TypeConverter, A2: TypeConverter, A3: TypeConverter,
+  A4: TypeConverter, A5: TypeConverter, A6: TypeConverter, A7: TypeConverter,
+  A8: TypeConverter](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) => B) = {
     implicit val ft = new FunctionBasedRowReader9(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
+    convertTo[B]
   }
 
-  def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
-  A4 : TypeConverter, A5 : TypeConverter, A6 : TypeConverter, A7: TypeConverter,
-  A8 : TypeConverter, A9 : TypeConverter](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => B) = {
+  def as[B: ClassTag, A0: TypeConverter, A1: TypeConverter, A2: TypeConverter, A3: TypeConverter,
+  A4: TypeConverter, A5: TypeConverter, A6: TypeConverter, A7: TypeConverter,
+  A8: TypeConverter, A9: TypeConverter](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => B) = {
     implicit val ft = new FunctionBasedRowReader10(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
+    convertTo[B]
   }
 
-  def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
-  A4 : TypeConverter, A5 : TypeConverter, A6 : TypeConverter, A7: TypeConverter, A8: TypeConverter,
-  A9 : TypeConverter, A10 : TypeConverter](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => B) = {
+  def as[B: ClassTag, A0: TypeConverter, A1: TypeConverter, A2: TypeConverter, A3: TypeConverter,
+  A4: TypeConverter, A5: TypeConverter, A6: TypeConverter, A7: TypeConverter, A8: TypeConverter,
+  A9: TypeConverter, A10: TypeConverter](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => B) = {
     implicit val ft = new FunctionBasedRowReader11(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
+    convertTo[B]
   }
 
-  def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
-  A4 : TypeConverter, A5 : TypeConverter, A6 : TypeConverter, A7: TypeConverter, A8: TypeConverter,
-  A9 : TypeConverter, A10: TypeConverter, A11 : TypeConverter](
-  f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => B) = {
+  def as[B: ClassTag, A0: TypeConverter, A1: TypeConverter, A2: TypeConverter, A3: TypeConverter,
+  A4: TypeConverter, A5: TypeConverter, A6: TypeConverter, A7: TypeConverter, A8: TypeConverter,
+  A9: TypeConverter, A10: TypeConverter, A11: TypeConverter](
+                                                              f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => B) = {
     implicit val ft = new FunctionBasedRowReader12(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
-  }
-
-  // ===================================================================
-  // no references to sc allowed below this line
-  // ===================================================================
-
-  // Lazy fields allow to recover non-serializable objects after deserialization of RDD
-  // Cassandra connection is not serializable, but will be recreated on-demand basing on serialized host and port.
-
-  // Table metadata should be fetched only once to guarantee all tasks use the same metadata.
-  // TableDef is serializable, so there is no problem:
-  lazy val tableDef = {
-    Schema.fromCassandra(connector, Some(keyspaceName), Some(tableName)).tables.headOption match {
-      case Some(t) => t
-      case None => throw new IOException(s"Table not found: $keyspaceName.$tableName")
-    }
-  }
-
-  private lazy val aliasToColumnName = columnNames.aliases
-
-  private lazy val rowTransformer = implicitly[RowReaderFactory[R]]
-    .rowReader(tableDef, RowReaderOptions(aliasToColumnName = aliasToColumnName))
-
-  private def checkColumnsExistence(columns: Seq[SelectableColumnRef]): Seq[SelectableColumnRef] = {
-    val allColumnNames = tableDef.allColumns.map(_.columnName).toSet
-    val regularColumnNames = tableDef.regularColumns.map(_.columnName).toSet
-
-    def checkSingleColumn(column: NamedColumnRef) = {
-      if (!allColumnNames.contains(column.columnName))
-        throw new IOException(s"Column $column not found in table $keyspaceName.$tableName")
-
-      column match {
-        case ColumnName(_, _) =>
-
-        case TTL(columnName, _) =>
-          if (!regularColumnNames.contains(columnName))
-            throw new IOException(s"TTL can be obtained only for regular columns, " +
-              s"but column $columnName is not a regular column in table $keyspaceName.$tableName.")
-
-        case WriteTime(columnName, _) =>
-          if (!regularColumnNames.contains(columnName))
-            throw new IOException(s"TTL can be obtained only for regular columns, " +
-              s"but column $columnName is not a regular column in table $keyspaceName.$tableName.")
-      }
-
-      column
-    }
-
-    columns.map {
-      case namedColumnRef: NamedColumnRef => checkSingleColumn(namedColumnRef)
-      case columnRef => columnRef
-    }
-  }
-
-
-  /** Returns the names of columns to be selected from the table.*/
-  lazy val selectedColumnRefs: Seq[SelectableColumnRef] = {
-    val providedColumnRefs =
-      columnNames match {
-        case AllColumns => tableDef.allColumns.map(col => col.columnName: NamedColumnRef).toSeq
-        case SomeColumns(cs @ _*) => checkColumnsExistence(cs)
-      }
-
-    (rowTransformer.columnNames, rowTransformer.requiredColumns) match {
-      case (Some(cs), None) => providedColumnRefs.filter(columnName => cs.toSet(columnName.selectedFromCassandraAs))
-      case (_, _) => providedColumnRefs
-    }
-  }
-
-
-  /** Checks for existence of keyspace, table, columns and whether the number of selected columns corresponds to
-    * the number of the columns expected by the target type constructor.
-    * If successful, does nothing, otherwise throws appropriate `IOException` or `AssertionError`.*/
-  lazy val verify = {
-    val targetType = implicitly[ClassTag[R]]
-
-    tableDef.allColumns  // will throw IOException if table does not exist
-
-    rowTransformer.columnNames match {
-      case Some(names) =>
-        val missingColumns = names.toSet -- selectedColumnRefs.map(_.selectedFromCassandraAs).toSet
-        assert(missingColumns.isEmpty, s"Missing columns needed by $targetType: ${missingColumns.mkString(", ")}")
-      case None =>
-    }
-
-    rowTransformer.requiredColumns match {
-      case Some(count) =>
-        assert(selectedColumnRefs.size >= count,
-        s"Not enough columns selected for the target row type $targetType: ${selectedColumnRefs.size} < $count")
-      case None =>
-    }
-  }
-
-  private lazy val cassandraPartitionerClassName =
-    connector.withSessionDo {
-      session =>
-        session.execute("SELECT partitioner FROM system.local").one().getString(0)
-    }
-
-  private def quote(name: String) = "\"" + name + "\""
-
-  override def getPartitions: Array[Partition] = {
-    if (empty) {
-      Array.empty
-    } else {
-      verify // let's fail fast
-      val tf = TokenFactory.forCassandraPartitioner(cassandraPartitionerClassName)
-      val partitions = new CassandraRDDPartitioner(connector, tableDef, splitSize)(tf).partitions(where)
-      logDebug(s"Created total ${partitions.size} partitions for $keyspaceName.$tableName.")
-      logTrace("Partitions: \n" + partitions.mkString("\n"))
-      partitions
-    }
-  }
-
-  override def getPreferredLocations(split: Partition) =
-    split.asInstanceOf[CassandraPartition]
-      .endpoints.map(_.getHostName).toSeq
-
-  private def tokenRangeToCqlQuery(range: CqlTokenRange): (String, Seq[Any]) = {
-    val columns = selectedColumnRefs.map(_.cql).mkString(", ")
-    val filter = (range.cql +: where.predicates ).filter(_.nonEmpty).mkString(" AND ")
-    val limitClause = limit.map(limit => s"LIMIT $limit").getOrElse("")
-    val orderBy = clusteringOrder.map(_.toCql(tableDef)).getOrElse("")
-    val quotedKeyspaceName = quote(keyspaceName)
-    val quotedTableName = quote(tableName)
-    (s"SELECT $columns FROM $quotedKeyspaceName.$quotedTableName WHERE $filter $orderBy $limitClause ALLOW FILTERING", range.values ++ where.values)
-  }
-
-  def protocolVersion(session: Session): ProtocolVersion = {
-    session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersionEnum
-  }
-
-  private def createStatement(session: Session, cql: String, values: Any*): Statement = {
-    try {
-      implicit val pv = protocolVersion(session)
-      val stmt = session.prepare(cql)
-      stmt.setConsistencyLevel(consistencyLevel)
-      val converters = stmt.getVariables
-        .map(v => ColumnType.converterToCassandra(v.getType))
-        .toArray
-      val convertedValues =
-        for ((value, converter) <- values zip converters)
-        yield converter.convert(value)
-      val bstm = stmt.bind(convertedValues: _*)
-      bstm.setFetchSize(fetchSize)
-      bstm
-    }
-    catch {
-      case t: Throwable =>
-        throw new IOException(s"Exception during preparation of $cql: ${t.getMessage}", t)
-    }
-  }
-
-  private def fetchTokenRange(session: Session, range: CqlTokenRange, inputMetricsUpdater: InputMetricsUpdater): Iterator[R] = {
-    val (cql, values) = tokenRangeToCqlQuery(range)
-    logDebug(s"Fetching data for range ${range.cql} with $cql with params ${values.mkString("[", ",", "]")}")
-    val stmt = createStatement(session, cql, values: _*)
-    val columnNamesArray = selectedColumnRefs.map(_.selectedFromCassandraAs).toArray
-
-    try {
-      implicit val pv = protocolVersion(session)
-      val tc = inputMetricsUpdater.resultSetFetchTimer.map(_.time())
-      val rs = session.execute(stmt)
-      tc.map(_.stop())
-      val iterator = new PrefetchingResultSetIterator(rs, fetchSize)
-      val iteratorWithMetrics = iterator.map(inputMetricsUpdater.updateMetrics)
-      val result = iteratorWithMetrics.map(rowTransformer.read(_, columnNamesArray))
-      logDebug(s"Row iterator for range ${range.cql} obtained successfully.")
-      result
-    } catch {
-      case t: Throwable =>
-        throw new IOException(s"Exception during execution of $cql: ${t.getMessage}", t)
-    }
-  }
-
-  override def compute(split: Partition, context: TaskContext): Iterator[R] = {
-    val session = connector.openSession()
-    val partition = split.asInstanceOf[CassandraPartition]
-    val tokenRanges = partition.tokenRanges
-    val metricsUpdater = InputMetricsUpdater(context, 20)
-
-    // Iterator flatMap trick flattens the iterator-of-iterator structure into a single iterator.
-    // flatMap on iterator is lazy, therefore a query for the next token range is executed not earlier
-    // than all of the rows returned by the previous query have been consumed
-    val rowIterator = tokenRanges.iterator.flatMap(
-      fetchTokenRange(session, _, metricsUpdater))
-    val countingIterator = new CountingIterator(rowIterator)
-
-    context.addTaskCompletionListener { (context) =>
-      val duration = metricsUpdater.finish() / 1000000000d
-      logDebug(f"Fetched ${countingIterator.count} rows from $keyspaceName.$tableName for partition ${partition.index} in $duration%.3f s.")
-      session.close()
-    }
-    countingIterator
-  }
-
-  override def take(num: Int): Array[R] = {
-    limit match {
-      case Some(_) => super.take(num)
-      case None => limit(num).take(num)
-    }
+    convertTo[B]
   }
 }
 
-object CassandraRDD {
-  def apply[T](sc: SparkContext, keyspaceName: String, tableName: String)
-              (implicit ct: ClassTag[T], rrf: RowReaderFactory[T]): CassandraRDD[T] =
-    new CassandraRDD[T](
-      sc, CassandraConnector(sc.getConf), keyspaceName, tableName, AllColumns, CqlWhereClause.empty)
 
-  def apply[K, V](sc: SparkContext, keyspaceName: String, tableName: String)
-                 (implicit keyCT: ClassTag[K], valueCT: ClassTag[V], rrf: RowReaderFactory[(K, V)]): CassandraRDD[(K, V)] =
-    new CassandraRDD[(K, V)](
-      sc, CassandraConnector(sc.getConf), keyspaceName, tableName, AllColumns, CqlWhereClause.empty)
-}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableRowReaderProvider.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableRowReaderProvider.scala
@@ -1,0 +1,165 @@
+package com.datastax.spark.connector.rdd
+
+import java.io.IOException
+
+import com.datastax.driver.core.{ProtocolVersion, Session}
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.cql.{CassandraConnector, Schema}
+import com.datastax.spark.connector.rdd.reader._
+
+import scala.reflect.ClassTag
+
+/**
+ * Used to get a RowReader of type [R] for transforming the rows of a particular Cassandra table into
+ * scala objects. Performs necessary checking of the schema and output class to make sure they are
+ * compatible.
+ * @see [[CassandraTableScanRDD]]
+ * @see [[CassandraJoinRDD]]
+ */
+trait CassandraTableRowReaderProvider[R] {
+
+  protected def connector: CassandraConnector
+
+  protected def keyspaceName: String
+
+  protected def tableName: String
+
+  protected def readConf: ReadConf
+
+  protected def columnNames: ColumnSelector
+
+  protected def fetchSize = readConf.fetchSize
+
+  protected def splitSize = readConf.splitSize
+
+  protected def consistencyLevel = readConf.consistencyLevel
+
+  /**
+   * rtf:RowReaderFactory and rct should be included as implict parameters in the constructor
+   * of the class implementing this trait see [[CassandraTableScanRDD]]
+   */
+  protected val rtf: RowReaderFactory[R]
+  protected val rct: ClassTag[R]
+  protected lazy val rowReader: RowReader[R] = rtf.rowReader(tableDef, RowReaderOptions(aliasToColumnName = aliasToColumnName))
+
+  private lazy val aliasToColumnName = columnNames.aliases
+
+  lazy val tableDef = {
+    Schema.fromCassandra(connector, Some(keyspaceName), Some(tableName)).tables.headOption match {
+      case Some(t) => t
+      case None => throw new IOException(s"Table not found: $keyspaceName.$tableName")
+    }
+  }
+
+  protected def checkColumnsExistence(columns: Seq[SelectableColumnRef]): Seq[SelectableColumnRef] = {
+    val allColumnNames = tableDef.allColumns.map(_.columnName).toSet
+    val regularColumnNames = tableDef.regularColumns.map(_.columnName).toSet
+
+    def checkSingleColumn(column: NamedColumnRef) = {
+      if (!allColumnNames.contains(column.columnName))
+        throw new IOException(s"Column $column not found in table $keyspaceName.$tableName")
+
+      column match {
+        case ColumnName(_, _) =>
+
+        case TTL(columnName, _) =>
+          if (!regularColumnNames.contains(columnName))
+            throw new IOException(s"TTL can be obtained only for regular columns, " +
+              s"but column $columnName is not a regular column in table $keyspaceName.$tableName.")
+
+        case WriteTime(columnName, _) =>
+          if (!regularColumnNames.contains(columnName))
+            throw new IOException(s"TTL can be obtained only for regular columns, " +
+              s"but column $columnName is not a regular column in table $keyspaceName.$tableName.")
+      }
+
+      column
+    }
+
+    columns.map {
+      case namedColumnRef: NamedColumnRef => checkSingleColumn(namedColumnRef)
+      case columnRef => columnRef
+    }
+  }
+
+  /** Returns the names of columns to be selected from the table.*/
+  lazy val selectedColumnRefs: Seq[SelectableColumnRef] = {
+    val providedColumnRefs =
+      columnNames match {
+        case AllColumns => tableDef.allColumns.map(col => col.columnName: NamedColumnRef).toSeq
+        case PartitionKeyColumns => tableDef.partitionKey.map(col => col.columnName: NamedColumnRef).toSeq
+        case SomeColumns(cs@_*) => checkColumnsExistence(cs)
+      }
+
+    (rowReader.columnNames, rowReader.requiredColumns) match {
+      case (Some(cs), None) => providedColumnRefs.filter(columnName => cs.toSet(columnName.selectedFromCassandraAs))
+      case (_, _) => providedColumnRefs
+    }
+  }
+
+  /** Filters currently selected set of columns with a new set of columns */
+  def narrowColumnSelection(columns: Seq[SelectableColumnRef]): Seq[SelectableColumnRef] = {
+    columnNames match {
+      case SomeColumns(cs@_*) =>
+        checkColumnsAvailable(columns, cs)
+      case AllColumns =>
+      case PartitionKeyColumns =>
+      // we do not check for column existence yet as it would require fetching schema and a call to C*
+      // columns existence will be checked by C* once the RDD gets computed.
+    }
+    columns
+  }
+
+  /** Throws IllegalArgumentException if columns sequence contains unavailable columns */
+  private def checkColumnsAvailable(columns: Seq[SelectableColumnRef], availableColumns: Seq[SelectableColumnRef]) {
+    val availableColumnsSet = availableColumns.collect {
+      case ColumnName(columnName, _) => columnName
+    }.toSet
+
+    val notFound = columns.collectFirst {
+      case ColumnName(columnName, _) if !availableColumnsSet.contains(columnName) => columnName
+    }
+
+    if (notFound.isDefined)
+      throw new IllegalArgumentException(
+        s"Column not found in selection: ${notFound.get}. " +
+          s"Available columns: [${availableColumns.mkString(",")}].")
+  }
+
+
+  protected lazy val cassandraPartitionerClassName =
+    connector.withSessionDo {
+      session =>
+        session.execute("SELECT partitioner FROM system.local").one().getString(0)
+    }
+
+  protected def quote(name: String) = "\"" + name + "\""
+
+  def protocolVersion(session: Session): ProtocolVersion = {
+    session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersionEnum
+  }
+
+  /** Checks for existence of keyspace, table, columns and whether the number of selected columns corresponds to
+    * the number of the columns expected by the target type constructor.
+    * If successful, does nothing, otherwise throws appropriate `IOException` or `AssertionError`. */
+  def verify() = {
+    val targetType = rct
+
+    tableDef.allColumns // will throw IOException if table does not exist
+
+    rowReader.columnNames match {
+      case Some(names) =>
+        val missingColumns = names.toSet -- selectedColumnRefs.map(_.selectedFromCassandraAs).toSet
+        assert(missingColumns.isEmpty, s"Missing columns needed by $targetType: ${missingColumns.mkString(", ")}")
+      case None =>
+    }
+
+    rowReader.requiredColumns match {
+      case Some(count) =>
+        assert(selectedColumnRefs.size >= count,
+          s"Not enough columns selected for the target row type $targetType: ${selectedColumnRefs.size} < $count")
+      case None =>
+    }
+  }
+
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
@@ -1,0 +1,189 @@
+package com.datastax.spark.connector.rdd
+
+import java.io.IOException
+
+import com.datastax.driver.core._
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.cql._
+import com.datastax.spark.connector.metrics.InputMetricsUpdater
+import com.datastax.spark.connector.rdd.partitioner.dht.TokenFactory
+import com.datastax.spark.connector.rdd.partitioner.{CassandraPartition, CassandraRDDPartitioner, CqlTokenRange}
+import com.datastax.spark.connector.rdd.reader._
+import com.datastax.spark.connector.types.ColumnType
+import com.datastax.spark.connector.util.CountingIterator
+import org.apache.spark.{Partition, SparkContext, TaskContext}
+
+import scala.collection.JavaConversions._
+import scala.language.existentials
+import scala.reflect.ClassTag
+
+
+/** RDD representing a Table Scan of A Cassandra table.
+  * This class is the main entry point for analyzing data in Cassandra database with Spark.
+  * Obtain objects of this class by calling [[com.datastax.spark.connector.SparkContextFunctions#cassandraTablecassandraTable]].
+  *
+  * Configuration properties should be passed in the `SparkConf` configuration of `SparkContext`.
+  * `CassandraRDD` needs to open connection to Cassandra, therefore it requires appropriate connection property values
+  * to be present in `SparkConf`. For the list of required and available properties, see
+  * [[com.datastax.spark.connector.cql.CassandraConnector CassandraConnector]].
+  *
+  * `CassandraRDD` divides the dataset into smaller partitions, processed locally on every cluster node.
+  * A data partition consists of one or more contiguous token ranges.
+  * To reduce the number of roundtrips to Cassandra, every partition is fetched in batches. The following
+  * properties control the number of partitions and the fetch size:
+  *
+  * - spark.cassandra.input.split.size:        approx number of Cassandra partitions in a Spark partition, default 100000
+  * - spark.cassandra.input.page.row.size:     number of CQL rows fetched per roundtrip, default 1000
+  *
+  * A `CassandraRDD` object gets serialized and sent to every Spark executor.
+  *
+  * By default, reads are performed at ConsistencyLevel.LOCAL_ONE in order to leverage data-locality and minimize network traffic.
+  * This read consistency level is controlled by the following property:
+  *
+  * - spark.cassandra.input.consistency.level: consistency level for RDD reads, string matching the ConsistencyLevel enum name.
+  *
+  * If a Cassandra node fails or gets overloaded during read, queries are retried to a different node.
+  */
+class CassandraTableScanRDD[R] private[connector](
+                                                   @transient sc: SparkContext,
+                                                   val connector: CassandraConnector,
+                                                   val keyspaceName: String,
+                                                   val tableName: String,
+                                                   val columnNames: ColumnSelector = AllColumns,
+                                                   val where: CqlWhereClause = CqlWhereClause.empty,
+                                                   val limit: Option[Long] = None,
+                                                   val clusteringOrder: Option[ClusteringOrder] = None,
+                                                   val readConf: ReadConf = ReadConf())
+                                                 (implicit val rct: ClassTag[R],
+                                                  @transient val rtf: RowReaderFactory[R])
+  extends CassandraRDD[R](sc, Seq.empty) with CassandraTableRowReaderProvider[R] {
+
+  override protected def copy(columnNames: ColumnSelector = columnNames,
+                              where: CqlWhereClause = where,
+                              limit: Option[Long] = limit,
+                              clusteringOrder: Option[ClusteringOrder] = None,
+                              readConf: ReadConf = readConf,
+                              connector: CassandraConnector = connector) = {
+    require(sc != null,
+      "RDD transformation requires a non-null SparkContext. Unfortunately SparkContext in this CassandraRDD is null. " +
+        "This can happen after CassandraRDD has been deserialized. SparkContext is not Serializable, therefore it deserializes to null." +
+        "RDD transformations are not allowed inside lambdas used in other RDD transformations.")
+    new CassandraTableScanRDD[R](sc, connector, keyspaceName, tableName, columnNames, where, limit, clusteringOrder, readConf).asInstanceOf[this.type]
+  }
+
+  override protected def convertTo[B](implicit ct: ClassTag[B], rrf: RowReaderFactory[B]): CassandraRDD[B] = {
+    new CassandraTableScanRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, limit, clusteringOrder, readConf)
+  }
+
+
+  override def getPartitions: Array[Partition] = {
+    verify() // let's fail fast
+    val tf = TokenFactory.forCassandraPartitioner(cassandraPartitionerClassName)
+    val partitions = new CassandraRDDPartitioner(connector, tableDef, splitSize)(tf).partitions(where)
+    logDebug(s"Created total ${partitions.size} partitions for $keyspaceName.$tableName.")
+    logTrace("Partitions: \n" + partitions.mkString("\n"))
+    partitions
+  }
+
+  override def getPreferredLocations(split: Partition) =
+    split.asInstanceOf[CassandraPartition]
+      .endpoints.map(_.getHostName).toSeq
+
+  private def tokenRangeToCqlQuery(range: CqlTokenRange): (String, Seq[Any]) = {
+    val columns = selectedColumnRefs.map(_.cql).mkString(", ")
+    val filter = (range.cql +: where.predicates).filter(_.nonEmpty).mkString(" AND ")
+    val limitClause = limit.map(limit => s"LIMIT $limit").getOrElse("")
+    val orderBy = clusteringOrder.map(_.toCql(tableDef)).getOrElse("")
+    val quotedKeyspaceName = quote(keyspaceName)
+    val quotedTableName = quote(tableName)
+    (s"SELECT $columns FROM $quotedKeyspaceName.$quotedTableName WHERE $filter $orderBy $limitClause ALLOW FILTERING", range.values ++ where.values)
+  }
+
+  private def createStatement(session: Session, cql: String, values: Any*): Statement = {
+    try {
+      implicit val pv = protocolVersion(session)
+      val stmt = session.prepare(cql)
+      stmt.setConsistencyLevel(consistencyLevel)
+      val converters = stmt.getVariables
+        .map(v => ColumnType.converterToCassandra(v.getType))
+        .toArray
+      val convertedValues =
+        for ((value, converter) <- values zip converters)
+        yield converter.convert(value)
+      val bstm = stmt.bind(convertedValues: _*)
+      bstm.setFetchSize(fetchSize)
+      bstm
+    }
+    catch {
+      case t: Throwable =>
+        throw new IOException(s"Exception during preparation of $cql: ${t.getMessage}", t)
+    }
+  }
+
+  private def fetchTokenRange(session: Session, range: CqlTokenRange, inputMetricsUpdater: InputMetricsUpdater): Iterator[R] = {
+    val (cql, values) = tokenRangeToCqlQuery(range)
+    logDebug(s"Fetching data for range ${range.cql} with $cql with params ${values.mkString("[", ",", "]")}")
+    val stmt = createStatement(session, cql, values: _*)
+    val columnNamesArray = selectedColumnRefs.map(_.selectedFromCassandraAs).toArray
+
+    try {
+      implicit val pv = protocolVersion(session)
+      val tc = inputMetricsUpdater.resultSetFetchTimer.map(_.time())
+      val rs = session.execute(stmt)
+      tc.map(_.stop())
+      val iterator = new PrefetchingResultSetIterator(rs, fetchSize)
+      val iteratorWithMetrics = iterator.map(inputMetricsUpdater.updateMetrics)
+      val result = iteratorWithMetrics.map(rowReader.read(_, columnNamesArray))
+      logDebug(s"Row iterator for range ${range.cql} obtained successfully.")
+      result
+    } catch {
+      case t: Throwable =>
+        throw new IOException(s"Exception during execution of $cql: ${t.getMessage}", t)
+    }
+  }
+
+  override def compute(split: Partition, context: TaskContext): Iterator[R] = {
+    val session = connector.openSession()
+    val partition = split.asInstanceOf[CassandraPartition]
+    val tokenRanges = partition.tokenRanges
+    val metricsUpdater = InputMetricsUpdater(context, 20)
+
+    // Iterator flatMap trick flattens the iterator-of-iterator structure into a single iterator.
+    // flatMap on iterator is lazy, therefore a query for the next token range is executed not earlier
+    // than all of the rows returned by the previous query have been consumed
+    val rowIterator = tokenRanges.iterator.flatMap(
+      fetchTokenRange(session, _, metricsUpdater))
+    val countingIterator = new CountingIterator(rowIterator, limit)
+
+    context.addTaskCompletionListener { (context) =>
+      val duration = metricsUpdater.finish() / 1000000000d
+      logDebug(f"Fetched ${countingIterator.count} rows from $keyspaceName.$tableName for partition ${partition.index} in $duration%.3f s.")
+      session.close()
+    }
+    countingIterator
+  }
+
+  override def toEmptyCassandraRDD(): EmptyCassandraRDD[R] = {
+    new EmptyCassandraRDD[R](sc, keyspaceName, tableName, columnNames, where, limit, clusteringOrder, readConf)
+  }
+
+  override def count(): Long = {
+    columnNames match {
+      case SomeColumns(_) => logWarning("You are about to count rows but an explicit projection has been specified.")
+      case _ =>
+    }
+    new CassandraTableScanRDD[Long](sc, connector, keyspaceName, tableName, SomeColumns(RowCountRef), where, limit, clusteringOrder, readConf).reduce(_ + _)
+  }
+}
+
+object CassandraTableScanRDD {
+  def apply[T](sc: SparkContext, keyspaceName: String, tableName: String)
+              (implicit ct: ClassTag[T], rrf: RowReaderFactory[T]): CassandraTableScanRDD[T] =
+    new CassandraTableScanRDD[T](
+      sc, CassandraConnector(sc.getConf), keyspaceName, tableName, AllColumns, CqlWhereClause.empty)
+
+  def apply[K, V](sc: SparkContext, keyspaceName: String, tableName: String)
+                 (implicit keyCT: ClassTag[K], valueCT: ClassTag[V], rrf: RowReaderFactory[(K, V)]): CassandraTableScanRDD[(K, V)] =
+    new CassandraTableScanRDD[(K, V)](
+      sc, CassandraConnector(sc.getConf), keyspaceName, tableName, AllColumns, CqlWhereClause.empty)
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/EmptyCassandraRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/EmptyCassandraRDD.scala
@@ -1,0 +1,49 @@
+package com.datastax.spark.connector.rdd
+
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.cql.CassandraConnector
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.{Partition, SparkContext, TaskContext}
+
+import scala.reflect.ClassTag
+
+class EmptyCassandraRDD[R](@transient sc: SparkContext,
+                           val keyspaceName: String,
+                           val tableName: String,
+                           val columnNames: ColumnSelector = AllColumns,
+                           val where: CqlWhereClause = CqlWhereClause.empty,
+                           val limit: Option[Long] = None,
+                           val clusteringOrder: Option[ClusteringOrder] = None,
+                           val readConf: ReadConf = ReadConf())
+                          (implicit val rct: ClassTag[R])
+  extends CassandraRDD[R](sc, Seq.empty) {
+
+  override protected def copy(columnNames: ColumnSelector = columnNames,
+                              where: CqlWhereClause = where,
+                              limit: Option[Long] = limit,
+                              clusteringOrder: Option[ClusteringOrder] = None,
+                              readConf: ReadConf = readConf,
+                              connector: CassandraConnector = connector) =
+    new EmptyCassandraRDD[R](sc, keyspaceName, tableName, columnNames, where, limit, clusteringOrder, readConf).asInstanceOf[this.type]
+
+  override protected def getPartitions: Array[Partition] = Array.empty
+
+  @DeveloperApi
+  override def compute(split: Partition, context: TaskContext): Iterator[R] = throw new UnsupportedOperationException("Cannot call compute on an EmptyRDD")
+
+  lazy val selectedColumnRefs: Seq[SelectableColumnRef] = {
+    val providedColumnNames =
+      columnNames match {
+        case AllColumns => Seq()
+        case PartitionKeyColumns => Seq()
+        case SomeColumns(cs@_*) => cs
+      }
+    providedColumnNames
+  }
+
+  override protected def connector: CassandraConnector = throw new UnsupportedOperationException("Empty Cassandra RDD's Don't Have Connections to Cassandra")
+
+  override def toEmptyCassandraRDD: EmptyCassandraRDD[R] = copy()
+
+  override protected def narrowColumnSelection(columns: Seq[SelectableColumnRef]): Seq[SelectableColumnRef] = columns
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/package.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/package.scala
@@ -1,7 +1,7 @@
 package com.datastax.spark.connector
 
 
-/** Contains [[com.datastax.spark.connector.rdd.CassandraRDD]] class that is the main entry point for
+/** Contains [[com.datastax.spark.connector.rdd.CassandraTableScanRDD]] class that is the main entry point for
   * analyzing Cassandra data from Spark. */
 package object rdd {
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartitionedRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartitionedRDD.scala
@@ -1,0 +1,36 @@
+package com.datastax.spark.connector.rdd.partitioner
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{Partition, Partitioner, TaskContext}
+
+import scala.reflect.ClassTag
+
+/**
+ * RDD created by repartitionByCassandraReplica with preferred locations mapping to the CassandraReplicas
+ * each partition was created for.
+ */
+protected[connector] class CassandraPartitionedRDD[T](prev: RDD[T])(implicit ct: ClassTag[T]) extends RDD[T](prev) {
+
+  //We aren't going to change the data
+  override def compute(split: Partition, context: TaskContext): Iterator[T] = prev.iterator(split, context)
+
+  @transient override val partitioner: Option[Partitioner] = prev.partitioner
+
+  /**
+   * This RDD was partitioned using the Replica Partitioner so we can use that to get preferred location data
+   */
+  override def getPartitions: Array[Partition] = {
+    partitioner match {
+      case Some(rp: ReplicaPartitioner) => prev.partitions.map(partition => rp.getEndpointPartition(partition))
+      case _ => throw new IllegalArgumentException("CassandraPartitionedRDD hasn't been partitioned by ReplicaPartitioner. This should be impossible")
+    }
+  }
+
+  override def getPreferredLocations(split: Partition): Seq[String] = {
+    split match {
+      case epp: ReplicaPartition =>
+        epp.endpoints.map(_.getHostAddress).toSeq
+      case other: Partition => throw new IllegalArgumentException("CassandraPartitionedRDD doesn't have Endpointed Partitions. This should be impossible.")
+    }
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraRDDPartition.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraRDDPartition.scala
@@ -7,6 +7,10 @@ import org.apache.spark.Partition
 /** Stores a CQL `WHERE` predicate matching a range of tokens. */
 case class CqlTokenRange(cql: String, values: Any*)
 
+trait EndpointPartition extends Partition {
+  def endpoints: Iterable[InetAddress]
+}
+
 /** Metadata describing Cassandra table partition processed by a single Spark task.
   * Beware the term "partition" is overloaded. Here, in the context of Spark,
   * it means an arbitrary collection of rows that can be processed locally on a single Cassandra cluster node.
@@ -21,5 +25,5 @@ case class CqlTokenRange(cql: String, values: Any*)
 case class CassandraPartition(index: Int,
                               endpoints: Iterable[InetAddress],
                               tokenRanges: Iterable[CqlTokenRange],
-                              rowCount: Long) extends Partition
+                              rowCount: Long) extends EndpointPartition
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraRDDPartitioner.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraRDDPartitioner.scala
@@ -2,28 +2,27 @@ package com.datastax.spark.connector.rdd.partitioner
 
 import java.net.InetAddress
 
-import scala.collection.JavaConversions._
-import scala.collection.parallel.ForkJoinTaskSupport
-import scala.concurrent.forkjoin.ForkJoinPool
-
-import org.apache.cassandra.thrift
-import org.apache.cassandra.thrift.Cassandra
-import org.apache.spark.Partition
-import org.apache.thrift.TApplicationException
-
 import com.datastax.spark.connector.cql.{CassandraConnector, TableDef}
 import com.datastax.spark.connector.rdd._
 import com.datastax.spark.connector.rdd.partitioner.dht.{CassandraNode, Token, TokenFactory}
 import com.datastax.spark.connector.util.CqlWhereParser
 import com.datastax.spark.connector.util.CqlWhereParser._
+import org.apache.cassandra.thrift
+import org.apache.cassandra.thrift.Cassandra
+import org.apache.spark.Partition
+import org.apache.thrift.TApplicationException
+
+import scala.collection.JavaConversions._
+import scala.collection.parallel.ForkJoinTaskSupport
+import scala.concurrent.forkjoin.ForkJoinPool
 
 /** Creates CassandraPartitions for given Cassandra table */
 class CassandraRDDPartitioner[V, T <: Token[V]](
-    connector: CassandraConnector,
-    tableDef: TableDef,
-    splitSize: Long)(
-  implicit
-    tokenFactory: TokenFactory[V, T]) {
+                                                 connector: CassandraConnector,
+                                                 tableDef: TableDef,
+                                                 splitSize: Long)(
+                                                 implicit
+                                                 tokenFactory: TokenFactory[V, T]) {
 
   type Token = com.datastax.spark.connector.rdd.partitioner.dht.Token[T]
   type TokenRange = com.datastax.spark.connector.rdd.partitioner.dht.TokenRange[V, T]
@@ -39,9 +38,9 @@ class CassandraRDDPartitioner[V, T <: Token[V]](
     (rpcAddress, localAddress) match {
       case (NullAddress, NullAddress) => throw new IllegalArgumentException(
         "Broadcast address and RPC address of a Cassandra node cannot be both set to 0.0.0.0")
-      case (NullAddress, local)       => CassandraNode(local, local)
-      case (rpc, NullAddress)         => CassandraNode(rpc, rpc)
-      case (rpc, local)               => CassandraNode(rpc, local)
+      case (NullAddress, local) => CassandraNode(local, local)
+      case (rpc, NullAddress) => CassandraNode(rpc, rpc)
+      case (rpc, local) => CassandraNode(rpc, local)
     }
   }
 
@@ -140,7 +139,7 @@ class CassandraRDDPartitioner[V, T <: Token[V]](
       case RangePredicate(c, _, _) if pk.contains(c) =>
         throw new UnsupportedOperationException(
           s"Range predicates on partition key columns (here: $c) are " +
-          s"not supported in where. Use filter instead.")
+            s"not supported in where. Use filter instead.")
     }.toSet
 
     if (whereColumns.nonEmpty && whereColumns.size < pk.size) {
@@ -153,7 +152,7 @@ class CassandraRDDPartitioner[V, T <: Token[V]](
     whereColumns.nonEmpty
   }
 
-  /** Computes Spark partitions of the given table. Called by [[CassandraRDD]]. */
+  /** Computes Spark partitions of the given table. Called by [[CassandraTableScanRDD]]. */
   def partitions(whereClause: CqlWhereClause): Array[Partition] = {
     connector.withCassandraClientDo {
       client =>

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/ReplicaPartitioner.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/ReplicaPartitioner.scala
@@ -1,0 +1,59 @@
+package com.datastax.spark.connector.rdd.partitioner
+
+import java.net.InetAddress
+
+import com.datastax.spark.connector.cql.CassandraConnector
+import org.apache.spark.{Partition, Partitioner}
+
+
+case class ReplicaPartition(index: Int, endpoints: Set[InetAddress]) extends EndpointPartition
+
+/**
+ * The replica partitioner will work on an RDD which is keyed on sets of InetAddresses representing Cassandra
+ * Hosts . It will group keys which share a common IP address into partitionsPerReplicaSet Partitions.
+ * @param partitionsPerReplicaSet The number of Spark Partitions to make Per Unique Endpoint
+ */
+class ReplicaPartitioner(partitionsPerReplicaSet: Int, connector: CassandraConnector) extends Partitioner {
+  /* TODO We Need JAVA-312 to get sets of replicas instead of single endpoints. Once we have that we'll be able to
+  build a map of Set[ip,ip,...] => Index before looking at our data and give the all options for the preferred location
+   for a partition*/
+  private val hosts = connector.hosts.toVector
+  private val numHosts = hosts.size
+  private val partitionIndexes = (0 until partitionsPerReplicaSet * numHosts).grouped(partitionsPerReplicaSet).toList
+  private val hostMap = (hosts zip partitionIndexes).toMap
+  // Ip1 -> (0,1,2,..), Ip2 -> (11,12,13...)
+  private val indexMap = for ((ip, partitions) <- hostMap; partition <- partitions) yield (partition, ip)
+  // 0->IP1, 1-> IP1, ...
+  private val rand = new java.util.Random()
+
+  private def randomHost: InetAddress =
+    hosts(rand.nextInt(numHosts))
+
+  /**
+   * Given a set of endpoints, pick a random endpoint, and then a random partition owned by that endpoint. If the
+   * requested host doesn't exist chose another random host.
+   * @param key A Set[InetAddress] of replicas for this Cassandra Partition
+   * @return An integer between 0 and numPartitions
+   */
+  override def getPartition(key: Any): Int = {
+    key match {
+      case key: Set[_] if key.size > 0 && key.forall(_.isInstanceOf[InetAddress]) =>
+        val replicaSet = key.asInstanceOf[Set[InetAddress]].toVector
+        val endpoint = replicaSet(rand.nextInt(replicaSet.size))
+        hostMap.getOrElse(endpoint, hostMap(randomHost))(rand.nextInt(partitionsPerReplicaSet))
+      case _ => throw new IllegalArgumentException(
+        "ReplicaPartitioner can only determine the partition of a tuple whose key is a non-empty Set[InetAddress]. " +
+          s"Invalid key: $key")
+    }
+  }
+
+  override def numPartitions: Int = partitionsPerReplicaSet * numHosts
+
+  def getEndpointPartition(partition: Partition): ReplicaPartition = {
+    val endpoints = indexMap.getOrElse(partition.index,
+      throw new RuntimeException(s"$indexMap : Can't get an endpoint for Partition $partition.index"))
+    new ReplicaPartition(index = partition.index, endpoints = Set(endpoints))
+  }
+
+}
+

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/CassandraStreamingRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/CassandraStreamingRDD.scala
@@ -1,15 +1,15 @@
 package com.datastax.spark.connector.streaming
 
 import com.datastax.spark.connector.cql.CassandraConnector
-import com.datastax.spark.connector.{ColumnSelector, AllColumns}
+import com.datastax.spark.connector.rdd.reader._
+import com.datastax.spark.connector.rdd.{CassandraTableScanRDD, ClusteringOrder, CqlWhereClause, ReadConf}
+import com.datastax.spark.connector.{AllColumns, ColumnSelector}
+import org.apache.spark.streaming.StreamingContext
 
 import scala.reflect.ClassTag
-import org.apache.spark.streaming.StreamingContext
-import com.datastax.spark.connector.rdd.{ClusteringOrder, ReadConf, CassandraRDD, CqlWhereClause}
-import com.datastax.spark.connector.rdd.reader._
 
 /** RDD representing a Cassandra table for Spark Streaming.
-  * @see [[com.datastax.spark.connector.rdd.CassandraRDD]] */
+  * @see [[com.datastax.spark.connector.rdd.CassandraTableScanRDD]]*/
 class CassandraStreamingRDD[R] private[connector] (
     sctx: StreamingContext,
     connector: CassandraConnector,
@@ -24,4 +24,4 @@ class CassandraStreamingRDD[R] private[connector] (
   implicit
     ct : ClassTag[R],
     @transient val rrf: RowReaderFactory[R])
-  extends CassandraRDD[R](sctx.sparkContext, connector, keyspace, table, columns, where, empty, limit, clusteringOrder, readConf)
+  extends CassandraTableScanRDD[R](sctx.sparkContext, connector, keyspace, table, columns, where, limit, clusteringOrder, readConf)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/CountingIterator.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/CountingIterator.scala
@@ -1,13 +1,16 @@
 package com.datastax.spark.connector.util
 
-/** Counts elements fetched form the underlying iterator. */
-class CountingIterator[T](iterator: Iterator[T]) extends Iterator[T] {
+/** Counts elements fetched form the underlying iterator. Limit causes iterator to terminate early */
+class CountingIterator[T](iterator: Iterator[T], limit: Option[Long] = None) extends Iterator[T] {
   private var _count = 0
 
   /** Returns the number of successful invocations of `next` */
   def count = _count
 
-  def hasNext = iterator.hasNext
+  def hasNext = limit match {
+    case Some(l) => _count < l && iterator.hasNext
+    case _ => iterator.hasNext
+  }
 
   def next() = {
     val item = iterator.next()

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/ReplicaMapper.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/ReplicaMapper.scala
@@ -1,0 +1,100 @@
+package com.datastax.spark.connector.writer
+
+
+import java.io.IOException
+import java.net.InetAddress
+
+import com.datastax.driver.core._
+import com.datastax.spark.connector.cql._
+import org.apache.spark.Logging
+
+import scala.collection.JavaConversions._
+import scala.collection._
+
+/**
+ * A utility class for determining the Replica Set (Ip Addresses) of a particular Cassaandra Row. Used
+ * by the [[com.datastax.spark.connector.RDDFunctions.keyByCassandraReplica()]] method. Uses the Java
+ * Driver to obtain replica information.
+ */
+class ReplicaMapper[T] private(
+                                connector: CassandraConnector,
+                                tableDef: TableDef,
+                                rowWriter: RowWriter[T]) extends Serializable with Logging {
+
+  val keyspaceName = tableDef.keyspaceName
+  val tableName = tableDef.tableName
+  val columnNames = rowWriter.columnNames
+  implicit val protocolVersion = connector.withClusterDo {
+    _.getConfiguration.getProtocolOptions.getProtocolVersionEnum
+  }
+
+
+  private def quote(name: String): String =
+    "\"" + name + "\""
+
+  /**
+   * This query is only used to build a prepared statement so we can more easily extract
+   * partition tokens from tables. We prepare a statement of the form SELECT * FROM keyspace.table
+   * where x= .... This statement is never executed.
+   */
+  private lazy val querySelectUsingOnlyPartitionKeys: String = {
+    val partitionKeys = tableDef.partitionKey
+    def quotedColumnNames(columns: Seq[ColumnDef]) = partitionKeys.map(_.columnName).map(quote)
+    val whereClause = quotedColumnNames(partitionKeys).map(c => s"$c = :$c").mkString(" AND ")
+    s"SELECT * FROM ${quote(keyspaceName)}.${quote(tableName)} WHERE $whereClause"
+  }
+
+  private def prepareDummyStatement(session: Session): PreparedStatement = {
+    try {
+      session.prepare(querySelectUsingOnlyPartitionKeys)
+    }
+    catch {
+      case t: Throwable =>
+        throw new IOException(s"Failed to prepare statement $querySelectUsingOnlyPartitionKeys: " + t.getMessage, t)
+    }
+  }
+
+  /**
+   * Pairs each piece of data with the Cassandra Replicas which that data would be found on
+   * @param data A source of data which can be bound to a statement by BatchStatementBuilder
+   * @return an Iterator over the same data keyed by the replica's ip addresses
+   */
+  def keyByReplicas(data: Iterator[T]): Iterator[(scala.collection.immutable.Set[InetAddress], T)] = {
+      connector.withSessionDo { session =>
+        val stmt = prepareDummyStatement(session)
+        val routingKeyGenerator = new RoutingKeyGenerator(tableDef, columnNames)
+        val boundStmtBuilder = new BoundStatementBuilder(rowWriter, stmt, protocolVersion)
+        val clusterMetadata = session.getCluster.getMetadata
+        data.map { row =>
+          val hosts = clusterMetadata
+            .getReplicas(keyspaceName, routingKeyGenerator.apply(boundStmtBuilder.bind(row)))
+            .map(_.getAddress)
+            .toSet[InetAddress]
+          (hosts, row)
+        }
+    }
+  }
+}
+
+/**
+ * Helper methods for mapping a set of data to their relative locations in a Cassandra Cluster.
+ */
+object ReplicaMapper {
+  def apply[T: RowWriterFactory](
+                                  connector: CassandraConnector,
+                                  keyspaceName: String,
+                                  tableName: String): ReplicaMapper[T] = {
+
+    val schema = Schema.fromCassandra(connector, Some(keyspaceName), Some(tableName))
+    val tableDef = schema.tables.headOption
+      .getOrElse(throw new IOException(s"Table not found: $keyspaceName.$tableName"))
+    val selectedColumns = tableDef.partitionKey.map(_.columnName).toSeq
+    val rowWriter = implicitly[RowWriterFactory[T]].rowWriter(
+      tableDef,
+      selectedColumns,
+      Map.empty.withDefault(x => x)
+    )
+    new ReplicaMapper[T](connector, tableDef, rowWriter)
+  }
+
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/RowWriterFactory.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/RowWriterFactory.scala
@@ -5,7 +5,7 @@ import com.datastax.spark.connector.mapper.ColumnMapper
 
 /** Creates instances of [[RowWriter]] objects for the given row type `T`.
   * `RowWriterFactory` is the trait you need to implement if you want to support row representations
-  * which cannot be simply mapped by a [[com.datastax.spark.connector.mapper.ColumnMapper ColumnMapper]].*/
+  * which cannot be simply mapped by a [[com.datastax.spark.connector.mapper.ColumnMapper ColumnMapper]]. */
 trait RowWriterFactory[T] {
 
   /** Creates a new `RowWriter` instance.
@@ -16,12 +16,12 @@ trait RowWriterFactory[T] {
 }
 
 /** Provides a low-priority implicit `RowWriterFactory` able to write objects of any class for which
-  * a [[com.datastax.spark.connector.mapper.ColumnMapper ColumnMapper]] is defined.*/
+  * a [[com.datastax.spark.connector.mapper.ColumnMapper ColumnMapper]] is defined. */
 trait LowPriorityRowWriterFactoryImplicits {
-  implicit def defaultRowWriterFactory[T : ColumnMapper]: RowWriterFactory[T] = DefaultRowWriter.factory
+  implicit def defaultRowWriterFactory[T: ColumnMapper]: RowWriterFactory[T] = DefaultRowWriter.factory
 }
 
-/** Provides an implicit `RowWriterFactory` for saving [[com.datastax.spark.connector.CassandraRow CassandraRow]] objects.*/
+/** Provides an implicit `RowWriterFactory` for saving [[com.datastax.spark.connector.CassandraRow CassandraRow]] objects. */
 object RowWriterFactory extends LowPriorityRowWriterFactoryImplicits {
   implicit val genericRowWriterFactory = CassandraRowWriter.Factory
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/SqlRowWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/SqlRowWriter.scala
@@ -3,7 +3,7 @@ package com.datastax.spark.connector.writer
 import com.datastax.spark.connector.cql.TableDef
 import org.apache.spark.sql.catalyst.expressions.Row
 
-/** A [[RowWriter]] that can write SparkSQL [[Row]] objects.*/
+/** A [[RowWriter]] that can write SparkSQL [[Row]] objects. */
 class SqlRowWriter(val table: TableDef, val columnNames: Seq[String]) extends RowWriter[Row] {
 
   /** Extracts column values from `data` object and writes them into the given buffer


### PR DESCRIPTION
Added function keyByReplica
    For keying RDD's based on their cassandra replica placement
Added function partitionByReplica
    Which keys an RDD based on replica placement then creates
    new partitions based on their replicas