### PR TITLE
SPARKC-52: Support for native Cassandra count

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@
  * Added support for write throughput limiting (SPARKC-57)
  * Added EmptyCassandraRDD (SPARKC-37)
  * Exposed authConf in CassandraConnector
+ * Overridden count() implementation in CassandraRDD which uses native Cassandra count (SPARKC-52)
 
 1.2.0 alpha 2
  * All connection properties can be set on SparkConf / CassandraConnectorConf objects and

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/CassandraJavaUtil.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/CassandraJavaUtil.java
@@ -457,7 +457,7 @@ public class CassandraJavaUtil {
             columnsSelection[i] = ColumnName$.MODULE$.apply(columnNames[i]);
         }
 
-        return SomeColumns$.MODULE$.apply(JAPI.seq(columnsSelection));
+        return SomeColumns$.MODULE$.apply(JAPI.<SelectableColumnRef>seq(columnsSelection));
     }
 
     public static NamedColumnRef[] convert(String... columnNames) {

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraJavaPairRDD.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraJavaPairRDD.java
@@ -1,5 +1,6 @@
 package com.datastax.spark.connector.japi.rdd;
 
+import com.datastax.spark.connector.SelectableColumnRef;
 import com.datastax.spark.connector.cql.CassandraConnector;
 import com.datastax.spark.connector.japi.CassandraJavaUtil;
 import com.datastax.spark.connector.NamedColumnRef;
@@ -44,7 +45,7 @@ public class CassandraJavaPairRDD<K, V> extends JavaPairRDD<K, V> {
     public CassandraJavaPairRDD<K, V> select(String... columnNames) {
         // explicit type argument is intentional and required here
         //noinspection RedundantTypeArguments
-        CassandraRDD<Tuple2<K, V>> newRDD = rdd().select(JavaApiHelper.<NamedColumnRef>toScalaSeq(CassandraJavaUtil.convert(columnNames)));
+        CassandraRDD<Tuple2<K, V>> newRDD = rdd().select(JavaApiHelper.<SelectableColumnRef>toScalaSeq(CassandraJavaUtil.convert(columnNames)));
         return new CassandraJavaPairRDD<>(newRDD, kClassTag(), vClassTag());
     }
 
@@ -55,10 +56,10 @@ public class CassandraJavaPairRDD<K, V> extends JavaPairRDD<K, V> {
      * times, it selects the subset of the already selected columns, so after a column was removed by the previous
      * {@code select} call, it is not possible to add it back.</p>
      */
-    public CassandraJavaPairRDD<K, V> select(NamedColumnRef... selectionColumns) {
+    public CassandraJavaPairRDD<K, V> select(SelectableColumnRef... selectionColumns) {
         // explicit type argument is intentional and required here
         //noinspection RedundantTypeArguments
-        CassandraRDD<Tuple2<K, V>> newRDD = rdd().select(JavaApiHelper.<NamedColumnRef>toScalaSeq(selectionColumns));
+        CassandraRDD<Tuple2<K, V>> newRDD = rdd().select(JavaApiHelper.<SelectableColumnRef>toScalaSeq(selectionColumns));
         return new CassandraJavaPairRDD<>(newRDD, kClassTag(), vClassTag());
     }
 
@@ -80,7 +81,7 @@ public class CassandraJavaPairRDD<K, V> extends JavaPairRDD<K, V> {
     public String[] selectedColumnNames() {
         // explicit type cast is intentional and required here
         //noinspection RedundantCast
-        return (String[]) rdd().selectedColumnNames().<String>toArray(getClassTag(String.class));
+        return (String[]) rdd().selectedColumnRefs().<String>toArray(getClassTag(String.class));
     }
 
     /**

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraJavaRDD.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraJavaRDD.java
@@ -1,6 +1,7 @@
 package com.datastax.spark.connector.japi.rdd;
 
 import com.datastax.spark.connector.NamedColumnRef;
+import com.datastax.spark.connector.SelectableColumnRef;
 import com.datastax.spark.connector.cql.CassandraConnector;
 import com.datastax.spark.connector.japi.CassandraJavaUtil;
 import com.datastax.spark.connector.rdd.CassandraRDD;
@@ -46,7 +47,7 @@ public class CassandraJavaRDD<R> extends JavaRDD<R> {
     public CassandraJavaRDD<R> select(String... columnNames) {
         // explicit type argument is intentional and required here
         //noinspection RedundantTypeArguments
-        CassandraRDD<R> newRDD = rdd().select(JavaApiHelper.<NamedColumnRef>toScalaSeq(CassandraJavaUtil.convert(columnNames)));
+        CassandraRDD<R> newRDD = rdd().select(JavaApiHelper.<SelectableColumnRef>toScalaSeq(CassandraJavaUtil.convert(columnNames)));
         return new CassandraJavaRDD<>(newRDD, classTag());
     }
 
@@ -57,10 +58,10 @@ public class CassandraJavaRDD<R> extends JavaRDD<R> {
      * times, it selects the subset of the already selected columns, so after a column was removed by the previous
      * {@code select} call, it is not possible to add it back.</p>
      */
-    public CassandraJavaRDD<R> select(NamedColumnRef... selectionColumns) {
+    public CassandraJavaRDD<R> select(SelectableColumnRef... selectionColumns) {
         // explicit type argument is intentional and required here
         //noinspection RedundantTypeArguments
-        CassandraRDD<R> newRDD = rdd().select(JavaApiHelper.<NamedColumnRef>toScalaSeq(selectionColumns));
+        CassandraRDD<R> newRDD = rdd().select(JavaApiHelper.<SelectableColumnRef>toScalaSeq(selectionColumns));
         return new CassandraJavaRDD<>(newRDD, classTag());
     }
 
@@ -82,7 +83,7 @@ public class CassandraJavaRDD<R> extends JavaRDD<R> {
     public NamedColumnRef[] selectedColumnNames() {
         // explicit type cast is intentional and required here
         //noinspection RedundantCast
-        return (NamedColumnRef[]) rdd().selectedColumnNames().<NamedColumnRef>toArray(getClassTag(NamedColumnRef.class));
+        return (NamedColumnRef[]) rdd().selectedColumnRefs().<NamedColumnRef>toArray(getClassTag(NamedColumnRef.class));
     }
 
     /**

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -581,6 +581,16 @@ class CassandraRDDSpec extends FlatSpec with Matchers with SharedEmbeddedCassand
     results.head.ttlOfValue <= ttl
   }
 
+  it should "count the CassandraRDD items" in {
+    val result = sc.cassandraTable("read_test", "big_table").count()
+    result shouldBe bigTableRowCount
+  }
+
+  it should "count the CassandraRDD items with where predicate" in {
+    val result = sc.cassandraTable("read_test", "big_table").where("key=1").count()
+    result shouldBe 1
+  }
+
   it should "allow to use empty RDD on undefined table" in {
     val result = sc.cassandraTable("unknown_ks", "unknown_table").toEmptyCassandraRDD.collect()
     result should have length 0

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ColumnRef.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ColumnRef.scala
@@ -47,7 +47,7 @@ case class WriteTime(columnName: String) extends NamedColumnRef {
   override def toString: String = selectedAs
 }
 
-case object CountColumn extends SelectableColumnRef {
+case object RowCountRef extends SelectableColumnRef {
   override def selectedAs: String = "count"
   override def cql: String = "count(*)"
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ColumnRef.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ColumnRef.scala
@@ -5,11 +5,7 @@ import scala.language.implicitConversions
 /** Unambiguous reference to a column in the query result set row. */
 sealed trait ColumnRef
 
-sealed trait NamedColumnRef extends ColumnRef {
-  /** Returns the column name which this selection bases on. In case of a function, such as `ttl` or
-    * `writetime`, it returns the column name passed to that function. */
-  def columnName: String
-
+sealed trait SelectableColumnRef extends ColumnRef {
   /** Returns a CQL phrase which has to be passed to the `SELECT` clause with appropriate quotation
     * marks. */
   def cql: String
@@ -17,6 +13,12 @@ sealed trait NamedColumnRef extends ColumnRef {
   /** Returns a name of the selection as it is seen in the result set. Most likely this is going to be
     * used when providing custom column name to field name mapping. */
   def selectedAs: String
+}
+
+sealed trait NamedColumnRef extends SelectableColumnRef {
+  /** Returns the column name which this selection bases on. In case of a function, such as `ttl` or
+    * `writetime`, it returns the column name passed to that function. */
+  def columnName: String
 }
 
 object NamedColumnRef {
@@ -43,6 +45,11 @@ case class WriteTime(columnName: String) extends NamedColumnRef {
   val selectedAs = s"writetime($columnName)"
 
   override def toString: String = selectedAs
+}
+
+case object CountColumn extends SelectableColumnRef {
+  override def selectedAs: String = "count"
+  override def cql: String = "count(*)"
 }
 
 /** References a column by its index in the row. Useful for tuples. */

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ColumnSelector.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ColumnSelector.scala
@@ -4,7 +4,7 @@ import scala.language.implicitConversions
 
 sealed trait ColumnSelector
 case object AllColumns extends ColumnSelector
-case class SomeColumns(columns: NamedColumnRef*) extends ColumnSelector
+case class SomeColumns(columns: SelectableColumnRef*) extends ColumnSelector
 
 object SomeColumns {
   @deprecated("Use com.datastax.spark.connector.rdd.SomeColumns instead of Seq", "1.0")

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
@@ -161,7 +161,7 @@ class CassandraRDD[R] private[connector] (
       case SomeColumns(_) => logWarning("You are about to count rows but an explicit projection has been specified.")
       case _ =>
     }
-    new CassandraRDD[Long](sc, connector, keyspaceName, tableName, SomeColumns(CountColumn), where, readConf).reduce(_ + _)
+    new CassandraRDD[Long](sc, connector, keyspaceName, tableName, SomeColumns(RowCountRef), where, readConf).reduce(_ + _)
   }
 
   /** Maps each row into object of a different type using provided function taking column value(s) as argument(s).

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
@@ -115,13 +115,11 @@ class CassandraRDD[R] private[connector] (
   }
 
   /** Throws IllegalArgumentException if columns sequence contains unavailable columns */
-  private def checkColumnsAvailable(columns: Seq[NamedColumnRef], availableColumns: Seq[NamedColumnRef]) {
-    val availableColumnsSet = availableColumns.collect {
-      case ColumnName(columnName) => columnName
-    }.toSet
+  private def checkColumnsAvailable(columns: Seq[SelectableColumnRef], availableColumns: Seq[SelectableColumnRef]) {
+    val availableColumnsSet = availableColumns.toSet
 
-    val notFound = columns.collectFirst {
-      case ColumnName(columnName) if !availableColumnsSet.contains(columnName) => columnName
+    val notFound = columns.find {
+      case column => !availableColumnsSet.contains(column)
     }
 
     if (notFound.isDefined)
@@ -131,7 +129,7 @@ class CassandraRDD[R] private[connector] (
   }
 
   /** Filters currently selected set of columns with a new set of columns */
-  private def narrowColumnSelection(columns: Seq[NamedColumnRef]): Seq[NamedColumnRef] = {
+  private def narrowColumnSelection(columns: Seq[SelectableColumnRef]): Seq[SelectableColumnRef] = {
     columnNames match {
       case SomeColumns(cs @ _*) =>
         checkColumnsAvailable(columns, cs)
@@ -154,8 +152,16 @@ class CassandraRDD[R] private[connector] (
     * just column names (which is also backward compatible) and optional add `.ttl` or `.writeTime`
     * suffix in order to create an appropriate [[NamedColumnRef]] instance.
     */
-  def select(columns: NamedColumnRef*): CassandraRDD[R] = {
+  def select(columns: SelectableColumnRef*): CassandraRDD[R] = {
     copy(columnNames = SomeColumns(narrowColumnSelection(columns): _*))
+  }
+
+  override def count(): Long = {
+    columnNames match {
+      case SomeColumns(_) => logWarning("You are about to count rows but an explicit projection has been specified.")
+      case _ =>
+    }
+    new CassandraRDD[Long](sc, connector, keyspaceName, tableName, SomeColumns(CountColumn), where, readConf).reduce(_ + _)
   }
 
   /** Maps each row into object of a different type using provided function taking column value(s) as argument(s).
@@ -260,7 +266,7 @@ class CassandraRDD[R] private[connector] (
 
   private lazy val rowTransformer = implicitly[RowReaderFactory[R]].rowReader(tableDef)
 
-  private def checkColumnsExistence(columns: Seq[NamedColumnRef]): Seq[NamedColumnRef] = {
+  private def checkColumnsExistence(columns: Seq[SelectableColumnRef]): Seq[SelectableColumnRef] = {
     val allColumnNames = tableDef.allColumns.map(_.columnName).toSet
     val regularColumnNames = tableDef.regularColumns.map(_.columnName).toSet
 
@@ -285,21 +291,24 @@ class CassandraRDD[R] private[connector] (
       column
     }
 
-    columns.map(checkSingleColumn)
+    columns.map {
+      case namedColumnRef: NamedColumnRef => checkSingleColumn(namedColumnRef)
+      case columnRef => columnRef
+    }
   }
 
 
   /** Returns the names of columns to be selected from the table.*/
-  lazy val selectedColumnNames: Seq[NamedColumnRef] = {
-    val providedColumnNames =
+  lazy val selectedColumnRefs: Seq[SelectableColumnRef] = {
+    val providedColumnRefs =
       columnNames match {
         case AllColumns => tableDef.allColumns.map(col => col.columnName: NamedColumnRef).toSeq
         case SomeColumns(cs @ _*) => checkColumnsExistence(cs)
       }
 
     (rowTransformer.columnNames, rowTransformer.requiredColumns) match {
-      case (Some(cs), None) => providedColumnNames.filter(columnName => cs.toSet(columnName.selectedAs))
-      case (_, _) => providedColumnNames
+      case (Some(cs), None) => providedColumnRefs.filter(columnName => cs.toSet(columnName.selectedAs))
+      case (_, _) => providedColumnRefs
     }
   }
 
@@ -314,15 +323,15 @@ class CassandraRDD[R] private[connector] (
 
     rowTransformer.columnNames match {
       case Some(names) =>
-        val missingColumns = names.toSet -- selectedColumnNames.map(_.selectedAs).toSet
+        val missingColumns = names.toSet -- selectedColumnRefs.map(_.selectedAs).toSet
         assert(missingColumns.isEmpty, s"Missing columns needed by $targetType: ${missingColumns.mkString(", ")}")
       case None =>
     }
 
     rowTransformer.requiredColumns match {
       case Some(count) =>
-        assert(selectedColumnNames.size >= count,
-        s"Not enough columns selected for the target row type $targetType: ${selectedColumnNames.size} < $count")
+        assert(selectedColumnRefs.size >= count,
+        s"Not enough columns selected for the target row type $targetType: ${selectedColumnRefs.size} < $count")
       case None =>
     }
   }
@@ -353,7 +362,7 @@ class CassandraRDD[R] private[connector] (
       .endpoints.map(_.getHostName).toSeq
 
   private def tokenRangeToCqlQuery(range: CqlTokenRange): (String, Seq[Any]) = {
-    val columns = selectedColumnNames.map(_.cql).mkString(", ")
+    val columns = selectedColumnRefs.map(_.cql).mkString(", ")
     val filter = (range.cql +: where.predicates ).filter(_.nonEmpty).mkString(" AND ") + " ALLOW FILTERING"
     val quotedKeyspaceName = quote(keyspaceName)
     val quotedTableName = quote(tableName)
@@ -389,7 +398,7 @@ class CassandraRDD[R] private[connector] (
     val (cql, values) = tokenRangeToCqlQuery(range)
     logDebug(s"Fetching data for range ${range.cql} with $cql with params ${values.mkString("[", ",", "]")}")
     val stmt = createStatement(session, cql, values: _*)
-    val columnNamesArray = selectedColumnNames.map(_.selectedAs).toArray
+    val columnNamesArray = selectedColumnRefs.map(_.selectedAs).toArray
 
     try {
       implicit val pv = protocolVersion(session)


### PR DESCRIPTION
With this patch:
- Added one more trait (SelectableColumnRef) in ColumnRef hierarchy to reflect columns without names
- Added CountColumn case class
- Refactored CassandraRDD, CassandraJavaRDD and CassandraJavaPairRDD
- added test cases
- CHANGES.txt