### PR TITLE
SPARKC-32: Added support for pushing down order by clause

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,8 @@
  * Overridden count() implementation in CassandraRDD which uses native Cassandra count (SPARKC-52)
  * Removed custom Logging class (SPARKC-54)
  * Added support for passing the limit clause to CQL in order to fetch top n results (SPARKC-31)
+ * Added support for pushing down order by clause for explicitly specifying an order of rows within
+   Cassandra partition (SPARKC-32)
 
 1.2.0 alpha 2
  * All connection properties can be set on SparkConf / CassandraConnectorConf objects and

--- a/doc/3_selection.md
+++ b/doc/3_selection.md
@@ -39,6 +39,13 @@ are currently allowed by the Cassandra engine. This limitation is going to be ad
 Cassandra releases. Currently, `ALLOW FILTERING` works well 
 with columns indexed by secondary indexes or clustering columns.  
 
+### Ordering rows
+
+CQL allows for requesting ascending or descending order of rows within a single Cassandra partition.
+It is allowed to pass the ordering direction by `withAscOrder` or `withDescOrder` methods of
+`CassandraRDD`. Note that it will work only if there is at least one clustering column in the table
+and a partition key predicate is specified by `where` clause.
+
 ### Limiting rows
 
 When a table is designed so that it include clustering keys and the use case is that only the first

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraJavaPairRDD.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraJavaPairRDD.java
@@ -76,6 +76,24 @@ public class CassandraJavaPairRDD<K, V> extends JavaPairRDD<K, V> {
     }
 
     /**
+     * Forces the rows within a selected Cassandra partition to be returned in ascending order
+     * (if possible).
+     */
+    public CassandraJavaPairRDD<K, V> withAscOrder() {
+        CassandraRDD<Tuple2<K, V>> newRDD = rdd().withAscOrder();
+        return new CassandraJavaPairRDD<>(newRDD, kClassTag(), vClassTag());
+    }
+
+    /**
+     * Forces the rows within a selected Cassandra partition to be returned in descending order
+     * (if possible).
+     */
+    public CassandraJavaPairRDD<K, V> withDescOrder() {
+        CassandraRDD<Tuple2<K, V>> newRDD = rdd().withAscOrder();
+        return new CassandraJavaPairRDD<>(newRDD, kClassTag(), vClassTag());
+    }
+
+    /**
      * Adds the limit clause to CQL select statement. The limit will be applied for each created
      * Spark partition. In other words, unless the data are fetched from a single Cassandra partition
      * the number of results is unpredictable.

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraJavaRDD.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraJavaRDD.java
@@ -78,6 +78,24 @@ public class CassandraJavaRDD<R> extends JavaRDD<R> {
     }
 
     /**
+     * Forces the rows within a selected Cassandra partition to be returned in ascending order
+     * (if possible).
+     */
+    public CassandraJavaRDD<R> withAscOrder() {
+        CassandraRDD<R> newRDD = rdd().withAscOrder();
+        return new CassandraJavaRDD<>(newRDD, classTag());
+    }
+
+    /**
+     * Forces the rows within a selected Cassandra partition to be returned in descending order
+     * (if possible).
+     */
+    public CassandraJavaRDD<R> withDescOrder() {
+        CassandraRDD<R> newRDD = rdd().withAscOrder();
+        return new CassandraJavaRDD<>(newRDD, classTag());
+    }
+
+    /**
      * Returns the names of columns to be selected from the table.
      */
     public NamedColumnRef[] selectedColumnNames() {

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -581,6 +581,18 @@ class CassandraRDDSpec extends FlatSpec with Matchers with SharedEmbeddedCassand
     results.head.ttlOfValue <= ttl
   }
 
+  it should "allow to specify ascending ordering" in {
+    val results = sc.cassandraTable[(Int, Date, String)]("read_test", "clustering_time")
+      .where("key=1").withAscOrder.collect()
+    results.map(_._3).toList shouldBe List("value1", "value2", "value3")
+  }
+
+  it should "allow to specify descending ordering" in {
+    val results = sc.cassandraTable[(Int, Date, String)]("read_test", "clustering_time")
+      .where("key=1").withDescOrder.collect()
+    results.map(_._3).toList shouldBe List("value3", "value2", "value1")
+  }
+
   it should "allow to specify rows number limit" in {
     val results = sc.cassandraTable[(Int, Date, String)]("read_test", "clustering_time").where("key=1").limit(2).collect()
     results should have length 2

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
@@ -2,6 +2,8 @@ package com.datastax.spark.connector.rdd
 
 import java.io.IOException
 
+import com.datastax.spark.connector.rdd.ClusteringOrder.{Descending, Ascending}
+
 import scala.reflect.ClassTag
 import scala.collection.JavaConversions._
 import scala.language.existentials
@@ -56,6 +58,7 @@ class CassandraRDD[R] private[connector] (
     val where: CqlWhereClause = CqlWhereClause.empty,
     val empty: Boolean = false,
     val limit: Option[Long] = None,
+    val clusteringOrder: Option[ClusteringOrder] = None,
     val readConf: ReadConf = ReadConf())(
   implicit
     ct : ClassTag[R], @transient rtf: RowReaderFactory[R])
@@ -68,6 +71,7 @@ class CassandraRDD[R] private[connector] (
   private def consistencyLevel = readConf.consistencyLevel
 
   private def copy(columnNames: ColumnSelector = columnNames,
+                   clusteringOrder: Option[ClusteringOrder] = clusteringOrder,
                    where: CqlWhereClause = where,
                    empty: Boolean = empty,
                    limit: Option[Long] = limit,
@@ -77,7 +81,7 @@ class CassandraRDD[R] private[connector] (
       "RDD transformation requires a non-null SparkContext. Unfortunately SparkContext in this CassandraRDD is null. " +
       "This can happen after CassandraRDD has been deserialized. SparkContext is not Serializable, therefore it deserializes to null." +
       "RDD transformations are not allowed inside lambdas used in other RDD transformations.")
-    new CassandraRDD(sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, readConf)
+    new CassandraRDD(sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
   }
 
   /** Returns a copy of this Cassandra RDD with specified connector */
@@ -91,6 +95,18 @@ class CassandraRDD[R] private[connector] (
   def where(cql: String, values: Any*): CassandraRDD[R] = {
     copy(where = where and CqlWhereClause(Seq(cql), values))
   }
+
+  /** Adds a CQL `ORDER BY` clause to the query.
+    * It can be applied only in case there are clustering columns and primary key predicate is
+    * pushed down in `where`.
+    * It is useful when the default direction of ordering rows within a single Cassandra partition
+    * needs to be changed. */
+  def clusteringOrder(order: ClusteringOrder): CassandraRDD[R] = {
+    copy(clusteringOrder = Some(order))
+  }
+
+  def withAscOrder: CassandraRDD[R] = clusteringOrder(Ascending)
+  def withDescOrder: CassandraRDD[R] = clusteringOrder(Descending)
 
   /** Allows to set custom read configuration, e.g. consistency level or fetch size. */
   def withReadConf(readConf: ReadConf) = {
@@ -150,7 +166,7 @@ class CassandraRDD[R] private[connector] (
       case SomeColumns(_) => logWarning("You are about to count rows but an explicit projection has been specified.")
       case _ =>
     }
-    new CassandraRDD[Long](sc, connector, keyspaceName, tableName, SomeColumns(RowCountRef), where, empty, limit, readConf).reduce(_ + _)
+    new CassandraRDD[Long](sc, connector, keyspaceName, tableName, SomeColumns(RowCountRef), where, empty, limit, clusteringOrder, readConf).reduce(_ + _)
   }
 
   /** Adds the limit clause to CQL select statement. The limit will be applied for each created
@@ -175,69 +191,69 @@ class CassandraRDD[R] private[connector] (
     * }}}*/
   def as[B : ClassTag, A0 : TypeConverter](f: A0 => B): CassandraRDD[B] = {
     implicit val ft = new FunctionBasedRowReader1(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, readConf)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter](f: (A0, A1) => B) = {
     implicit val ft = new FunctionBasedRowReader2(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, readConf)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter](f: (A0, A1, A2) => B) = {
     implicit val ft = new FunctionBasedRowReader3(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, readConf)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter,
   A3 : TypeConverter](f: (A0, A1, A2, A3) => B) = {
     implicit val ft = new FunctionBasedRowReader4(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, readConf)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
   A4 : TypeConverter](f: (A0, A1, A2, A3, A4) => B) = {
     implicit val ft = new FunctionBasedRowReader5(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, readConf)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
   A4 : TypeConverter, A5 : TypeConverter](f: (A0, A1, A2, A3, A4, A5) => B) = {
     implicit val ft = new FunctionBasedRowReader6(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, readConf)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
   A4 : TypeConverter, A5 : TypeConverter, A6 : TypeConverter](f: (A0, A1, A2, A3, A4, A5, A6) => B) = {
     implicit val ft = new FunctionBasedRowReader7(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, readConf)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
   A4 : TypeConverter, A5 : TypeConverter, A6 : TypeConverter,
   A7 : TypeConverter](f: (A0, A1, A2, A3, A4, A5, A6, A7) => B) = {
     implicit val ft = new FunctionBasedRowReader8(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, readConf)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
   A4 : TypeConverter, A5 : TypeConverter, A6 : TypeConverter, A7: TypeConverter,
   A8 : TypeConverter](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) => B) = {
     implicit val ft = new FunctionBasedRowReader9(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, readConf)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
   A4 : TypeConverter, A5 : TypeConverter, A6 : TypeConverter, A7: TypeConverter,
   A8 : TypeConverter, A9 : TypeConverter](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) => B) = {
     implicit val ft = new FunctionBasedRowReader10(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, readConf)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
   A4 : TypeConverter, A5 : TypeConverter, A6 : TypeConverter, A7: TypeConverter, A8: TypeConverter,
   A9 : TypeConverter, A10 : TypeConverter](f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => B) = {
     implicit val ft = new FunctionBasedRowReader11(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, readConf)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
   }
 
   def as[B : ClassTag, A0 : TypeConverter, A1 : TypeConverter, A2 : TypeConverter, A3 : TypeConverter,
@@ -245,7 +261,7 @@ class CassandraRDD[R] private[connector] (
   A9 : TypeConverter, A10: TypeConverter, A11 : TypeConverter](
   f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => B) = {
     implicit val ft = new FunctionBasedRowReader12(f)
-    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, readConf)
+    new CassandraRDD[B](sc, connector, keyspaceName, tableName, columnNames, where, empty, limit, clusteringOrder, readConf)
   }
 
   // ===================================================================
@@ -365,9 +381,10 @@ class CassandraRDD[R] private[connector] (
     val columns = selectedColumnRefs.map(_.cql).mkString(", ")
     val filter = (range.cql +: where.predicates ).filter(_.nonEmpty).mkString(" AND ")
     val limitClause = limit.map(limit => s"LIMIT $limit").getOrElse("")
+    val orderBy = clusteringOrder.map(_.toCql(tableDef)).getOrElse("")
     val quotedKeyspaceName = quote(keyspaceName)
     val quotedTableName = quote(tableName)
-    (s"SELECT $columns FROM $quotedKeyspaceName.$quotedTableName WHERE $filter $limitClause ALLOW FILTERING", range.values ++ where.values)
+    (s"SELECT $columns FROM $quotedKeyspaceName.$quotedTableName WHERE $filter $orderBy $limitClause ALLOW FILTERING", range.values ++ where.values)
   }
 
   def protocolVersion(session: Session): ProtocolVersion = {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/ClusteringOrder.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/ClusteringOrder.scala
@@ -1,0 +1,22 @@
+package com.datastax.spark.connector.rdd
+
+import com.datastax.spark.connector.cql.TableDef
+
+sealed trait ClusteringOrder extends Serializable {
+  private[connector] def toCql(tableDef: TableDef): String
+}
+
+object ClusteringOrder {
+  private[connector] def cqlClause(tableDef: TableDef, order: String) =
+    tableDef.clusteringColumns.headOption.map(cc => s"""ORDER BY "${cc.columnName}" $order""")
+      .getOrElse(throw new IllegalArgumentException("Order by can be specified only if there are some clustering columns"))
+
+  case object Ascending extends ClusteringOrder {
+    override private[connector] def toCql(tableDef: TableDef): String = cqlClause(tableDef, "ASC")
+  }
+
+  case object Descending extends ClusteringOrder {
+    override private[connector] def toCql(tableDef: TableDef): String = cqlClause(tableDef, "DESC")
+  }
+
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/CassandraStreamingRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/CassandraStreamingRDD.scala
@@ -5,7 +5,7 @@ import com.datastax.spark.connector.{ColumnSelector, AllColumns}
 
 import scala.reflect.ClassTag
 import org.apache.spark.streaming.StreamingContext
-import com.datastax.spark.connector.rdd.{ReadConf, CassandraRDD, CqlWhereClause}
+import com.datastax.spark.connector.rdd.{ClusteringOrder, ReadConf, CassandraRDD, CqlWhereClause}
 import com.datastax.spark.connector.rdd.reader._
 
 /** RDD representing a Cassandra table for Spark Streaming.
@@ -19,8 +19,9 @@ class CassandraStreamingRDD[R] private[connector] (
     where: CqlWhereClause = CqlWhereClause.empty,
     empty: Boolean = false,
     limit: Option[Long] = None,
+    clusteringOrder: Option[ClusteringOrder] = None,
     readConf: ReadConf = ReadConf())(
   implicit
     ct : ClassTag[R],
     @transient rrf: RowReaderFactory[R])
-  extends CassandraRDD[R](sctx.sparkContext, connector, keyspace, table, columns, where, empty, limit, readConf)
+  extends CassandraRDD[R](sctx.sparkContext, connector, keyspace, table, columns, where, empty, limit, clusteringOrder, readConf)


### PR DESCRIPTION
With this patch:
- added withAscOrder and withDescOrder methods to CassandraRDD, CassandraJavaRDD and CassandraJavaPairRDD
- updated CQL generation method in CassandraRDD so that it can use the order by clause
- added test cases
- updated documentation and CHANGES.txt