### PR TITLE
SPARKC-70: Fixed reading and writing objects with inherited fields

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,7 @@
  * Added support for passing the limit clause to CQL in order to fetch top n results (SPARKC-31)
  * Added support for pushing down order by clause for explicitly specifying an order of rows within
    Cassandra partition (SPARKC-32)
+ * Fixed problems when rows are mapped to classes with inherited fields (SPARKC-70)
 
 1.2.0 alpha 2
  * All connection properties can be set on SparkConf / CassandraConnectorConf objects and

--- a/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaRDDSpec.scala
+++ b/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaRDDSpec.scala
@@ -41,6 +41,11 @@ with ShouldMatchers with SharedEmbeddedCassandra with SparkTemplate {
     session.execute("INSERT INTO java_api_test.test_table2 (some_key, some_value) VALUES (2, 'two')")
     session.execute("INSERT INTO java_api_test.test_table2 (some_key, some_value) VALUES (3, null)")
 
+    session.execute("CREATE TABLE java_api_test.test_table3 (key INT, value TEXT, sub_class_field TEXT, PRIMARY KEY (key))")
+    session.execute("INSERT INTO java_api_test.test_table3 (key, value, sub_class_field) VALUES (1, 'one', 'a')")
+    session.execute("INSERT INTO java_api_test.test_table3 (key, value, sub_class_field) VALUES (2, 'two', 'b')")
+    session.execute("INSERT INTO java_api_test.test_table3 (key, value, sub_class_field) VALUES (3,  null, 'c')")
+
     session.execute("CREATE TABLE IF NOT EXISTS java_api_test.collections (key INT PRIMARY KEY, l list<text>, s set<text>, m map<text, text>)")
     session.execute("INSERT INTO java_api_test.collections (key, l, s, m) VALUES (1, ['item1', 'item2'], {'item1', 'item2'}, {'key1': 'value1', 'key2': 'value2'})")
     session.execute("INSERT INTO java_api_test.collections (key, l, s, m) VALUES (2, null, null, null)")
@@ -68,6 +73,14 @@ with ShouldMatchers with SharedEmbeddedCassandra with SparkTemplate {
     assert(beans.exists(bean ⇒ bean.getValue == "one" && bean.getKey == 1))
     assert(beans.exists(bean ⇒ bean.getValue == "two" && bean.getKey == 2))
     assert(beans.exists(bean ⇒ bean.getValue == null && bean.getKey == 3))
+  }
+
+  it should "allow to read data as Java beans with inherited fields" in {
+    val beans = javaFunctions(sc).cassandraTable("java_api_test", "test_table3", mapRowTo(classOf[SampleJavaBeanSubClass])).collect()
+    assert(beans.size == 3)
+    assert(beans.exists(bean ⇒ bean.getValue == "one" && bean.getKey == 1 && bean.getSubClassField == "a"))
+    assert(beans.exists(bean ⇒ bean.getValue == "two" && bean.getKey == 2 && bean.getSubClassField == "b"))
+    assert(beans.exists(bean ⇒ bean.getValue == null && bean.getKey == 3 && bean.getSubClassField == "c"))
   }
 
   it should "allow to read data as Java beans (with multiple constructors)" in {

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -32,6 +32,15 @@ class MutableKeyValueWithConversion(var key: String, var group: Int) extends Ser
   var value: Long = 0L
 }
 
+class SuperKeyValue extends Serializable {
+  var key: Int = 0
+  var value: String = ""
+}
+
+class SubKeyValue extends SuperKeyValue {
+  var group: Long = 0L
+}
+
 class CassandraRDDSpec extends FlatSpec with Matchers with SharedEmbeddedCassandra with SparkTemplate {
 
   useCassandraConfig("cassandra-default.yaml.template")
@@ -113,6 +122,16 @@ class CassandraRDDSpec extends FlatSpec with Matchers with SharedEmbeddedCassand
     result.head.key should (be >= 1 and be <= 3)
     result.head.group should (be >= 100L and be <= 300L)
     result.head.value should startWith("000")
+  }
+
+  "A CassandraRDD" should "allow to read a Cassandra table as Array of user-defined objects with inherited fields" in {
+    val result = sc.cassandraTable[SubKeyValue]("read_test", "key_value").collect()
+    result should have length 3
+    result.map(kv => (kv.key, kv.group, kv.value)).toSet shouldBe Set(
+      (1, 100, "0001"),
+      (2, 100, "0002"),
+      (3, 300, "0003")
+    )
   }
 
   it should "allow to read a Cassandra table as Array of user-defined class objects" in {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/ClassBasedRowReader.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/ClassBasedRowReader.scala
@@ -30,8 +30,11 @@ class ClassBasedRowReader[R : TypeTag : ColumnMapper](table: TableDef, skipColum
   @transient
   private val setterTypes: Map[String, Type] = {
     def argType(name: String) = {
-      val methodSymbol = tpe.declaration(newTermName(name)).asMethod
-      methodSymbol.typeSignatureIn(tpe).asInstanceOf[MethodType].params(0).typeSignature
+      val symbol = tpe.member(newTermName(name))
+      if (symbol.isMethod)
+        symbol.asMethod.typeSignatureIn(tpe).asInstanceOf[MethodType].params(0).typeSignature
+      else
+        throw new IllegalArgumentException(s"The provided type $tpe does not implement the method $name")
     }
     columnMap.setters.keys.map(name => (name, argType(name))).toMap
   }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/ReflectionUtil.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/ReflectionUtil.scala
@@ -77,9 +77,9 @@ object ReflectionUtil {
 
   /** Returns a list of names and return types of 0-argument public methods of a Scala type */
   def getters(tpe: Type): Seq[(String, Type)] = TypeTag.synchronized {
-    val methods = for (d <- tpe.declarations.toSeq if d.isMethod && d.isPublic) yield d.asMethod
+    val methods = for (d <- tpe.members.toSeq if d.isMethod && d.isPublic) yield d.asMethod
     val getters = for (m <- methods if m.paramss.size == 0 && m.typeParams.size == 0) yield m
-    for (g <- getters) yield {
+    for (g <- getters if g.isGetter) yield {
       // the reason we're using typeSignatureIn is because the getter might be a generic type
       // and we don't really want to get generic type here, but a concrete one:
       val returnType = g.typeSignatureIn(tpe).asInstanceOf[NullaryMethodType].resultType
@@ -94,9 +94,9 @@ object ReflectionUtil {
   /** Returns a list of names and parameter types of 1-argument public methods of a Scala type,
     * returning no result (Unit) */
   def setters(tpe: Type): Seq[(String, Type)] = TypeTag.synchronized {
-    val methods = for (d <- tpe.declarations.toSeq if d.isMethod && d.isPublic) yield d.asMethod
+    val methods = for (d <- tpe.members.toSeq if d.isMethod && d.isPublic) yield d.asMethod
     val setters = for (m <- methods if m.paramss.size == 1 && m.paramss(0).size == 1 && m.returnType =:= typeOf[Unit]) yield m
-    for (s <- setters) yield {
+    for (s <- setters if s.isSetter) yield {
       // need a concrete type, not a generic one:
       val paramType = s.typeSignatureIn(tpe).asInstanceOf[MethodType].params(0).typeSignature
       (s.name.toString, paramType)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/ReflectionUtil.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/ReflectionUtil.scala
@@ -78,8 +78,7 @@ object ReflectionUtil {
   /** Returns a list of names and return types of 0-argument public methods of a Scala type */
   def getters(tpe: Type): Seq[(String, Type)] = TypeTag.synchronized {
     val methods = for (d <- tpe.members.toSeq if d.isMethod && d.isPublic) yield d.asMethod
-    val getters = for (m <- methods if m.paramss.size == 0 && m.typeParams.size == 0) yield m
-    for (g <- getters if g.isGetter) yield {
+    for (g <- methods if g.isGetter) yield {
       // the reason we're using typeSignatureIn is because the getter might be a generic type
       // and we don't really want to get generic type here, but a concrete one:
       val returnType = g.typeSignatureIn(tpe).asInstanceOf[NullaryMethodType].resultType
@@ -95,8 +94,7 @@ object ReflectionUtil {
     * returning no result (Unit) */
   def setters(tpe: Type): Seq[(String, Type)] = TypeTag.synchronized {
     val methods = for (d <- tpe.members.toSeq if d.isMethod && d.isPublic) yield d.asMethod
-    val setters = for (m <- methods if m.paramss.size == 1 && m.paramss(0).size == 1 && m.returnType =:= typeOf[Unit]) yield m
-    for (s <- setters if s.isSetter) yield {
+    for (s <- methods if s.isSetter) yield {
       // need a concrete type, not a generic one:
       val paramType = s.typeSignatureIn(tpe).asInstanceOf[MethodType].params(0).typeSignature
       (s.name.toString, paramType)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/DefaultRowWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/DefaultRowWriter.scala
@@ -41,7 +41,7 @@ class DefaultRowWriter[T : ColumnMapper](table: TableDef, selectedColumns: Seq[S
     val missingPrimaryKeyColumns = primaryKeyColumnNames.toSet -- columnNames
     if (missingPrimaryKeyColumns.nonEmpty)
       throw new IllegalArgumentException(
-        s"Some primary key columns are missing in RDD or have not been selected: ${missingPrimaryKeyColumns.mkString(", ")}")
+        s"Some primary key columns are missing in RDD or have not been selected: ${missingPrimaryKeyColumns.mkString(", ")} (required primary key columns are: $primaryKeyColumnNames and all columns are $columnNames, table is: $table)")
   }
 
   private def columnNameByRef(columnRef: ColumnRef): Option[String] = {

--- a/spark-cassandra-connector/src/test/java/com/datastax/spark/connector/SampleJavaBeanSubClass.java
+++ b/spark-cassandra-connector/src/test/java/com/datastax/spark/connector/SampleJavaBeanSubClass.java
@@ -1,0 +1,28 @@
+package com.datastax.spark.connector;
+
+/**
+ * This is a sample JavaBean style class/subclass. In order to test JavaAPI correctly, we cannot
+ * implement this in Scala because Scala adds some additional accessors and mutators.
+ */
+public class SampleJavaBeanSubClass extends SampleJavaBean
+{
+    private String subClassField;
+
+    public static SampleJavaBeanSubClass newInstance(Integer key, String value, String subClassField) {
+        SampleJavaBeanSubClass bean = new SampleJavaBeanSubClass();
+        bean.setKey(key);
+        bean.setValue(value);
+        bean.setSubClassField(subClassField);
+        return bean;
+    }
+
+    public String getSubClassField()
+    {
+        return subClassField;
+    }
+
+    public void setSubClassField(String subClassField)
+    {
+        this.subClassField = subClassField;
+    }
+}

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/util/ReflectionUtilSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/util/ReflectionUtilSpec.scala
@@ -70,22 +70,22 @@ class ReflectionUtilSpec extends FlatSpec with Matchers {
   private class ClassWithGetters(val arg1: Int, val arg2: List[String])
 
   "ReflectionUtil.getters" should "return getter names and types" in {
-    val getters = ReflectionUtil.getters[ClassWithGetters]
+    val getters = ReflectionUtil.getters[ClassWithGetters].toMap
     getters should have size 2
-    getters(0)._1 should be("arg1")
-    getters(1)._1 should be("arg2")
-    assert(getters(0)._2 =:= typeOf[Int])
-    assert(getters(1)._2 =:= typeOf[List[String]])
+    getters.keySet should contain ("arg1")
+    getters.keySet should contain ("arg2")
+    assert(getters("arg1") =:= typeOf[Int])
+    assert(getters("arg2") =:= typeOf[List[String]])
   }
 
   private class ClassWithSetters(var arg1: Int, var arg2: List[String])
 
   "ReflectionUtil.setters" should "return setter names and types" in {
-    val setters = ReflectionUtil.setters[ClassWithSetters]
+    val setters = ReflectionUtil.setters[ClassWithSetters].toMap
     setters should have size 2
-    setters(0)._1 should be("arg1_$eq")
-    setters(1)._1 should be("arg2_$eq")
-    assert(setters(0)._2 =:= typeOf[Int])
-    assert(setters(1)._2 =:= typeOf[List[String]])
+    setters.keySet should contain ("arg1_$eq")
+    setters.keySet should contain ("arg2_$eq")
+    assert(setters("arg1_$eq") =:= typeOf[Int])
+    assert(setters("arg2_$eq") =:= typeOf[List[String]])
   }
 }

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/util/ReflectionUtilSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/util/ReflectionUtilSpec.scala
@@ -67,7 +67,11 @@ class ReflectionUtilSpec extends FlatSpec with Matchers {
     assert(params(1)._2 =:= typeOf[List[String]])
   }
 
-  private class ClassWithGetters(val arg1: Int, val arg2: List[String])
+  private class ClassWithGetters(val arg1: Int, val arg2: List[String]) {
+    def getterLikeMethod: String = null
+
+    def otherMethod(x: String): String = null
+  }
 
   "ReflectionUtil.getters" should "return getter names and types" in {
     val getters = ReflectionUtil.getters[ClassWithGetters].toMap
@@ -78,7 +82,11 @@ class ReflectionUtilSpec extends FlatSpec with Matchers {
     assert(getters("arg2") =:= typeOf[List[String]])
   }
 
-  private class ClassWithSetters(var arg1: Int, var arg2: List[String])
+  private class ClassWithSetters(var arg1: Int, var arg2: List[String]) {
+    def setterLikeMethod_=(x: String): Unit = {}
+
+    def otherMethod(x: String): Unit = {}
+  }
 
   "ReflectionUtil.setters" should "return setter names and types" in {
     val setters = ReflectionUtil.setters[ClassWithSetters].toMap


### PR DESCRIPTION
With this patch:
- Added test cases for CassandraRDD, TableWriter, CassandraJavaRDD and CassandraJavaUtil
- Updted test cases in ReflectionUtilSpec
- Fixed ClassBasedRowReader, DefaultRowWriter and ReflectionUtils so that they use member methods rather than declared methods