### PR TITLE
Sparkc-73 support cross cluster table join for Spark SQL Cassandra integration

### DIFF
--- a/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/SparkTemplate.scala
+++ b/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/SparkTemplate.scala
@@ -4,7 +4,6 @@ import org.apache.spark.{SparkEnv, SparkConf, SparkContext}
 
 trait SparkTemplate {
   val conf = SparkTemplate.conf
-  val sc = SparkTemplate.sc
 }
 
 object SparkTemplate {
@@ -17,8 +16,6 @@ object SparkTemplate {
     .setAppName(getClass.getSimpleName)
 
   System.err.println("The Spark configuration is as follows:\n" + conf.toDebugString)
-
-  val sc = new SparkContext(conf)
 
   lazy val actorSystem = SparkEnv.get.actorSystem
 

--- a/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/CassandraJavaUtilSpec.scala
+++ b/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/CassandraJavaUtilSpec.scala
@@ -10,7 +10,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.collection.JavaConversions._
 import CassandraJavaUtil._
 
-class CassandraJavaUtilSpec extends FlatSpec with Matchers with BeforeAndAfter with SharedEmbeddedCassandra with SparkTemplate {
+class CassandraJavaUtilSpec extends SparkCassandraITSpecBase with BeforeAndAfter {
 
   useCassandraConfig("cassandra-default.yaml.template")
   val conn = CassandraConnector(Set(cassandraHost))

--- a/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaRDDSpec.scala
+++ b/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaRDDSpec.scala
@@ -19,8 +19,7 @@ import org.scalatest._
 import scala.collection.JavaConversions._
 import CassandraJavaUtil._
 
-class CassandraJavaRDDSpec extends FlatSpec with Matchers with BeforeAndAfter with BeforeAndAfterAll
-with ShouldMatchers with SharedEmbeddedCassandra with SparkTemplate {
+class CassandraJavaRDDSpec extends SparkCassandraITSpecBase with BeforeAndAfter with ShouldMatchers {
 
   useCassandraConfig("cassandra-default.yaml.template")
 

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/DStreamJavaFunctions.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/DStreamJavaFunctions.java
@@ -7,6 +7,7 @@ import com.datastax.spark.connector.writer.RowWriterFactory;
 import com.datastax.spark.connector.writer.WriteConf;
 import org.apache.spark.SparkConf;
 import org.apache.spark.streaming.dstream.DStream;
+import scala.Option$;
 
 /**
  * A Java API wrapper over {@link org.apache.spark.streaming.dstream.DStream} to provide Spark Cassandra Connector
@@ -38,6 +39,12 @@ public class DStreamJavaFunctions<T> extends RDDAndDStreamCommonJavaFunctions<T>
     @Override
     protected void saveToCassandra(String keyspace, String table, RowWriterFactory<T> rowWriterFactory,
                                    ColumnSelector columnNames, WriteConf conf, CassandraConnector connector) {
-        dsf.saveToCassandra(keyspace, table, columnNames, conf, connector, rowWriterFactory);
+        saveToCassandra(keyspace, table, null, rowWriterFactory, columnNames, conf, connector);
+    }
+
+    @Override
+    protected void saveToCassandra(String keyspace, String table, String cluster, RowWriterFactory<T> rowWriterFactory,
+                                   ColumnSelector columnNames, WriteConf conf, CassandraConnector connector) {
+        dsf.saveToCassandra(keyspace, table, columnNames, conf, Option$.MODULE$.apply(cluster), connector, rowWriterFactory);
     }
 }

--- a/spark-cassandra-connector-java/src/main/scala/com/datastax/spark/connector/japi/RDDJavaFunctions.scala
+++ b/spark-cassandra-connector-java/src/main/scala/com/datastax/spark/connector/japi/RDDJavaFunctions.scala
@@ -41,6 +41,17 @@ class RDDJavaFunctions[T](val rdd: RDD[T]) extends RDDAndDStreamCommonJavaFuncti
     rdd.saveToCassandra(keyspace, table, columnNames, conf)(connector, rowWriterFactory)
   }
 
+  override def saveToCassandra(keyspace: String,
+                               table: String,
+                               cluster: String,
+                               rowWriterFactory: RowWriterFactory[T],
+                               columnNames: ColumnSelector,
+                               conf: WriteConf,
+                               connector: CassandraConnector) = {
+
+    rdd.saveToCassandra(keyspace, table, columnNames, conf, Option(cluster))(connector, rowWriterFactory)
+  }
+
   /** Applies a function to each item, and groups consecutive items having the same value together.
     * Contrary to `groupBy`, items from the same group must be already next to each other in the
     * original collection. Works locally on each partition, so items from different

--- a/spark-cassandra-connector/src/it/resources/cassandra-second.yaml.template
+++ b/spark-cassandra-connector/src/it/resources/cassandra-second.yaml.template
@@ -1,0 +1,752 @@
+# Cassandra storage config YAML
+
+# NOTE:
+#   See http://wiki.apache.org/cassandra/StorageConfiguration for
+#   full explanations of configuration directives
+# /NOTE
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+cluster_name: 'Test Cluster2'
+
+# This defines the number of tokens randomly assigned to this node on the ring
+# The more tokens, relative to other nodes, the larger the proportion of data
+# that this node will store. You probably want all nodes to have the same number
+# of tokens assuming they have equal hardware capability.
+#
+# If you leave this unspecified, Cassandra will use the default of 1 token for legacy compatibility,
+# and will use the initial_token as described below.
+#
+# Specifying initial_token will override this setting on the node's initial start,
+# on subsequent starts, this setting will apply even if initial token is set.
+#
+# If you already have a cluster with 1 token per node, and wish to migrate to
+# multiple tokens per node, see http://wiki.apache.org/cassandra/Operations
+num_tokens: 256
+
+# initial_token allows you to specify tokens manually.  While you can use # it with
+# vnodes (num_tokens > 1, above) -- in which case you should provide a
+# comma-separated list -- it's primarily used when adding nodes # to legacy clusters
+# that do not have vnodes enabled.
+# initial_token:
+
+# See http://wiki.apache.org/cassandra/HintedHandoff
+# May either be "true" or "false" to enable globally, or contain a list
+# of data centers to enable per-datacenter.
+# hinted_handoff_enabled: DC1,DC2
+hinted_handoff_enabled: true
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
+max_hint_window_in_ms: 10800000 # 3 hours
+# Maximum throttle in KBs per second, per delivery thread.  This will be
+# reduced proportionally to the number of nodes in the cluster.  (If there
+# are two nodes in the cluster, each delivery thread will use the maximum
+# rate; if there are three, each will throttle to half of the maximum,
+# since we expect two nodes to be delivering hints simultaneously.)
+hinted_handoff_throttle_in_kb: 1024
+# Number of threads with which to deliver hints;
+# Consider increasing this number when you have multi-dc deployments, since
+# cross-dc handoff tends to be slower
+max_hints_delivery_threads: 2
+
+# Maximum throttle in KBs per second, total. This will be
+# reduced proportionally to the number of nodes in the cluster.
+batchlog_replay_throttle_in_kb: 1024
+
+# Authentication backend, implementing IAuthenticator; used to identify users
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+# PasswordAuthenticator}.
+#
+# - AllowAllAuthenticator performs no checks - set it to disable authentication.
+# - PasswordAuthenticator relies on username/password pairs to authenticate
+#   users. It keeps usernames and hashed passwords in system_auth.credentials table.
+#   Please increase system_auth keyspace replication factor if you use this authenticator.
+authenticator: AllowAllAuthenticator
+
+# Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+# CassandraAuthorizer}.
+#
+# - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+# - CassandraAuthorizer stores permissions in system_auth.permissions table. Please
+#   increase system_auth keyspace replication factor if you use this authorizer.
+authorizer: AllowAllAuthorizer
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 2000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+permissions_validity_in_ms: 2000
+
+# The partitioner is responsible for distributing groups of rows (by
+# partition key) across nodes in the cluster.  You should leave this
+# alone for new clusters.  The partitioner can NOT be changed without
+# reloading all data, so when upgrading you should set this to the
+# same partitioner you were already using.
+#
+# Besides Murmur3Partitioner, partitioners included for backwards
+# compatibility include RandomPartitioner, ByteOrderedPartitioner, and
+# OrderPreservingPartitioner.
+#
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+# Directories where Cassandra should store data on disk.  Cassandra
+# will spread data evenly across them, subject to the granularity of
+# the configured compaction strategy.
+# If not set, the default directory is $CASSANDRA_HOME/data/data.
+data_file_directories:
+     - ${cassandra_dir}/data
+
+# commit log.  when running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+# If not set, the default directory is $CASSANDRA_HOME/data/commitlog.
+commitlog_directory: ${cassandra_dir}/commitlog
+
+# policy for data disk failures:
+# stop_paranoid: shut down gossip and Thrift even for single-sstable errors.
+# stop: shut down gossip and Thrift, leaving the node effectively dead, but
+#       can still be inspected via JMX.
+# best_effort: stop using the failed disk and respond to requests based on
+#              remaining available sstables.  This means you WILL see obsolete
+#              data at CL.ONE!
+# ignore: ignore fatal errors and let requests fail, as in pre-1.2 Cassandra
+disk_failure_policy: stop
+
+# policy for commit disk failures:
+# stop: shut down gossip and Thrift, leaving the node effectively dead, but
+#       can still be inspected via JMX.
+# stop_commit: shutdown the commit log, letting writes collect but
+#              continuing to service reads, as in pre-2.0.5 Cassandra
+# ignore: ignore fatal errors and let the batches fail
+commit_failure_policy: stop
+
+# Maximum size of the key cache in memory.
+#
+# Each key cache hit saves 1 seek and each row cache hit saves 2 seeks at the
+# minimum, sometimes more. The key cache is fairly tiny for the amount of
+# time it saves, so it's worthwhile to use it at large numbers.
+# The row cache saves even more time, but must contain the entire row,
+# so it is extremely space-intensive. It's best to only use the
+# row cache if you have hot rows or static rows.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(5% of Heap (in MB), 100MB)). Set to 0 to disable key cache.
+key_cache_size_in_mb:
+
+# Duration in seconds after which Cassandra should
+# save the key cache. Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 14400 or 4 hours.
+key_cache_save_period: 14400
+
+# Number of keys from the key cache to save
+# Disabled by default, meaning all keys are going to be saved
+# key_cache_keys_to_save: 100
+
+# Maximum size of the row cache in memory.
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is 0, to disable row caching.
+row_cache_size_in_mb: 0
+
+# Duration in seconds after which Cassandra should
+# save the row cache. Caches are saved to saved_caches_directory as specified
+# in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 0 to disable saving the row cache.
+row_cache_save_period: 0
+
+# Number of keys from the row cache to save
+# Disabled by default, meaning all keys are going to be saved
+# row_cache_keys_to_save: 100
+
+# Maximum size of the counter cache in memory.
+#
+# Counter cache helps to reduce counter locks' contention for hot counter cells.
+# In case of RF = 1 a counter cache hit will cause Cassandra to skip the read before
+# write entirely. With RF > 1 a counter cache hit will still help to reduce the duration
+# of the lock hold, helping with hot counter cell updates, but will not allow skipping
+# the read entirely. Only the local (clock, count) tuple of a counter cell is kept
+# in memory, not the whole counter, so it's relatively cheap.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(2.5% of Heap (in MB), 50MB)). Set to 0 to disable counter cache.
+# NOTE: if you perform counter deletes and rely on low gcgs, you should disable the counter cache.
+counter_cache_size_in_mb:
+
+# Duration in seconds after which Cassandra should
+# save the counter cache (keys only). Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Default is 7200 or 2 hours.
+counter_cache_save_period: 7200
+
+# Number of keys from the counter cache to save
+# Disabled by default, meaning all keys are going to be saved
+# counter_cache_keys_to_save: 100
+
+# The off-heap memory allocator.  Affects storage engine metadata as
+# well as caches.  Experiments show that JEMAlloc saves some memory
+# than the native GCC allocator (i.e., JEMalloc is more
+# fragmentation-resistant).
+#
+# Supported values are: NativeAllocator, JEMallocAllocator
+#
+# If you intend to use JEMallocAllocator you have to install JEMalloc as library and
+# modify cassandra-env.sh as directed in the file.
+#
+# Defaults to NativeAllocator
+# memory_allocator: NativeAllocator
+
+# saved caches
+# If not set, the default directory is $CASSANDRA_HOME/data/saved_caches.
+saved_caches_directory: ${cassandra_dir}/saved_caches
+
+# commitlog_sync may be either "periodic" or "batch."
+# When in batch mode, Cassandra won't ack writes until the commit log
+# has been fsynced to disk.  It will wait up to
+# commitlog_sync_batch_window_in_ms milliseconds for other writes, before
+# performing the sync.
+#
+# commitlog_sync: batch
+# commitlog_sync_batch_window_in_ms: 50
+#
+# the other option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period_in_ms
+# milliseconds.  commitlog_periodic_queue_size allows 1024*(CPU cores) pending
+# entries on the commitlog queue by default.  If you are writing very large
+# blobs, you should reduce that; 16*cores works reasonably well for 1MB blobs.
+# It should be at least as large as the concurrent_writes setting.
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+# commitlog_periodic_queue_size:
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+commitlog_segment_size_in_mb: 32
+
+# any class that implements the SeedProvider interface and has a
+# constructor that takes a Map<String, String> of parameters will do.
+seed_provider:
+    # Addresses of hosts that are deemed contact points.
+    # Cassandra nodes use this list of hosts to find each other and learn
+    # the topology of the ring.  You must change this if you are running
+    # multiple nodes!
+    - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+      parameters:
+          # seeds is actually a comma-delimited list of addresses.
+          # Ex: "<ip1>,<ip2>,<ip3>"
+          - seeds: "127.0.0.2"
+
+# For workloads with more data than can fit in memory, Cassandra's
+# bottleneck will be reads that need to fetch data from
+# disk. "concurrent_reads" should be set to (16 * number_of_drives) in
+# order to allow the operations to enqueue low enough in the stack
+# that the OS and drives can reorder them. Same applies to
+# "concurrent_counter_writes", since counter writes read the current
+# values before incrementing and writing them back.
+#
+# On the other hand, since writes are almost never IO bound, the ideal
+# number of "concurrent_writes" is dependent on the number of cores in
+# your system; (8 * number_of_cores) is a good rule of thumb.
+concurrent_reads: 32
+concurrent_writes: 32
+concurrent_counter_writes: 32
+
+# Total memory to use for sstable-reading buffers.  Defaults to
+# the smaller of 1/4 of heap or 512MB.
+# file_cache_size_in_mb: 512
+
+# Total permitted memory to use for memtables. Cassandra will stop
+# accepting writes when the limit is exceeded until a flush completes,
+# and will trigger a flush based on memtable_cleanup_threshold
+# If omitted, Cassandra will set both to 1/4 the size of the heap.
+# memtable_heap_space_in_mb: 2048
+# memtable_offheap_space_in_mb: 2048
+
+# Ratio of occupied non-flushing memtable size to total permitted size
+# that will trigger a flush of the largest memtable.  Lager mct will
+# mean larger flushes and hence less compaction, but also less concurrent
+# flush activity which can make it difficult to keep your disks fed
+# under heavy write load.
+#
+# memtable_cleanup_threshold defaults to 1 / (memtable_flush_writers + 1)
+# memtable_cleanup_threshold: 0.11
+
+# Specify the way Cassandra allocates and manages memtable memory.
+# Options are:
+#   heap_buffers:    on heap nio buffers
+#   offheap_buffers: off heap (direct) nio buffers
+#   offheap_objects: native memory, eliminating nio buffer heap overhead
+memtable_allocation_type: heap_buffers
+
+# Total space to use for commitlogs.  Since commitlog segments are
+# mmapped, and hence use up address space, the default size is 32
+# on 32-bit JVMs, and 8192 on 64-bit JVMs.
+#
+# If space gets above this value (it will round up to the next nearest
+# segment multiple), Cassandra will flush every dirty CF in the oldest
+# segment and remove it.  So a small total commitlog space will tend
+# to cause more flush activity on less-active columnfamilies.
+# commitlog_total_space_in_mb: 8192
+
+# This sets the amount of memtable flush writer threads.  These will
+# be blocked by disk io, and each one will hold a memtable in memory
+# while blocked.
+#
+# memtable_flush_writers defaults to the smaller of (number of disks,
+# number of cores), with a minimum of 2 and a maximum of 8.
+#
+# If your data directories are backed by SSD, you should increase this
+# to the number of cores.
+#memtable_flush_writers: 8
+
+# A fixed memory pool size in MB for for SSTable index summaries. If left
+# empty, this will default to 5% of the heap size. If the memory usage of
+# all index summaries exceeds this limit, SSTables with low read rates will
+# shrink their index summaries in order to meet this limit.  However, this
+# is a best-effort process. In extreme conditions Cassandra may need to use
+# more than this amount of memory.
+index_summary_capacity_in_mb:
+
+# How frequently index summaries should be resampled.  This is done
+# periodically to redistribute memory from the fixed-size pool to sstables
+# proportional their recent read rates.  Setting to -1 will disable this
+# process, leaving existing index summaries at their current sampling level.
+index_summary_resize_interval_in_minutes: 60
+
+# Whether to, when doing sequential writing, fsync() at intervals in
+# order to force the operating system to flush the dirty
+# buffers. Enable this to avoid sudden dirty buffer flushing from
+# impacting read latencies. Almost always a good idea on SSDs; not
+# necessarily on platters.
+trickle_fsync: false
+trickle_fsync_interval_in_kb: 10240
+
+# TCP port, for commands and data
+storage_port: 7010
+
+# SSL port, for encrypted communication.  Unused unless enabled in
+# encryption_options
+ssl_storage_port: 7011
+
+# Address to bind to and tell other Cassandra nodes to connect to. You
+# _must_ change this if you want multiple nodes to be able to
+# communicate!
+#
+# Leaving it blank leaves it up to InetAddress.getLocalHost(). This
+# will always do the Right Thing _if_ the node is properly configured
+# (hostname, name resolution, etc), and the Right Thing is to use the
+# address associated with the hostname (it might not be).
+#
+# Setting this to 0.0.0.0 is always wrong.
+listen_address: 127.0.0.2
+
+# Address to broadcast to other Cassandra nodes
+# Leaving this blank will set it to the same value as listen_address
+# broadcast_address: 1.2.3.4
+
+# Internode authentication backend, implementing IInternodeAuthenticator;
+# used to allow/disallow connections from peer nodes.
+# internode_authenticator: org.apache.cassandra.auth.AllowAllInternodeAuthenticator
+
+# Whether to start the native transport server.
+# Please note that the address on which the native transport is bound is the
+# same as the rpc_address. The port however is different and specified below.
+start_native_transport: true
+# port for the CQL native transport to listen for clients on
+native_transport_port: 9043
+# The maximum threads for handling requests when the native transport is used.
+# This is similar to rpc_max_threads though the default differs slightly (and
+# there is no native_transport_min_threads, idle threads will always be stopped
+# after 30 seconds).
+# native_transport_max_threads: 128
+#
+# The maximum size of allowed frame. Frame (requests) larger than this will
+# be rejected as invalid. The default is 256MB.
+# native_transport_max_frame_size_in_mb: 256
+
+# Whether to start the thrift rpc server.
+start_rpc: true
+
+# The address to bind the Thrift RPC service and native transport
+# server to.
+#
+# Leaving this blank has the same effect as on listen_address
+# (i.e. it will be based on the configured hostname of the node).
+#
+# Note that unlike listen_address, you can specify 0.0.0.0, but you must also
+# set broadcast_rpc_address to a value other than 0.0.0.0.
+rpc_address: 127.0.0.2
+# port for Thrift to listen for clients on
+rpc_port: 9161
+
+# RPC address to broadcast to drivers and other Cassandra nodes. This cannot
+# be set to 0.0.0.0. If left blank, this will be set to the value of
+# rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
+# be set.
+# broadcast_rpc_address: 1.2.3.4
+
+# enable or disable keepalive on rpc/native connections
+rpc_keepalive: true
+
+# Cassandra provides two out-of-the-box options for the RPC Server:
+#
+# sync  -> One thread per thrift connection. For a very large number of clients, memory
+#          will be your limiting factor. On a 64 bit JVM, 180KB is the minimum stack size
+#          per thread, and that will correspond to your use of virtual memory (but physical memory
+#          may be limited depending on use of stack space).
+#
+# hsha  -> Stands for "half synchronous, half asynchronous." All thrift clients are handled
+#          asynchronously using a small number of threads that does not vary with the amount
+#          of thrift clients (and thus scales well to many clients). The rpc requests are still
+#          synchronous (one thread per active request).
+#
+# The default is sync because on Windows hsha is about 30% slower.  On Linux,
+# sync/hsha performance is about the same, with hsha of course using less memory.
+#
+# Alternatively,  can provide your own RPC server by providing the fully-qualified class name
+# of an o.a.c.t.TServerFactory that can create an instance of it.
+rpc_server_type: sync
+
+# Uncomment rpc_min|max_thread to set request pool size limits.
+#
+# Regardless of your choice of RPC server (see above), the number of maximum requests in the
+# RPC thread pool dictates how many concurrent requests are possible (but if you are using the sync
+# RPC server, it also dictates the number of clients that can be connected at all).
+#
+# The default is unlimited and thus provides no protection against clients overwhelming the server. You are
+# encouraged to set a maximum that makes sense for you in production, but do keep in mind that
+# rpc_max_threads represents the maximum number of client requests this server may execute concurrently.
+#
+# rpc_min_threads: 16
+# rpc_max_threads: 2048
+
+# uncomment to set socket buffer sizes on rpc connections
+# rpc_send_buff_size_in_bytes:
+# rpc_recv_buff_size_in_bytes:
+
+# Uncomment to set socket buffer size for internode communication
+# Note that when setting this, the buffer size is limited by net.core.wmem_max
+# and when not setting it it is defined by net.ipv4.tcp_wmem
+# See:
+# /proc/sys/net/core/wmem_max
+# /proc/sys/net/core/rmem_max
+# /proc/sys/net/ipv4/tcp_wmem
+# /proc/sys/net/ipv4/tcp_wmem
+# and: man tcp
+# internode_send_buff_size_in_bytes:
+# internode_recv_buff_size_in_bytes:
+
+# Frame size for thrift (maximum message length).
+thrift_framed_transport_size_in_mb: 15
+
+# Set to true to have Cassandra create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# keyspace data.  Removing these links is the operator's
+# responsibility.
+incremental_backups: false
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Cassandra won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+snapshot_before_compaction: false
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: true
+
+# When executing a scan, within or across a partition, we need to keep the
+# tombstones seen in memory so we can return them to the coordinator, which
+# will use them to make sure other replicas also know about the deleted rows.
+# With workloads that generate a lot of tombstones, this can cause performance
+# problems and even exaust the server heap.
+# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# Adjust the thresholds here if you understand the dangers and want to
+# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
+# using the StorageService mbean.
+tombstone_warn_threshold: 1000
+tombstone_failure_threshold: 100000
+
+# Granularity of the collation index of rows within a partition.
+# Increase if your rows are large, or if you have a very large
+# number of rows per partition.  The competing goals are these:
+#   1) a smaller granularity means more index entries are generated
+#      and looking up rows withing the partition by collation column
+#      is faster
+#   2) but, Cassandra will keep the collation index in memory for hot
+#      rows (as part of the key cache), so a larger granularity means
+#      you can cache more hot rows
+column_index_size_in_kb: 64
+
+
+# Log WARN on any batch size exceeding this value. 5kb per batch by default.
+# Caution should be taken on increasing the size of this threshold as it can lead to node instability.
+batch_size_warn_threshold_in_kb: 5
+
+# Number of simultaneous compactions to allow, NOT including
+# validation "compactions" for anti-entropy repair.  Simultaneous
+# compactions can help preserve read performance in a mixed read/write
+# workload, by mitigating the tendency of small sstables to accumulate
+# during a single long running compactions. The default is usually
+# fine and if you experience problems with compaction running too
+# slowly or too fast, you should look at
+# compaction_throughput_mb_per_sec first.
+#
+# concurrent_compactors defaults to the smaller of (number of disks,
+# number of cores), with a minimum of 2 and a maximum of 8.
+#
+# If your data directories are backed by SSD, you should increase this
+# to the number of cores.
+#concurrent_compactors: 1
+
+# Throttles compaction to the given total throughput across the entire
+# system. The faster you insert data, the faster you need to compact in
+# order to keep the sstable count down, but in general, setting this to
+# 16 to 32 times the rate you are inserting data is more than sufficient.
+# Setting this to 0 disables throttling. Note that this account for all types
+# of compaction, including validation compaction.
+compaction_throughput_mb_per_sec: 16
+
+# When compacting, the replacement sstable(s) can be opened before they
+# are completely written, and used in place of the prior sstables for
+# any range that has been written. This helps to smoothly transfer reads
+# between the sstables, reducing page cache churn and keeping hot rows hot
+sstable_preemptive_open_interval_in_mb: 50
+
+# Throttles all outbound streaming file transfers on this node to the
+# given total throughput in Mbps. This is necessary because Cassandra does
+# mostly sequential IO when streaming data during bootstrap or repair, which
+# can lead to saturating the network connection and degrading rpc performance.
+# When unset, the default is 200 Mbps or 25 MB/s.
+# stream_throughput_outbound_megabits_per_sec: 200
+
+# Throttles all streaming file transfer between the datacenters,
+# this setting allows users to throttle inter dc stream throughput in addition
+# to throttling all network stream traffic as configured with
+# stream_throughput_outbound_megabits_per_sec
+# inter_dc_stream_throughput_outbound_megabits_per_sec:
+
+# How long the coordinator should wait for read operations to complete
+read_request_timeout_in_ms: 5000
+# How long the coordinator should wait for seq or index scans to complete
+range_request_timeout_in_ms: 10000
+# How long the coordinator should wait for writes to complete
+write_request_timeout_in_ms: 2000
+# How long the coordinator should wait for counter writes to complete
+counter_write_request_timeout_in_ms: 5000
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+cas_contention_timeout_in_ms: 1000
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+truncate_request_timeout_in_ms: 60000
+# The default timeout for other, miscellaneous operations
+request_timeout_in_ms: 10000
+
+# Enable operation timeout information exchange between nodes to accurately
+# measure request timeouts.  If disabled, replicas will assume that requests
+# were forwarded to them instantly by the coordinator, which means that
+# under overload conditions we will waste that much extra time processing
+# already-timed-out requests.
+#
+# Warning: before enabling this property make sure to ntp is installed
+# and the times are synchronized between the nodes.
+cross_node_timeout: false
+
+# Enable socket timeout for streaming operation.
+# When a timeout occurs during streaming, streaming is retried from the start
+# of the current file. This _can_ involve re-streaming an important amount of
+# data, so you should avoid setting the value too low.
+# Default value is 0, which never timeout streams.
+# streaming_socket_timeout_in_ms: 0
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+
+# endpoint_snitch -- Set this to a class that implements
+# IEndpointSnitch.  The snitch has two functions:
+# - it teaches Cassandra enough about your network topology to route
+#   requests efficiently
+# - it allows Cassandra to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Cassandra will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# IF YOU CHANGE THE SNITCH AFTER DATA IS INSERTED INTO THE CLUSTER,
+# YOU MUST RUN A FULL REPAIR, SINCE THE SNITCH AFFECTS WHERE REPLICAS
+# ARE PLACED.
+#
+# Out of the box, Cassandra provides
+#  - SimpleSnitch:
+#    Treats Strategy order as proximity. This can improve cache
+#    locality when disabling read repair.  Only appropriate for
+#    single-datacenter deployments.
+#  - GossipingPropertyFileSnitch
+#    This should be your go-to snitch for production use.  The rack
+#    and datacenter for the local node are defined in
+#    cassandra-rackdc.properties and propagated to other nodes via
+#    gossip.  If cassandra-topology.properties exists, it is used as a
+#    fallback, allowing migration from the PropertyFileSnitch.
+#  - PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#  - Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region. Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#  - Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Cassandra will switch to the private IP after
+#    establishing a connection.)
+#  - RackInferringSnitch:
+#    Proximity is determined by rack and data center, which are
+#    assumed to correspond to the 3rd and 2nd octet of each node's IP
+#    address, respectively.  Unless this happens to match your
+#    deployment conventions, this is best used as an example of
+#    writing a custom Snitch class and is provided in that spirit.
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+endpoint_snitch: SimpleSnitch
+
+# controls how often to perform the more expensive part of host score
+# calculation
+dynamic_snitch_update_interval_in_ms: 100
+# controls how often to reset all host scores, allowing a bad host to
+# possibly recover
+dynamic_snitch_reset_interval_in_ms: 600000
+# if set greater than zero and read_repair_chance is < 1.0, this will allow
+# 'pinning' of replicas to hosts in order to increase cache capacity.
+# The badness threshold will control how much worse the pinned host has to be
+# before the dynamic snitch will prefer other replicas over it.  This is
+# expressed as a double which represents a percentage.  Thus, a value of
+# 0.2 means Cassandra would continue to prefer the static snitch values
+# until the pinned host was 20% worse than the fastest.
+dynamic_snitch_badness_threshold: 0.1
+
+# request_scheduler -- Set this to a class that implements
+# RequestScheduler, which will schedule incoming client requests
+# according to the specific policy. This is useful for multi-tenancy
+# with a single Cassandra cluster.
+# NOTE: This is specifically for requests from the client and does
+# not affect inter node communication.
+# org.apache.cassandra.scheduler.NoScheduler - No scheduling takes place
+# org.apache.cassandra.scheduler.RoundRobinScheduler - Round robin of
+# client requests to a node with a separate queue for each
+# request_scheduler_id. The scheduler is further customized by
+# request_scheduler_options as described below.
+request_scheduler: org.apache.cassandra.scheduler.NoScheduler
+
+# Scheduler Options vary based on the type of scheduler
+# NoScheduler - Has no options
+# RoundRobin
+#  - throttle_limit -- The throttle_limit is the number of in-flight
+#                      requests per client.  Requests beyond
+#                      that limit are queued up until
+#                      running requests can complete.
+#                      The value of 80 here is twice the number of
+#                      concurrent_reads + concurrent_writes.
+#  - default_weight -- default_weight is optional and allows for
+#                      overriding the default which is 1.
+#  - weights -- Weights are optional and will default to 1 or the
+#               overridden default_weight. The weight translates into how
+#               many requests are handled during each turn of the
+#               RoundRobin, based on the scheduler id.
+#
+# request_scheduler_options:
+#    throttle_limit: 80
+#    default_weight: 5
+#    weights:
+#      Keyspace1: 1
+#      Keyspace2: 5
+
+# request_scheduler_id -- An identifier based on which to perform
+# the request scheduling. Currently the only valid option is keyspace.
+# request_scheduler_id: keyspace
+
+# Enable or disable inter-node encryption
+# Default settings are TLS v1, RSA 1024-bit keys (it is imperative that
+# users generate their own keys) TLS_RSA_WITH_AES_128_CBC_SHA as the cipher
+# suite for authentication, key exchange and encryption of the actual data transfers.
+# Use the DHE/ECDHE ciphers if running in FIPS 140 compliant mode.
+# NOTE: No custom encryption options are enabled at the moment
+# The available internode options are : all, none, dc, rack
+#
+# If set to dc cassandra will encrypt the traffic between the DCs
+# If set to rack cassandra will encrypt the traffic between the racks
+#
+# The passwords used in these options must match the passwords used when generating
+# the keystore and truststore.  For instructions on generating these files, see:
+# http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
+#
+server_encryption_options:
+    internode_encryption: none
+    keystore: conf/.keystore
+    keystore_password: cassandra
+    truststore: conf/.truststore
+    truststore_password: cassandra
+    # More advanced defaults below:
+    # protocol: TLS
+    # algorithm: SunX509
+    # store_type: JKS
+    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
+    # require_client_auth: false
+
+# enable or disable client/server encryption.
+client_encryption_options:
+    enabled: false
+    keystore: conf/.keystore
+    keystore_password: cassandra
+    # require_client_auth: false
+    # Set trustore and truststore_password if require_client_auth is true
+    # truststore: conf/.truststore
+    # truststore_password: cassandra
+    # More advanced defaults below:
+    # protocol: TLS
+    # algorithm: SunX509
+    # store_type: JKS
+    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
+
+# internode_compression controls whether traffic between nodes is
+# compressed.
+# can be:  all  - all traffic is compressed
+#          dc   - traffic between different datacenters is compressed
+#          none - nothing is compressed.
+internode_compression: all
+
+# Enable or disable tcp_nodelay for inter-dc communication.
+# Disabling it will result in larger (but fewer) network packets being sent,
+# reducing overhead from the TCP protocol itself, at the cost of increasing
+# latency if you block for cross-datacenter responses.
+inter_dc_tcp_nodelay: false

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/SparkCassandraITSpecBase.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/SparkCassandraITSpecBase.scala
@@ -1,0 +1,22 @@
+package com.datastax.spark.connector
+
+import com.datastax.spark.connector.embedded.{SecondEmbeddedCassandra, SparkTemplate}
+import com.datastax.spark.connector.testkit.SharedEmbeddedCassandra
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.cassandra.CassandraSQLContext
+import org.scalatest.{Matchers, FlatSpec, ConfigMap, BeforeAndAfterAll}
+
+
+trait SparkCassandraITSpecBase extends FlatSpec with Matchers with SharedEmbeddedCassandra with SparkTemplate with BeforeAndAfterAll {
+  var sc: SparkContext = null
+
+  override def beforeAll(configMap: ConfigMap) {
+    sc = new SparkContext(conf)
+  }
+
+  override def afterAll(configMap: ConfigMap) {
+    if (sc != null) {
+      sc.stop()
+    }
+  }
+}

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraPartitionKeyWhereSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraPartitionKeyWhereSpec.scala
@@ -5,7 +5,7 @@ import com.datastax.spark.connector.testkit.SharedEmbeddedCassandra
 import com.datastax.spark.connector.embedded._
 import org.scalatest.{FlatSpec, Matchers}
 
-class CassandraPartitionKeyWhereSpec extends FlatSpec with Matchers with SharedEmbeddedCassandra with SparkTemplate {
+class CassandraPartitionKeyWhereSpec extends SparkCassandraITSpecBase {
 
   useCassandraConfig("cassandra-default.yaml.template")
   val conn = CassandraConnector(Set(cassandraHost))

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -32,7 +32,7 @@ class MutableKeyValueWithConversion(var key: String, var group: Int) extends Ser
   var value: Long = 0L
 }
 
-class CassandraRDDSpec extends FlatSpec with Matchers with SharedEmbeddedCassandra with SparkTemplate {
+class CassandraRDDSpec extends SparkCassandraITSpecBase {
 
   useCassandraConfig("cassandra-default.yaml.template")
   val conn = CassandraConnector(Set(cassandraHost))

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/repl/CassandraRDDReplSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/repl/CassandraRDDReplSpec.scala
@@ -1,11 +1,12 @@
 package com.datastax.spark.connector.repl
 
+import com.datastax.spark.connector.SparkCassandraITSpecBase
 import com.datastax.spark.connector.testkit.SharedEmbeddedCassandra
 import org.scalatest.{FlatSpec, Matchers}
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.embedded._
 
-class CassandraRDDReplSpec extends FlatSpec with Matchers with SharedEmbeddedCassandra with SparkTemplate with SparkRepl {
+class CassandraRDDReplSpec extends SparkCassandraITSpecBase with SparkRepl {
   useCassandraConfig("cassandra-default.yaml.template")
 
   val conn = CassandraConnector(Set(cassandraHost))

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLClusterLevelJoinSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLClusterLevelJoinSpec.scala
@@ -44,10 +44,17 @@ class CassandraSQLClusterLevelJoinSpec extends FlatSpec with Matchers with Share
     session.execute("INSERT INTO sql_test2.test2 (a, d, e) VALUES (6, 1, 6)")
     session.execute("INSERT INTO sql_test2.test2 (a, d, e) VALUES (4, 1, 4)")
     session.execute("INSERT INTO sql_test2.test2 (a, d, e) VALUES (5, 1, 5)")
+    session.execute("CREATE TABLE IF NOT EXISTS sql_test2.test3 (a INT PRIMARY KEY, d INT, e INT)")
   }
 
   it should "allow to join tables from different clusters" in {
     val result = cc.sql("SELECT * FROM cluster1.sql_test1.test1 AS test1 Join cluster2.sql_test2.test2 AS test2 where test1.a=test2.a").collect()
     result should have length 2
+  }
+
+  it should "allow to write data to another cluster" in {
+    val insert = cc.sql("INSERT INTO cluster2.sql_test2.test3 SELECT * FROM cluster1.sql_test1.test1 AS t1").collect()
+    val result = cc.sql("SELECT * FROM cluster2.sql_test2.test3 AS test3").collect()
+    result should have length 5
   }
 }

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLClusterLevelJoinSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLClusterLevelJoinSpec.scala
@@ -1,8 +1,53 @@
 package com.datastax.spark.connector.sql
 
-/**
- * Created by alex on 3/2/15.
- */
-class CassandraSQLClusterLevelJoinSpec {
+import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.embedded.{EmbeddedCassandra, SecondEmbeddedCassandra, SparkTemplate}
+import com.datastax.spark.connector.testkit.SharedEmbeddedCassandra
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.cassandra.CassandraSQLContext
+import org.scalatest.{Matchers, FlatSpec}
 
+class CassandraSQLClusterLevelJoinSpec extends FlatSpec with Matchers with SharedEmbeddedCassandra with SecondEmbeddedCassandra with SparkTemplate {
+  useCassandraConfig("cassandra-default.yaml.template")
+  val conn = CassandraConnector(Set(cassandraHost))
+  conf.set("spark.cluster1.cassandra.connection.host", EmbeddedCassandra.cassandraHost.getHostAddress)
+    .set("spark.cluster1.cassandra.connection.native.port", "9042")
+    .set("spark.cluster1.cassandra.connection.rpc.port", "9160")
+    .set("spark.cluster2.cassandra.connection.host", SecondEmbeddedCassandra.cassandraHost.getHostAddress)
+    .set("spark.cluster2.cassandra.connection.native.port", "9043")
+    .set("spark.cluster2.cassandra.connection.rpc.port", "9161")
+    .set("spark.driver.allowMultipleContexts", "true")
+  val sparkContext = new SparkContext(conf)
+  val cc = new CassandraSQLContext(sparkContext)
+
+  conn.withSessionDo { session =>
+    session.execute("CREATE KEYSPACE IF NOT EXISTS sql_test1 WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }")
+
+    session.execute("CREATE TABLE IF NOT EXISTS sql_test1.test1 (a INT PRIMARY KEY, b INT, c INT)")
+    session.execute("USE sql_test1")
+    session.execute("INSERT INTO sql_test1.test1 (a, b, c) VALUES (1, 1, 1)")
+    session.execute("INSERT INTO sql_test1.test1 (a, b, c) VALUES (2, 1, 2)")
+    session.execute("INSERT INTO sql_test1.test1 (a, b, c) VALUES (3, 1, 3)")
+    session.execute("INSERT INTO sql_test1.test1 (a, b, c) VALUES (4, 1, 4)")
+    session.execute("INSERT INTO sql_test1.test1 (a, b, c) VALUES (5, 1, 5)")
+  }
+
+  useCassandraConfig2("cassandra-second.yaml.template")
+  val conn2 = CassandraConnector(Set(cassandraHost2), 9043)
+  conn2.withSessionDo { session =>
+    session.execute("CREATE KEYSPACE IF NOT EXISTS sql_test2 WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }")
+
+    session.execute("CREATE TABLE IF NOT EXISTS sql_test2.test2 (a INT PRIMARY KEY, d INT, e INT)")
+    session.execute("USE sql_test2")
+    session.execute("INSERT INTO sql_test2.test2 (a, d, e) VALUES (8, 1, 8)")
+    session.execute("INSERT INTO sql_test2.test2 (a, d, e) VALUES (7, 1, 7)")
+    session.execute("INSERT INTO sql_test2.test2 (a, d, e) VALUES (6, 1, 6)")
+    session.execute("INSERT INTO sql_test2.test2 (a, d, e) VALUES (4, 1, 4)")
+    session.execute("INSERT INTO sql_test2.test2 (a, d, e) VALUES (5, 1, 5)")
+  }
+
+  it should "allow to join tables from different clusters" in {
+    val result = cc.sql("SELECT * FROM cluster1.sql_test1.test1 AS test1 Join cluster2.sql_test2.test2 AS test2 where test1.a=test2.a").collect()
+    result should have length 2
+  }
 }

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLClusterLevelJoinSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLClusterLevelJoinSpec.scala
@@ -1,0 +1,8 @@
+package com.datastax.spark.connector.sql
+
+/**
+ * Created by alex on 3/2/15.
+ */
+class CassandraSQLClusterLevelJoinSpec {
+
+}

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterColumnNamesSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterColumnNamesSpec.scala
@@ -5,8 +5,10 @@ import com.datastax.spark.connector.{SomeColumns, AllColumns}
 import com.datastax.spark.connector.testkit._
 import com.datastax.spark.connector.embedded._
 import com.datastax.spark.connector._
+import org.apache.spark.SparkContext
+import org.scalatest.{BeforeAndAfterAll, ConfigMap}
 
-class TableWriterColumnNamesSpec extends AbstractSpec with SharedEmbeddedCassandra with SparkTemplate {
+class TableWriterColumnNamesSpec extends AbstractSpec with SharedEmbeddedCassandra with SparkTemplate with BeforeAndAfterAll {
 
   useCassandraConfig("cassandra-default.yaml.template")
   val conn = CassandraConnector(Set(cassandraHost))
@@ -18,6 +20,18 @@ class TableWriterColumnNamesSpec extends AbstractSpec with SharedEmbeddedCassand
       session.execute("CREATE KEYSPACE IF NOT EXISTS column_names_test WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }")
       session.execute("CREATE TABLE IF NOT EXISTS column_names_test.key_value (key INT, group BIGINT, value TEXT, PRIMARY KEY (key, group))")
       session.execute("TRUNCATE column_names_test.key_value")
+    }
+  }
+
+  var sc: SparkContext = null
+
+  override def beforeAll(configMap: ConfigMap) {
+    sc = new SparkContext(conf)
+  }
+
+  override def afterAll(configMap: ConfigMap) {
+    if (sc != null) {
+      sc.stop()
     }
   }
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
@@ -21,7 +21,7 @@ case class KeyValueWithTimestamp(key: Int, group: Long, value: String, timestamp
 case class KeyValueWithConversion(key: String, group: Int, value: String)
 case class CustomerId(id: String)
 
-class TableWriterSpec extends FlatSpec with Matchers with BeforeAndAfter with SharedEmbeddedCassandra with SparkTemplate {
+class TableWriterSpec extends SparkCassandraITSpecBase with BeforeAndAfter {
 
   useCassandraConfig("cassandra-default.yaml.template")
   val conn = CassandraConnector(Set(cassandraHost))

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/SparkContextFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/SparkContextFunctions.scala
@@ -43,17 +43,17 @@ class SparkContextFunctions(@transient val sc: SparkContext) extends Serializabl
     *   rdd3.first.word  // foo
     *   rdd3.first.count // 20
     * }}}*/
-  def cassandraTable[T](keyspace: String, table: String)
-                       (implicit connector: CassandraConnector = CassandraConnector(sc.getConf),
+  def cassandraTable[T](keyspace: String, table: String, cluster: Option[String] = None)
+                       (implicit connector: CassandraConnector = CassandraConnector(sc.getConf, cluster),
                         ct: ClassTag[T], rrf: RowReaderFactory[T],
                         ev: ValidRDDType[T]) =
-    new CassandraRDD[T](sc, connector, keyspace, table, readConf = ReadConf.fromSparkConf(sc.getConf))
+    new CassandraRDD[T](sc, connector, keyspace, table, readConf = ReadConf.fromSparkConf(sc.getConf, cluster))
 
   /** Produces the empty CassandraRDD which does not perform any validation and it does not even
     * try to return any rows. */
-  def emptyCassandraTable[T](keyspace: String, table: String)
-                            (implicit connector: CassandraConnector = CassandraConnector(sc.getConf),
+  def emptyCassandraTable[T](keyspace: String, table: String, cluster: Option[String] = None)
+                            (implicit connector: CassandraConnector = CassandraConnector(sc.getConf, cluster),
                              ct: ClassTag[T], rrf: RowReaderFactory[T],
                              ev: ValidRDDType[T]) =
-    new CassandraRDD[T](sc, connector, keyspace, table, readConf = ReadConf.fromSparkConf(sc.getConf), empty = true)
+    new CassandraRDD[T](sc, connector, keyspace, table, readConf = ReadConf.fromSparkConf(sc.getConf, cluster), empty = true)
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/AuthConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/AuthConf.scala
@@ -63,9 +63,9 @@ object DefaultAuthConfFactory extends AuthConfFactory {
 object AuthConf {
   val AuthConfFactoryProperty = "spark.cassandra.auth.conf.factory"
 
-  def fromSparkConf(conf: SparkConf) = {
+  def fromSparkConf(conf: SparkConf, cluster: Option[String]) = {
     val authConfFactory = conf
-      .getOption(AuthConfFactoryProperty)
+      .getOption(CassandraConnectorConf.processProperty(AuthConfFactoryProperty, cluster))
       .map(ReflectionUtil.findGlobalObject[AuthConfFactory])
       .getOrElse(DefaultAuthConfFactory)
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
@@ -83,11 +83,8 @@ object CassandraConnectionFactory {
   val ConnectionFactoryProperty = "spark.cassandra.connection.factory"
 
   def fromSparkConf(conf: SparkConf, cluster: Option[String] = None): CassandraConnectionFactory = {
-    val factory = cluster match {
-      case Some(c) => conf.getOption("spark." + c + ".cassandra.connection.factory")
-      case None    => conf.getOption(ConnectionFactoryProperty)
-    }
-    factory.map(ReflectionUtil.findGlobalObject[CassandraConnectionFactory])
+    conf.getOption(CassandraConnectorConf.processProperty(ConnectionFactoryProperty, cluster))
+      .map(ReflectionUtil.findGlobalObject[CassandraConnectionFactory])
       .getOrElse(DefaultConnectionFactory)
   }
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
@@ -82,9 +82,12 @@ object DefaultConnectionFactory extends CassandraConnectionFactory {
 object CassandraConnectionFactory {
   val ConnectionFactoryProperty = "spark.cassandra.connection.factory"
 
-  def fromSparkConf(conf: SparkConf): CassandraConnectionFactory = {
-    conf.getOption(ConnectionFactoryProperty)
-      .map(ReflectionUtil.findGlobalObject[CassandraConnectionFactory])
+  def fromSparkConf(conf: SparkConf, cluster: Option[String] = None): CassandraConnectionFactory = {
+    val factory = cluster match {
+      case Some(c) => conf.getOption("spark." + c + ".cassandra.connection.factory")
+      case None    => conf.getOption(ConnectionFactoryProperty)
+    }
+    factory.map(ReflectionUtil.findGlobalObject[CassandraConnectionFactory])
       .getOrElse(DefaultConnectionFactory)
   }
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
@@ -197,6 +197,11 @@ object CassandraConnector extends Logging {
   }))
 
   /** Returns a CassandraConnector created from properties found in the `SparkConf` object */
+  def apply(conf: SparkConf, cluster: Option[String]): CassandraConnector = {
+    new CassandraConnector(CassandraConnectorConf(conf, cluster))
+  }
+
+  /** Returns a CassandraConnector created from properties found in the `SparkConf` object */
   def apply(conf: SparkConf): CassandraConnector = {
     new CassandraConnector(CassandraConnectorConf(conf))
   }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -60,9 +60,9 @@ object CassandraConnectorConf extends Logging {
     }
   }
 
-  private def processProperty(property: String, cluster: Option[String] = None): String = {
+  def processProperty(property: String, cluster: Option[String] = None): String = {
     cluster match {
-      case Some(c) => property.replaceFirst("spark.cassandra", "spark." + c + ".cassandra")
+      case Some(c) => property.replaceFirst("spark.cassandra", s"spark.$c.cassandra")
       case None => property
     }
   }
@@ -80,7 +80,7 @@ object CassandraConnectorConf extends Logging {
 
     val rpcPort = conf.getInt(processProperty(CassandraConnectionRpcPortProperty, cluster), DefaultRpcPort)
     val nativePort = conf.getInt(processProperty(CassandraConnectionNativePortProperty, cluster), DefaultNativePort)
-    val authConf = AuthConf.fromSparkConf(conf)
+    val authConf = AuthConf.fromSparkConf(conf, cluster)
     val keepAlive = conf.getInt(processProperty(CassandraConnectionKeepAliveProperty, cluster), DefaultKeepAliveMillis)
     
     val localDC = conf.getOption(processProperty(CassandraConnectionLocalDCProperty, cluster))

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -60,26 +60,37 @@ object CassandraConnectorConf extends Logging {
     }
   }
 
-  def apply(conf: SparkConf): CassandraConnectorConf = {
-    val hostsStr = conf.get(CassandraConnectionHostProperty, InetAddress.getLocalHost.getHostAddress)
+  private def processProperty(property: String, cluster: Option[String] = None): String = {
+    cluster match {
+      case Some(c) => property.replaceFirst("spark.cassandra", "spark." + c + ".cassandra")
+      case None => property
+    }
+  }
+
+  def apply(conf: SparkConf): CassandraConnectorConf = getCassandraConnectorConf(conf, None)
+
+  def apply(conf: SparkConf, cluster: Option[String]): CassandraConnectorConf = getCassandraConnectorConf(conf, cluster)
+
+  def getCassandraConnectorConf(conf: SparkConf, cluster: Option[String]): CassandraConnectorConf = {
+    val hostsStr = conf.get(processProperty(CassandraConnectionHostProperty, cluster), InetAddress.getLocalHost.getHostAddress)
     val hosts = for {
       hostName <- hostsStr.split(",").toSet[String]
       hostAddress <- resolveHost(hostName)
     } yield hostAddress
 
-    val rpcPort = conf.getInt(CassandraConnectionRpcPortProperty, DefaultRpcPort)
-    val nativePort = conf.getInt(CassandraConnectionNativePortProperty, DefaultNativePort)
+    val rpcPort = conf.getInt(processProperty(CassandraConnectionRpcPortProperty, cluster), DefaultRpcPort)
+    val nativePort = conf.getInt(processProperty(CassandraConnectionNativePortProperty, cluster), DefaultNativePort)
     val authConf = AuthConf.fromSparkConf(conf)
-    val keepAlive = conf.getInt(CassandraConnectionKeepAliveProperty, DefaultKeepAliveMillis)
+    val keepAlive = conf.getInt(processProperty(CassandraConnectionKeepAliveProperty, cluster), DefaultKeepAliveMillis)
     
-    val localDC = conf.getOption(CassandraConnectionLocalDCProperty)
-    val minReconnectionDelay = conf.getInt(CassandraMinReconnectionDelayProperty, DefaultMinReconnectionDelayMillis)
-    val maxReconnectionDelay = conf.getInt(CassandraMaxReconnectionDelayProperty, DefaultMaxReconnectionDelayMillis)
-    val queryRetryCount = conf.getInt(CassandraQueryRetryCountProperty, DefaultQueryRetryCount)
-    val connectTimeout = conf.getInt(CassandraConnectionTimeoutProperty, DefaultConnectTimeoutMillis)
-    val readTimeout = conf.getInt(CassandraReadTimeoutProperty, DefaultReadTimeoutMillis)
+    val localDC = conf.getOption(processProperty(CassandraConnectionLocalDCProperty, cluster))
+    val minReconnectionDelay = conf.getInt(processProperty(CassandraMinReconnectionDelayProperty, cluster), DefaultMinReconnectionDelayMillis)
+    val maxReconnectionDelay = conf.getInt(processProperty(CassandraMaxReconnectionDelayProperty, cluster), DefaultMaxReconnectionDelayMillis)
+    val queryRetryCount = conf.getInt(processProperty(CassandraQueryRetryCountProperty, cluster), DefaultQueryRetryCount)
+    val connectTimeout = conf.getInt(processProperty(CassandraConnectionTimeoutProperty, cluster), DefaultConnectTimeoutMillis)
+    val readTimeout = conf.getInt(processProperty(CassandraReadTimeoutProperty, cluster), DefaultReadTimeoutMillis)
 
-    val connectionFactory = CassandraConnectionFactory.fromSparkConf(conf)
+    val connectionFactory = CassandraConnectionFactory.fromSparkConf(conf, cluster)
 
     CassandraConnectorConf(
       hosts = hosts,

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
@@ -440,4 +440,14 @@ object CassandraRDD {
                  (implicit keyCT: ClassTag[K], valueCT: ClassTag[V], rrf: RowReaderFactory[(K, V)]): CassandraRDD[(K, V)] =
     new CassandraRDD[(K, V)](
       sc, CassandraConnector(sc.getConf), keyspaceName, tableName, AllColumns, CqlWhereClause.empty)
+
+  def apply[T](sc: SparkContext, keyspaceName: String, tableName: String, cluster: String)
+              (implicit ct: ClassTag[T], rrf: RowReaderFactory[T]): CassandraRDD[T] =
+    new CassandraRDD[T](
+      sc, CassandraConnector(sc.getConf, Option(cluster)), keyspaceName, tableName, AllColumns, CqlWhereClause.empty)
+
+  def apply[K, V](sc: SparkContext, keyspaceName: String, tableName: String, cluster: String)
+                 (implicit keyCT: ClassTag[K], valueCT: ClassTag[V], rrf: RowReaderFactory[(K, V)]): CassandraRDD[(K, V)] =
+    new CassandraRDD[(K, V)](
+      sc, CassandraConnector(sc.getConf, Option(cluster)), keyspaceName, tableName, AllColumns, CqlWhereClause.empty)
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
@@ -21,14 +21,25 @@ object ReadConf {
   val DefaultFetchSize = 1000
   val DefaultConsistencyLevel = ConsistencyLevel.LOCAL_ONE
 
-  def fromSparkConf(conf: SparkConf): ReadConf = {
-    ReadConf(
-      fetchSize = conf.getInt("spark.cassandra.input.page.row.size", DefaultFetchSize),
-      splitSize = conf.getInt("spark.cassandra.input.split.size", DefaultSplitSize),
-      consistencyLevel = ConsistencyLevel.valueOf(
-        conf.get("spark.cassandra.input.consistency.level", DefaultConsistencyLevel.name()))
-    )
-  }
+  def fromSparkConf(conf: SparkConf, cluster: Option[String] = None): ReadConf = {
+    cluster match {
+      case Some(c) =>
+        val clusterName = cluster.get
+        ReadConf(
+          fetchSize = conf.getInt("spark." + clusterName + ".cassandra.input.page.row.size", DefaultFetchSize),
+          splitSize = conf.getInt("spark." + clusterName + ".cassandra.input.split.size", DefaultSplitSize),
+          consistencyLevel = ConsistencyLevel.valueOf(
+            conf.get("spark." + clusterName + ".cassandra.input.consistency.level", DefaultConsistencyLevel.name()))
+        )
+      case None =>
+        ReadConf(
+          fetchSize = conf.getInt("spark.cassandra.input.page.row.size", DefaultFetchSize),
+          splitSize = conf.getInt("spark.cassandra.input.split.size", DefaultSplitSize),
+          consistencyLevel = ConsistencyLevel.valueOf(
+            conf.get("spark.cassandra.input.consistency.level", DefaultConsistencyLevel.name()))
+        )
+    }
 
+  }
 }
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
@@ -1,5 +1,6 @@
 package com.datastax.spark.connector.rdd
 
+import com.datastax.spark.connector.cql.CassandraConnectorConf
 import org.apache.spark.SparkConf
 
 import com.datastax.driver.core.ConsistencyLevel
@@ -22,24 +23,12 @@ object ReadConf {
   val DefaultConsistencyLevel = ConsistencyLevel.LOCAL_ONE
 
   def fromSparkConf(conf: SparkConf, cluster: Option[String] = None): ReadConf = {
-    cluster match {
-      case Some(c) =>
-        val clusterName = cluster.get
-        ReadConf(
-          fetchSize = conf.getInt("spark." + clusterName + ".cassandra.input.page.row.size", DefaultFetchSize),
-          splitSize = conf.getInt("spark." + clusterName + ".cassandra.input.split.size", DefaultSplitSize),
-          consistencyLevel = ConsistencyLevel.valueOf(
-            conf.get("spark." + clusterName + ".cassandra.input.consistency.level", DefaultConsistencyLevel.name()))
-        )
-      case None =>
-        ReadConf(
-          fetchSize = conf.getInt("spark.cassandra.input.page.row.size", DefaultFetchSize),
-          splitSize = conf.getInt("spark.cassandra.input.split.size", DefaultSplitSize),
-          consistencyLevel = ConsistencyLevel.valueOf(
-            conf.get("spark.cassandra.input.consistency.level", DefaultConsistencyLevel.name()))
-        )
-    }
-
+    ReadConf(
+      fetchSize = conf.getInt(CassandraConnectorConf.processProperty("spark.cassandra.input.page.row.size", cluster), DefaultFetchSize),
+      splitSize = conf.getInt(CassandraConnectorConf.processProperty("spark.cassandra.input.split.size", cluster), DefaultSplitSize),
+      consistencyLevel = ConsistencyLevel.valueOf(
+        conf.get(CassandraConnectorConf.processProperty("spark.cassandra.input.consistency.level", cluster), DefaultConsistencyLevel.name()))
+    )
   }
 }
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/StreamingContextFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/StreamingContextFunctions.scala
@@ -17,14 +17,14 @@ import scala.reflect.ClassTag
 class StreamingContextFunctions (ssc: StreamingContext) extends SparkContextFunctions(ssc.sparkContext) {
   import scala.reflect.ClassTag
 
-  override def cassandraTable[T](keyspace: String, table: String)(
+  override def cassandraTable[T](keyspace: String, table: String, cluster: Option[String] = None)(
     implicit
-      connector: CassandraConnector = CassandraConnector(ssc.sparkContext.getConf),
+      connector: CassandraConnector = CassandraConnector(ssc.sparkContext.getConf, cluster),
       ct: ClassTag[T],
       rrf: RowReaderFactory[T],
       ev: ValidRDDType[T]): CassandraStreamingRDD[T] = {
 
-    val readConf = ReadConf.fromSparkConf(ssc.sparkContext.getConf)
+    val readConf = ReadConf.fromSparkConf(ssc.sparkContext.getConf, cluster)
     new CassandraStreamingRDD[T](ssc, connector, keyspace, table, readConf = readConf)
   }
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WritableToCassandra.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WritableToCassandra.scala
@@ -39,12 +39,13 @@ abstract class WritableToCassandra[T] {
    * @param columnNames The list of column names to save data to.
    *                Uses only the unique column names, and you must select at least all primary key
    *                columns. All other fields are discarded. Non-selected property/column names are left unchanged.
-   * @param writeConf additional configuration object allowing to set consistency level, batch size, etc.
+   * @param clusterName the name of the Cluster to use
    */
   def saveToCassandra(keyspaceName: String,
                       tableName: String,
                       columnNames: ColumnSelector,
-                      writeConf: WriteConf)
+                      writeConf: WriteConf,
+                      clusterName: Option[String])
                      (implicit connector: CassandraConnector, rwf: RowWriterFactory[T])
 
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
@@ -1,7 +1,7 @@
 package com.datastax.spark.connector.writer
 
 import com.datastax.driver.core.{ConsistencyLevel, DataType}
-import com.datastax.spark.connector.cql.{ColumnDef, RegularColumn}
+import com.datastax.spark.connector.cql.{CassandraConnectorConf, ColumnDef, RegularColumn}
 import com.datastax.spark.connector.types.ColumnType
 import com.datastax.spark.connector.{BatchSize, BytesInBatch, RowsInBatch}
 import org.apache.commons.configuration.ConfigurationException
@@ -55,16 +55,16 @@ object WriteConf {
   val DefaultBatchLevel = BatchLevel.Partition
   val DefaultThroughputMiBPS = Int.MaxValue
 
-  def fromSparkConf(conf: SparkConf): WriteConf = {
+  def fromSparkConf(conf: SparkConf, cluster: Option[String]): WriteConf = {
 
     val batchSizeInBytes = conf.getInt(
-      "spark.cassandra.output.batch.size.bytes", DefaultBatchSizeInBytes)
+      CassandraConnectorConf.processProperty("spark.cassandra.output.batch.size.bytes", cluster), DefaultBatchSizeInBytes)
 
     val consistencyLevel = ConsistencyLevel.valueOf(
-      conf.get("spark.cassandra.output.consistency.level", DefaultConsistencyLevel.name()))
+      conf.get(CassandraConnectorConf.processProperty("spark.cassandra.output.consistency.level", cluster), DefaultConsistencyLevel.name()))
 
     val batchSizeInRowsStr = conf.get(
-      "spark.cassandra.output.batch.size.rows", "auto")
+      CassandraConnectorConf.processProperty("spark.cassandra.output.batch.size.rows", cluster), "auto")
 
     val batchSize = {
       val Number = "([0-9]+)".r
@@ -78,16 +78,16 @@ object WriteConf {
     }
 
     val batchBufferSize = conf.getInt(
-      "spark.cassandra.output.batch.buffer.size", DefaultBatchBufferSize)
+      CassandraConnectorConf.processProperty("spark.cassandra.output.batch.buffer.size", cluster), DefaultBatchBufferSize)
 
     val batchLevel = conf.getOption(
-      "spark.cassandra.output.batch.level").map(BatchLevel.apply).getOrElse(DefaultBatchLevel)
+      CassandraConnectorConf.processProperty("spark.cassandra.output.batch.level", cluster)).map(BatchLevel.apply).getOrElse(DefaultBatchLevel)
 
     val parallelismLevel = conf.getInt(
-      "spark.cassandra.output.concurrent.writes", DefaultParallelismLevel)
+      CassandraConnectorConf.processProperty("spark.cassandra.output.concurrent.writes", cluster), DefaultParallelismLevel)
 
     val throughputMiBPS = conf.getInt(
-      "spark.cassandra.output.throughput_mb_per_sec", DefaultThroughputMiBPS)
+      CassandraConnectorConf.processProperty("spark.cassandra.output.throughput_mb_per_sec", cluster), DefaultThroughputMiBPS)
 
     WriteConf(
       batchSize = batchSize,

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraCatalog.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraCatalog.scala
@@ -18,7 +18,8 @@ private[cassandra] class CassandraCatalog(cc: CassandraSQLContext) extends Catal
        .build(
           new CacheLoader[String, Schema] {
             def load(cluster: String) : Schema = {
-              Schema.fromCassandra(CassandraConnector(cc.conf))
+              val clusterOpt = toOption(cluster)
+              Schema.fromCassandra(CassandraConnector(cc.conf, clusterOpt))
             }
           })
 
@@ -27,8 +28,16 @@ private[cassandra] class CassandraCatalog(cc: CassandraSQLContext) extends Catal
     val schema = schemas.get(cluster)
     val keyspaceDef = schema.keyspaceByName.getOrElse(database, throw new IOException(s"Keyspace not found: $database"))
     val tableDef = keyspaceDef.tableByName.getOrElse(table, throw new IOException(s"Table not found: $database.$table"))
-    val tableWithQualifiers = Subquery(table, CassandraRelation(tableDef, alias)(cc))
+    val clusterOpt = toOption(cluster)
+    val tableWithQualifiers = Subquery(table, CassandraRelation(tableDef, alias, clusterOpt)(cc))
     alias.map(a => Subquery(a, tableWithQualifiers)).getOrElse(tableWithQualifiers)
+  }
+
+  private def toOption(cluster: String): Option[String] = {
+    cluster match {
+      case "default" => None
+      case _         => Option(cluster)
+    }
   }
 
   private def getClusterDBTableNames(tableIdentifier: Seq[String]): (String, String, String) = {

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraRelation.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraRelation.scala
@@ -9,7 +9,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{Statistics, LeafNode}
 import org.apache.spark.sql.{StructField, catalyst}
 
 private[cassandra] case class CassandraRelation
-  (tableDef: TableDef, alias: Option[String])(@transient cc: CassandraSQLContext)
+  (tableDef: TableDef, alias: Option[String], cluster: Option[String] = None)(@transient cc: CassandraSQLContext)
   extends LeafNode {
 
   val keyspaceName          = tableDef.keyspaceName

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraTableScan.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraTableScan.scala
@@ -18,8 +18,7 @@ case class CassandraTableScan(
 
   private def inputRdd = {
     logInfo(s"attributes : ${attributes.map(_.name).mkString(",")}")
-    //TODO: cluster level CassandraConnector, read configuration settings
-    var rdd = context.sparkContext.cassandraTable[CassandraSQLRow](relation.keyspaceName, relation.tableName)
+    var rdd = context.sparkContext.cassandraTable[CassandraSQLRow](relation.keyspaceName, relation.tableName, relation.cluster)
     if (attributes.map(_.name).size > 0)
       rdd = rdd.select(attributes.map(a => relation.columnNameByLowercase(a.name): NamedColumnRef): _*)
     if (pushdownPred.nonEmpty) {

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/InsertIntoCassandraTable.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/InsertIntoCassandraTable.scala
@@ -2,7 +2,7 @@ package org.apache.spark.sql.cassandra
 
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql.CassandraConnector
-import com.datastax.spark.connector.writer.SqlRowWriter
+import com.datastax.spark.connector.writer.{WriteConf, SqlRowWriter}
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Row}
@@ -29,8 +29,9 @@ case class InsertIntoCassandraTable(cassandraRelation: CassandraRelation,
   private lazy val result: RDD[Row] = {
     val childRdd = child.execute()
 
-    //TODO: cluster level CassandraConnector, write configuration settings
-    childRdd.saveToCassandra(cassandraRelation.keyspaceName, cassandraRelation.tableName)(CassandraConnector(sparkContext.getConf), SqlRowWriter.Factory)
+    childRdd.saveToCassandra(cassandraRelation.keyspaceName, cassandraRelation.tableName,
+      AllColumns, WriteConf.fromSparkConf(sparkContext.getConf, None), None)(
+        CassandraConnector(sparkContext.getConf, cassandraRelation.cluster), SqlRowWriter.Factory)
 
     cc.sparkContext.makeRDD(Nil, 1)
   }

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/WriteConfTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/WriteConfTest.scala
@@ -9,7 +9,7 @@ class WriteConfTest extends FlatSpec with Matchers {
 
   "WriteConf" should "be configured with proper defaults" in {
     val conf = new SparkConf(false)
-    val writeConf = WriteConf.fromSparkConf(conf)
+    val writeConf = WriteConf.fromSparkConf(conf, None)
 
     writeConf.batchSize should be(BytesInBatch(WriteConf.DefaultBatchSizeInBytes))
     writeConf.consistencyLevel should be(WriteConf.DefaultConsistencyLevel)
@@ -19,7 +19,7 @@ class WriteConfTest extends FlatSpec with Matchers {
   it should "allow to set consistency level" in {
     val conf = new SparkConf(false)
       .set("spark.cassandra.output.consistency.level", "THREE")
-    val writeConf = WriteConf.fromSparkConf(conf)
+    val writeConf = WriteConf.fromSparkConf(conf, None)
 
     writeConf.consistencyLevel should be(ConsistencyLevel.THREE)
   }
@@ -27,7 +27,7 @@ class WriteConfTest extends FlatSpec with Matchers {
   it should "allow to set parallelism level" in {
     val conf = new SparkConf(false)
       .set("spark.cassandra.output.concurrent.writes", "17")
-    val writeConf = WriteConf.fromSparkConf(conf)
+    val writeConf = WriteConf.fromSparkConf(conf, None)
 
     writeConf.parallelismLevel should be(17)
   }
@@ -35,7 +35,7 @@ class WriteConfTest extends FlatSpec with Matchers {
   it should "allow to set batch size in bytes" in {
     val conf = new SparkConf(false)
       .set("spark.cassandra.output.batch.size.bytes", "12345")
-    val writeConf = WriteConf.fromSparkConf(conf)
+    val writeConf = WriteConf.fromSparkConf(conf, None)
 
     writeConf.batchSize should be(BytesInBatch(12345))
   }
@@ -44,7 +44,7 @@ class WriteConfTest extends FlatSpec with Matchers {
     val conf = new SparkConf(false)
       .set("spark.cassandra.output.batch.size.bytes", "12345")
       .set("spark.cassandra.output.batch.size.rows", "auto")
-    val writeConf = WriteConf.fromSparkConf(conf)
+    val writeConf = WriteConf.fromSparkConf(conf, None)
 
     writeConf.batchSize should be(BytesInBatch(12345))
   }
@@ -52,7 +52,7 @@ class WriteConfTest extends FlatSpec with Matchers {
   it should "allow to set batch size in rows" in {
     val conf = new SparkConf(false)
       .set("spark.cassandra.output.batch.size.rows", "12345")
-    val writeConf = WriteConf.fromSparkConf(conf)
+    val writeConf = WriteConf.fromSparkConf(conf, None)
 
     writeConf.batchSize should be(RowsInBatch(12345))
   }


### PR DESCRIPTION
For integration tests, set 127.0.0.2 as a loopback alias address.