### PR TITLE
SPARKC-29: Improve error message when SparkContext is null in CassandraR...

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+1.0.7 (unreleased)
+ * Improved error message when attempting to transform CassandraRDD after deserialization (SPARKC-29)
+
 1.0.6
  * Upgraded Java Driver to 2.0.8 and added some logging in LocalNodeFirstLoadBalancingPolicy (SPARKC-18)
  

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
@@ -66,8 +66,13 @@ class CassandraRDD[R] private[connector] (
 
   private val connector = CassandraConnector(sc.getConf)
 
-  private def copy(columnNames: ColumnSelector = columnNames, where: CqlWhereClause = where): CassandraRDD[R] =
+  private def copy(columnNames: ColumnSelector = columnNames, where: CqlWhereClause = where): CassandraRDD[R] = {
+    require(sc != null,
+      "RDD transformation requires a non-null SparkContext. Unfortunately SparkContext in this CassandraRDD is null. " +
+      "This can happen after CassandraRDD has been deserialized. SparkContext is not Serializable, therefore it deserializes to null." +
+      "RDD transformations are not allowed inside lambdas used in other RDD transformations.")
     new CassandraRDD(sc, keyspaceName, tableName, columnNames, where)
+  }
 
   /** Adds a CQL `WHERE` predicate(s) to the query.
     * Useful for leveraging secondary indexes in Cassandra.


### PR DESCRIPTION
...DD after deserialization and the user wants to transform it.