### PR TITLE
SPARKC-30: Upgrade to Spark 1.2.1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@
  * All connection properties can be set on SparkConf / CassandraConnectorConf objects and
    the settings are automatically distributed to Spark Executors (SPARKC-28)
  * Report Connector metrics to Spark metrics system (SPARKC-27)
+ * Upgraded to Spark 1.2.1 (SPARKC-30)
 
 1.2.0 alpha 1
  * Added support for TTL and timestamp in the writer (#153)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -121,7 +121,8 @@ object Settings extends Build {
     fork in Test := true,
     fork in IntegrationTest := true,
     (compile in IntegrationTest) <<= (compile in Test, compile in IntegrationTest) map { (_, c) => c },
-    managedClasspath in IntegrationTest <<= Classpaths.concat(managedClasspath in IntegrationTest, exportedProducts in Test)
+    managedClasspath in IntegrationTest <<= Classpaths.concat(managedClasspath in IntegrationTest, exportedProducts in Test),
+    javaOptions in IntegrationTest ++= Seq("-XX:MaxPermSize=256M", "-Xmx1g")
   )
 
   lazy val sbtAssemblySettings = assemblySettings ++ Seq(

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -33,6 +33,6 @@ object Versions {
   val ScalaTest       = "2.2.2"
   val Scalactic       = "2.2.2"
   val Slf4j           = "1.7.7"
-  val Spark           = "1.2.0"
-  val SparkRepl       = "1.1.1"
+  val Spark           = "1.2.1"
+  val SparkRepl       = "1.2.1"
 }

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLSpec.scala
@@ -172,17 +172,17 @@ class CassandraSQLSpec extends FlatSpec with Matchers with SharedEmbeddedCassand
     result should have length 2
   }
 
-  ignore should "allow to select rows with union clause" in {
+  it should "allow to select rows with union clause" in {
     val result = cc.sql("SELECT test1.a FROM sql_test.test1 AS test1 UNION DISTINCT SELECT test2.a FROM sql_test.test2 AS test2").collect()
     result should have length 3
   }
 
-  ignore should "allow to select rows with union distinct clause" in {
+  it should "allow to select rows with union distinct clause" in {
     val result = cc.sql("SELECT test1.a FROM sql_test.test1 AS test1 UNION DISTINCT SELECT test2.a FROM sql_test.test2 AS test2").collect()
     result should have length 3
   }
 
-  ignore should "allow to select rows with union all clause" in {
+  it should "allow to select rows with union all clause" in {
     val result = cc.sql("SELECT test1.a FROM sql_test.test1 AS test1 UNION ALL SELECT test2.a FROM sql_test.test2 AS test2").collect()
     result should have length 17
   }
@@ -208,55 +208,55 @@ class CassandraSQLSpec extends FlatSpec with Matchers with SharedEmbeddedCassand
     result2 should have length 9
   }
 
-  ignore should "allow to insert into another table in different keyspace" in {
+  it should "allow to insert into another table in different keyspace" in {
     val result = cc.sql("INSERT INTO sql_test2.test3 SELECT test2.a, test2.b, test2.c FROM sql_test.test2 as test2").collect()
     val result2 = cc.sql("SELECT test3.a, test3.b, test3.c FROM sql_test2.test3 as test3").collect()
     result2 should have length 9
   }
 
-  ignore should "allow to join two tables" in {
+  it should "allow to join two tables" in {
     val result = cc.sql("SELECT test1.a, test1.b, test1.c, test2.a FROM sql_test.test1 AS test1 " +
       "JOIN sql_test.test2 AS test2 ON test1.a = test2.a AND test1.b = test2.b AND test1.c = test2.c").collect()
     result should have length 4
   }
 
-  ignore should "allow to join two tables from different keyspaces" in {
+  it should "allow to join two tables from different keyspaces" in {
     val result = cc.sql("SELECT test1.a, test1.b, test1.c, test2.a FROM sql_test.test1 AS test1 " +
       "JOIN sql_test2.test2 AS test2 ON test1.a = test2.a AND test1.b = test2.b AND test1.c = test2.c").collect()
     result should have length 4
   }
 
-  ignore should "allow to inner join two tables" in {
+  it should "allow to inner join two tables" in {
     val result = cc.sql("SELECT test1.a, test1.b, test1.c, test2.a FROM sql_test.test1 AS test1 " +
       "INNER JOIN sql_test.test2 AS test2 ON test1.a = test2.a AND test1.b = test2.b AND test1.c = test2.c").collect()
     result should have length 4
   }
 
-  ignore should "allow to left join two tables" in {
+  it should "allow to left join two tables" in {
     val result = cc.sql("SELECT test1.a, test1.b, test1.c, test1.d, test1.e, test1.f FROM sql_test.test1 AS test1 " +
       "LEFT JOIN sql_test.test2 AS test2 ON test1.a = test2.a AND test1.b = test2.b AND test1.c = test2.c").collect()
     result should have length 8
   }
 
-  ignore should "allow to left outer join two tables" in {
+  it should "allow to left outer join two tables" in {
     val result = cc.sql("SELECT test1.a, test1.b, test1.c, test1.d, test1.e, test1.f FROM sql_test.test1 AS test1 " +
       "LEFT OUTER JOIN sql_test.test2 AS test2 ON test1.a = test2.a AND test1.b = test2.b AND test1.c = test2.c").collect()
     result should have length 8
   }
 
-  ignore should "allow to right join two tables" in {
+  it should "allow to right join two tables" in {
     val result = cc.sql("SELECT test2.a, test2.b, test2.c FROM sql_test.test1 AS test1 " +
       "RIGHT JOIN sql_test.test2 AS test2 ON test1.a = test2.a AND test1.b = test2.b AND test1.c = test2.c").collect()
     result should have length 12
   }
 
-  ignore should "allow to right outer join two tables" in {
+  it should "allow to right outer join two tables" in {
     val result = cc.sql("SELECT test2.a, test2.b, test2.c FROM sql_test.test1 AS test1 " +
       "RIGHT OUTER JOIN sql_test.test2 AS test2 ON test1.a = test2.a AND test1.b = test2.b AND test1.c = test2.c").collect()
     result should have length 12
   }
 
-  ignore should "allow to full join two tables" in {
+  it should "allow to full join two tables" in {
     val result = cc.sql("SELECT test2.a, test2.b, test2.c FROM sql_test.test1 AS test1 " +
       "FULL JOIN sql_test.test2 AS test2 ON test1.a = test2.a AND test1.b = test2.b AND test1.c = test2.c").collect()
     result should have length 16


### PR DESCRIPTION
- changed Spark dependency version
- updated CassandraCatalog
- unlocked CassandraSQL tests which where ignored before
- increased max perm size for test