### PR TITLE
SPARKC-84: Rename batch.level to batch.grouping.key. Rename batch.buffer...

### DIFF
--- a/doc/5_saving.md
+++ b/doc/5_saving.md
@@ -120,9 +120,9 @@ The following properties set in `SparkConf` can be used to fine-tune the saving 
   - `spark.cassandra.output.batch.size.rows`: number of rows per single batch; default is 'auto' which means the connector 
      will adjust the number of rows based on the amount of data in each row  
   - `spark.cassandra.output.batch.size.bytes`: maximum total size of the batch in bytes; defaults to 16 kB.
-  - `spark.cassandra.output.batch.level`: determines how insert statements are grouped into batches; available values are:
-     - `all`: all statements are appended to a single batch until it reaches its maximum size
-     - `replicaset`: a batch may contain only statements to be written to the same replica set
+  - `spark.cassandra.output.batch.grouping.key`: determines how insert statements are grouped into batches; available values are:
+     - `none`: a batch may contain any statements
+     - `replica_set`: a batch may contain only statements to be written to the same replica set
      - `partition` (default): a batch may contain only statements for rows sharing the same partition key value
   - `spark.cassandra.output.batch.buffer.size`: how many batches per single Spark task can be stored in memory before sending to Cassandra; default 1000
   - `spark.cassandra.output.concurrent.writes`: maximum number of batches executed in parallel by a single Spark task; defaults to 5

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/CassandraJavaUtil.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/CassandraJavaUtil.java
@@ -15,7 +15,6 @@ import com.datastax.spark.connector.SomeColumns$;
 import com.datastax.spark.connector.TTL;
 import com.datastax.spark.connector.WriteTime;
 import com.datastax.spark.connector.cql.CassandraConnector;
-import com.datastax.spark.connector.mapper.*;
 import com.datastax.spark.connector.mapper.ColumnMapper;
 import com.datastax.spark.connector.rdd.reader.ClassBasedRowReaderFactory;
 import com.datastax.spark.connector.rdd.reader.RowReaderFactory;
@@ -23,7 +22,7 @@ import com.datastax.spark.connector.rdd.reader.ValueRowReaderFactory;
 import com.datastax.spark.connector.types.TypeConverter;
 import com.datastax.spark.connector.types.TypeConverter$;
 import com.datastax.spark.connector.util.JavaApiHelper;
-import com.datastax.spark.connector.writer.BatchLevel;
+import com.datastax.spark.connector.writer.BatchGroupingKey;
 import com.datastax.spark.connector.writer.RowWriterFactory;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -450,9 +449,9 @@ public class CassandraJavaUtil {
         return BytesInBatch$.MODULE$.apply(batchSizeInBytes);
     }
 
-    public static final BatchLevel batchLevelAll = BatchLevel.All$.MODULE$;
-    public static final BatchLevel batchLevelPartition = BatchLevel.Partition$.MODULE$;
-    public static final BatchLevel batchLevelReplicaSet = BatchLevel.ReplicaSet$.MODULE$;
+    public static final BatchGroupingKey BATCH_GROUPING_KEY_NONE = BatchGroupingKey.None$.MODULE$;
+    public static final BatchGroupingKey BATCH_GROUPING_KEY_PARTITION = BatchGroupingKey.Partition$.MODULE$;
+    public static final BatchGroupingKey BATCH_GROUPING_KEY_REPLICA_SET = BatchGroupingKey.ReplicaSet$.MODULE$;
 
     // -------------------------------------------------------------------------
     //              Column selector factory methods and constants 

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/RDDAndDStreamCommonJavaFunctions.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/RDDAndDStreamCommonJavaFunctions.java
@@ -175,7 +175,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
         public WriterBuilder withBatchSize(BatchSize batchSize) {
             if (!Objects.equals(writeConf.batchSize(), batchSize))
                 return withWriteConf(
-                    new WriteConf(batchSize, writeConf.batchBufferSize(), writeConf.batchLevel(),
+                    new WriteConf(batchSize, writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                         writeConf.consistencyLevel(), writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
                         writeConf.ttl(), writeConf.timestamp()));
             else
@@ -190,10 +190,10 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
          *
          * @return this instance or copy to allow method invocation chaining
          */
-        public WriterBuilder withBatchBufferSize(int batchBufferSize) {
-            if (writeConf.batchBufferSize() != batchBufferSize)
+        public WriterBuilder withBatchGroupingBufferSize(int batchGroupingBufferSize) {
+            if (writeConf.batchGroupingBufferSize() != batchGroupingBufferSize)
                 return withWriteConf(
-                    new WriteConf(writeConf.batchSize(), batchBufferSize, writeConf.batchLevel(),
+                    new WriteConf(writeConf.batchSize(), batchGroupingBufferSize, writeConf.batchGroupingKey(),
                         writeConf.consistencyLevel(), writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
                         writeConf.ttl(), writeConf.timestamp()));
             else
@@ -208,10 +208,10 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
          *
          * @return this instance or copy to allow method invocation chaining
          */
-        public WriterBuilder withBatchLevel(BatchLevel batchLevel) {
-            if (!Objects.equals(writeConf.batchLevel(), batchLevel))
+        public WriterBuilder withBatchGroupingKey(BatchGroupingKey batchGroupingKey) {
+            if (!Objects.equals(writeConf.batchGroupingKey(), batchGroupingKey))
                 return withWriteConf(
-                    new WriteConf(writeConf.batchSize(), writeConf.batchBufferSize(), batchLevel,
+                    new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), batchGroupingKey,
                         writeConf.consistencyLevel(), writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
                         writeConf.ttl(), writeConf.timestamp()));
             else
@@ -229,7 +229,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
         public WriterBuilder withConsistencyLevel(ConsistencyLevel consistencyLevel) {
             if (writeConf.consistencyLevel() != consistencyLevel)
                 return withWriteConf(
-                    new WriteConf(writeConf.batchSize(), writeConf.batchBufferSize(), writeConf.batchLevel(),
+                    new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                         consistencyLevel, writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
                         writeConf.ttl(), writeConf.timestamp()));
             else
@@ -247,7 +247,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
         public WriterBuilder withParallelismLevel(int parallelismLevel) {
             if (writeConf.parallelismLevel() != parallelismLevel)
                 return withWriteConf(
-                    new WriteConf(writeConf.batchSize(), writeConf.batchBufferSize(), writeConf.batchLevel(),
+                    new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                         writeConf.consistencyLevel(), parallelismLevel, writeConf.throughputMiBPS(),
                         writeConf.ttl(), writeConf.timestamp()));
             else
@@ -265,7 +265,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
         public WriterBuilder withThroughputMBPS(int throughputMBPS) {
             if (writeConf.throughputMiBPS() != throughputMBPS)
                 return withWriteConf(
-                    new WriteConf(writeConf.batchSize(), writeConf.batchBufferSize(), writeConf.batchLevel(),
+                    new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                         writeConf.consistencyLevel(), writeConf.parallelismLevel(), throughputMBPS,
                         writeConf.ttl(), writeConf.timestamp()));
             else
@@ -279,8 +279,8 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 ? this
                 : withWriteConf(new WriteConf(
                     writeConf.batchSize(),
-                    writeConf.batchBufferSize(),
-                    writeConf.batchLevel(),
+                    writeConf.batchGroupingBufferSize(),
+                    writeConf.batchGroupingKey(),
                     writeConf.consistencyLevel(),
                     writeConf.parallelismLevel(),
                     writeConf.throughputMiBPS(),
@@ -357,8 +357,8 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 ? this
                 : withWriteConf(new WriteConf(
                     writeConf.batchSize(),
-                    writeConf.batchBufferSize(),
-                    writeConf.batchLevel(),
+                    writeConf.batchGroupingBufferSize(),
+                    writeConf.batchGroupingKey(),
                     writeConf.consistencyLevel(),
                     writeConf.parallelismLevel(),
                     writeConf.throughputMiBPS(),

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/BatchGroupingKey.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/BatchGroupingKey.scala
@@ -1,23 +1,23 @@
 package com.datastax.spark.connector.writer
 
-sealed trait BatchLevel
+sealed trait BatchGroupingKey
 
-object BatchLevel {
+object BatchGroupingKey {
 
   /** Any row can be added to any batch. This works the same as previous batching implementation. */
-  case object All extends BatchLevel
+  case object None extends BatchGroupingKey
 
   /** Each batch is associated with a set of replicas. If a set of replicas for the inserted row is
     * the same as it is for a batch, the row can be added to the batch. */
-  case object ReplicaSet extends BatchLevel
+  case object ReplicaSet extends BatchGroupingKey
 
   /** Each batch is associated with a partition key. If the partition key of the inserted row is the
     * same as it is for a batch, the row can be added to the batch. */
-  case object Partition extends BatchLevel
+  case object Partition extends BatchGroupingKey
 
-  def apply(name: String): BatchLevel = name.toLowerCase match {
-    case "all" => All
-    case "replicaset" => ReplicaSet
+  def apply(name: String): BatchGroupingKey = name.toLowerCase match {
+    case "none" => None
+    case "replica_set" => ReplicaSet
     case "partition" => Partition
     case _ => throw new IllegalArgumentException(s"Invalid batch level: $name")
   }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
@@ -11,9 +11,9 @@ import org.apache.spark.SparkConf
   *
   * @param batchSize approx. number of bytes to be written in a single batch or
   *                  exact number of rows to be written in a single batch;
-  * @param batchBufferSize the number of distinct batches that can be buffered before
+  * @param batchGroupingBufferSize the number of distinct batches that can be buffered before
   *                        they are written to Cassandra
-  * @param batchLevel which rows can be grouped into a single batch
+  * @param batchGroupingKey which rows can be grouped into a single batch
   * @param consistencyLevel consistency level for writes, default LOCAL_ONE
   * @param parallelismLevel number of batches to be written in parallel
   * @param ttl       the default TTL value which is used when it is defined (in seconds)
@@ -21,8 +21,8 @@ import org.apache.spark.SparkConf
   */
 
 case class WriteConf(batchSize: BatchSize = BatchSize.Automatic,
-                     batchBufferSize: Int = WriteConf.DefaultBatchBufferSize,
-                     batchLevel: BatchLevel = WriteConf.DefaultBatchLevel,
+                     batchGroupingBufferSize: Int = WriteConf.DefaultBatchGroupingBufferSize,
+                     batchGroupingKey: BatchGroupingKey = WriteConf.DefaultBatchGroupingKey,
                      consistencyLevel: ConsistencyLevel = WriteConf.DefaultConsistencyLevel,
                      parallelismLevel: Int = WriteConf.DefaultParallelismLevel,
                      throughputMiBPS: Int = WriteConf.DefaultThroughputMiBPS,
@@ -51,8 +51,8 @@ object WriteConf {
   val DefaultConsistencyLevel = ConsistencyLevel.LOCAL_ONE
   val DefaultBatchSizeInBytes = 16 * 1024
   val DefaultParallelismLevel = 8
-  val DefaultBatchBufferSize = 1000
-  val DefaultBatchLevel = BatchLevel.Partition
+  val DefaultBatchGroupingBufferSize = 1000
+  val DefaultBatchGroupingKey = BatchGroupingKey.Partition
   val DefaultThroughputMiBPS = Int.MaxValue
 
   def fromSparkConf(conf: SparkConf): WriteConf = {
@@ -78,10 +78,10 @@ object WriteConf {
     }
 
     val batchBufferSize = conf.getInt(
-      "spark.cassandra.output.batch.buffer.size", DefaultBatchBufferSize)
+      "spark.cassandra.output.batch.grouping.buffer.size", DefaultBatchGroupingBufferSize)
 
-    val batchLevel = conf.getOption(
-      "spark.cassandra.output.batch.level").map(BatchLevel.apply).getOrElse(DefaultBatchLevel)
+    val batchGroupingKey = conf.getOption(
+      "spark.cassandra.output.batch.grouping.key").map(BatchGroupingKey.apply).getOrElse(DefaultBatchGroupingKey)
 
     val parallelismLevel = conf.getInt(
       "spark.cassandra.output.concurrent.writes", DefaultParallelismLevel)
@@ -91,8 +91,8 @@ object WriteConf {
 
     WriteConf(
       batchSize = batchSize,
-      batchBufferSize = batchBufferSize,
-      batchLevel = batchLevel,
+      batchGroupingBufferSize = batchBufferSize,
+      batchGroupingKey = batchGroupingKey,
       consistencyLevel = consistencyLevel,
       parallelismLevel = parallelismLevel,
       throughputMiBPS = throughputMiBPS)

--- a/spark-cassandra-connector/src/perf/scala/com/datastax/spark/connector/util/BenchmarkUtil.scala
+++ b/spark-cassandra-connector/src/perf/scala/com/datastax/spark/connector/util/BenchmarkUtil.scala
@@ -63,4 +63,15 @@ object BenchmarkUtil {
   def timeIt[T](code: => T): T =
     timeIt(1)(code)
 
+
+  def printTime[T](message: String)(code: => T): T = {
+    val start = System.nanoTime()
+    val result = code
+    val end = System.nanoTime()
+    println(message + ": " + formatTime((end - start) / 1000000000.0))
+    result
+  }
+
+  def printTime[T](code: => T): T =
+    printTime("elapsed")(code)
 }

--- a/spark-cassandra-connector/src/perf/scala/com/datastax/spark/connector/writer/BasicWriteBenchmark.scala
+++ b/spark-cassandra-connector/src/perf/scala/com/datastax/spark/connector/writer/BasicWriteBenchmark.scala
@@ -1,0 +1,39 @@
+package com.datastax.spark.connector.writer
+
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.util.BenchmarkUtil
+import org.apache.spark.{SparkConf, SparkContext}
+
+object BasicWriteBenchmark extends App {
+
+  val cassandraPartitionsToWrite = 100000
+  val rowsPerCassandraPartition = 10
+  val rowsPerSparkPartition = 50000
+  
+  val conf = new SparkConf(true)
+    .setAppName("Write performance test")
+    .set("spark.cassandra.connection.host", "localhost")
+    .set("spark.cassandra.output.concurrent.writes", "16")
+    .set("spark.cassandra.output.batch.size.bytes", "4096")
+    .set("spark.cassandra.output.batch.grouping.key", "partition")
+    .setMaster("local[1]")
+
+  val sc = new SparkContext(conf)
+  val conn = CassandraConnector(conf)
+
+  conn.withSessionDo { session =>
+    session.execute("CREATE KEYSPACE IF NOT EXISTS benchmarks WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1 }")
+    session.execute("CREATE TABLE IF NOT EXISTS benchmarks.write_benchmark (p INT, c INT, value VARCHAR, PRIMARY KEY(p, c))")
+  }
+
+  BenchmarkUtil.printTime {
+    val col =
+      for (i <- 1 to cassandraPartitionsToWrite; j <- 1 to rowsPerCassandraPartition)
+      yield (i, j, "data:" + i + ":" + j)
+    val rdd = sc.parallelize(col, cassandraPartitionsToWrite * rowsPerCassandraPartition / rowsPerSparkPartition)
+    rdd.saveToCassandra("benchmarks", "write_benchmark")
+  }
+
+  sc.stop()
+}

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/WriteConfTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/WriteConfTest.scala
@@ -59,16 +59,16 @@ class WriteConfTest extends FlatSpec with Matchers {
 
   it should "allow to set batch level" in {
     val conf = new SparkConf(false)
-      .set("spark.cassandra.output.batch.level", "all")
+      .set("spark.cassandra.output.batch.grouping.key", "none")
     val writeConf = WriteConf.fromSparkConf(conf)
-    writeConf.batchLevel should be(BatchLevel.All)
+    writeConf.batchGroupingKey should be(BatchGroupingKey.None)
   }
 
   it should "allow to set batch buffer size" in {
     val conf = new SparkConf(false)
-      .set("spark.cassandra.output.batch.buffer.size", "30000")
+      .set("spark.cassandra.output.batch.grouping.buffer.size", "30000")
     val writeConf = WriteConf.fromSparkConf(conf)
-    writeConf.batchBufferSize should be(30000)
+    writeConf.batchGroupingBufferSize should be(30000)
   }
 
 


### PR DESCRIPTION
....size to batch.grouping.buffer.size. Rename batch grouping key value "all" to "none" and "replicaset" to "replica_set".