### PR TITLE
sbt-spark-package plugin addition

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -20,8 +20,11 @@ import scala.language.postfixOps
 import sbt._
 import sbt.Keys._
 import sbtrelease.ReleasePlugin._
-import sbtassembly.Plugin._
-import AssemblyKeys._
+import sbtassembly._
+import sbtassembly.AssemblyPlugin._
+import sbtassembly.AssemblyKeys._
+import sbtsparkpackage.SparkPackagePlugin._
+import sbtsparkpackage.SparkPackagePlugin.autoImport._
 import com.typesafe.tools.mima.plugin.MimaKeys._
 import com.typesafe.tools.mima.plugin.MimaPlugin._
 import com.typesafe.sbt.SbtScalariform
@@ -47,6 +50,8 @@ object Settings extends Build {
     normalizedName := "spark-cassandra-connector",
     name := "DataStax Apache Cassandra connector for Apache Spark",
     organization := "com.datastax.spark",
+    sparkPackageName := "datastax/spark-cassandra-connector",
+    sparkVersion := Versions.Spark,
     description  := """
                   |A library that exposes Cassandra tables as Spark RDDs, writes Spark RDDs to
                   |Cassandra tables, and executes CQL queries in Spark applications.""".stringPrefix,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
 addSbtPlugin("com.scalapenos" % "sbt-prompt" % "0.2.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+
+resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages/maven"
+
+addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.1.1")


### PR DESCRIPTION
Using the sbt-spark-package plugin, you can make an official release on the Spark Packages Repo by easily creating the release artifact. Simply run:
```scala
sbt/sbt spark-cassandra-connector/spDist
```
You will find the zip archive in `$CASSANDRA/spark-cassandra-connector/target/`

With the 0.2 release (which should be out by next monday March 16, 2015), you will be able to make a release by simply
```scala
sbt/sbt spark-cassandra-connector/spPublish
```
Please refer to the README at https://github.com/databricks/sbt-spark-package
on more information on what more to configure once the 0.2 release is out.