### PR TITLE
Updated docs

### DIFF
--- a/doc/5_saving.md
+++ b/doc/5_saving.md
@@ -77,5 +77,6 @@ The following properties set in `SparkConf` can be used to fine-tune the saving 
      will adjust the number of rows based on the amount of data in each row  
   - `spark.cassandra.output.batch.size.bytes`: maximum total size of the batch in bytes; defaults to 16 kB.
   - `spark.cassandra.output.concurrent.writes`: maximum number of batches executed in parallel by a single Spark task; defaults to 5
+  - `spark.cassandra.output.consistency.level`: consistency level for writing; defaults to LOCAL_ONE.
 
 [Next - Customizing the object mapping](6_advanced_mapper.md)


### PR DESCRIPTION
Added the "spark.cassandra.output.consistency.level" setting to the documentation.
Fixes #307