### PR TITLE
fix to report the correct row count

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -128,7 +128,7 @@ class TableWriter[T] private (
       val batchStmtBuilder = new BatchStatementBuilder(batchType, routingKeyGenerator, writeConf.consistencyLevel)
       val batchKeyGenerator = batchRoutingKey(session, routingKeyGenerator) _
       val batchBuilder = new GroupingBatchBuilder(boundStmtBuilder, batchStmtBuilder, batchKeyGenerator,
-        writeConf.batchSize, writeConf.batchBufferSize, data)
+        writeConf.batchSize, writeConf.batchBufferSize, rowIterator)
       val rateLimiter = new RateLimiter(writeConf.throughputMiBPS * 1024 * 1024, 1024 * 1024)
 
       logDebug(s"Writing data partition to $keyspaceName.$tableName in batches of ${writeConf.batchSize}.")


### PR DESCRIPTION
row count is reported as 0 currently. As the number of rows is logged at
info level, this can be misleading. This fix passes the CountingIterator
to the batch builder.