### PR TITLE
SPARKC-91: Fixes in metrics

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
  * Cross cluster table join and write for Spark SQL (SPARKC-73)
+ * Enabling / disabling metrics in metrics configuration file and other metrics fixes (SPARKC-91)
 
 1.2.0 rc 1
  * More Spark SQL predicate push (SPARKC-72)
@@ -15,7 +16,7 @@
  * Set Java driver version to 2.1.5 and Cassandra to 2.1.3 (SPARKC-92)
  * Moved Spark streaming related methods from CassandraJavaUtil to CassandraStreamingJavaUtil 
    (SPARKC-80)
-
+ 
 1.2.0 alpha 3
  * Exposed spanBy and spanByKey in Java API (SPARKC-39)
  * Added automatic generation of Cassandra table schema from a Scala type and

--- a/doc/11_metrics.md
+++ b/doc/11_metrics.md
@@ -19,18 +19,18 @@ driver. To access these metrics add a new source called cassandra-connector in y
 `metrics.properties` file. Example:
 
 ```
-cassandra-connector.sink.csv.class=org.apache.spark.metrics.sink.CsvSink
-cassandra-connector.sink.csv.period=5
-cassandra-connector.sink.csv.unit=seconds
-cassandra-connector.sink.csv.directory=/tmp/spark/sink
+executor.source.cassandra-connector.class=org.apache.spark.metrics.CassandraConnectorSource
+driver.source.cassandra-connector.class=org.apache.spark.metrics.CassandraConnectorSource
 ```
 
 ### Performance impact
 While there should be a minimal performance effect from collecting metrics, Metric collection can be
-disabled by setting the following options in the Spark configuration:
+disabled. Codahale metrics are not collected if CassandraConnectorSource is not specified in the
+metrics configuration file. In order to disable task metrics, use these properties in Spark
+configuration:
 
-- `spark.cassandra.input.metrics` - set to `false` to disable collection of input metrics
-- `spark.cassandra.output.metrics` - set to `false` to disable collection of output metrics
+- `spark.cassandra.input.metrics` - set to `false` to disable collection of input task metrics
+- `spark.cassandra.output.metrics` - set to `false` to disable collection of output task metrics
 
 ### Available metrics
 Metric name            | Unit description
@@ -44,7 +44,11 @@ write-success-counter  | Number successfully written batches
 write-failure-counter  | Number of failed batches
 read-byte-meter        | Number of bytes read from Cassandra
 read-row-meter         | Number of rows read from Cassandra
-read-page-wait-timer   | The Time spent by the driver waiting for rows to be paged in from C*
 read-task-timer        | Timer to measure time of reading a single partition
+
+### Compatibility
+Codahale based metrics should work with either Spark 1.1.x or Spark 1.2.x. However task metrics
+works only with Spark 1.2.x. Therefore, if this version of Spark Cassandra Connector is to be used with
+Spark 1.1.x, task based metrics have to be disabled.
 
 [Next - Building And Artifacts](doc/12_building_and_artifacts.md)

--- a/project/CassandraSparkBuild.scala
+++ b/project/CassandraSparkBuild.scala
@@ -26,6 +26,10 @@ object CassandraSparkBuild extends Build {
 
   val demosPath = file(s"$namespace-demos")
 
+  autoAPIMappings := true
+
+//  apiMappings += (unmanagedBase.value / "spark-core_2.10-1.2.1.jar" -> url(s"http://spark.apache.org/docs/1.2.1/api/scala/"))
+
   lazy val root = RootProject("root", file("."), Seq(embedded, connector, jconnector, demos))
 
   lazy val embedded = CrossScalaVersionsProject(

--- a/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/SparkTemplate.scala
+++ b/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/SparkTemplate.scala
@@ -1,24 +1,59 @@
 package com.datastax.spark.connector.embedded
 
-import java.net.InetAddress
-
-import org.apache.spark.{SparkEnv, SparkConf, SparkContext}
+import akka.actor.ActorSystem
+import org.apache.spark.{SparkConf, SparkContext, SparkEnv}
 
 trait SparkTemplate {
-  val conf = SparkTemplate.conf
+  /** Obtains the active [[org.apache.spark.SparkContext]] object. */
+  def sc: SparkContext = SparkTemplate.sc
+
+  /** Obtains the [[akka.actor.ActorSystem]] associated with the active [[org.apache.spark.SparkEnv]]. */
+  def actorSystem: ActorSystem = SparkTemplate.actorSystem
+
+  /** Ensures that the currently running [[org.apache.spark.SparkContext]] uses the provided configuration.
+    * If the configurations are different or force is `true` Spark context is stopped and started again
+    * with the given configuration. */
+  def useSparkConf(conf: SparkConf, force: Boolean = false): SparkContext =
+    SparkTemplate.useSparkConf(conf, force)
+
+  def defaultSparkConf = SparkTemplate.defaultConf
 }
 
 object SparkTemplate {
 
-  val conf = new SparkConf(true)
+  /** Default configuration for [[org.apache.spark.SparkContext]]. */
+  val defaultConf = new SparkConf(true)
     .set("spark.cassandra.connection.host", EmbeddedCassandra.getHost(0).getHostAddress)
     .set("spark.cleaner.ttl", "3600")
-    .set("spark.metrics.conf", this.getClass.getResource("/metrics.properties").getPath)
     .setMaster(sys.env.getOrElse("IT_TEST_SPARK_MASTER", "local[*]"))
-    .setAppName(getClass.getSimpleName)
+    .setAppName("Test")
 
-  System.err.println("The Spark configuration is as follows:\n" + conf.toDebugString)
+  private var _sc: SparkContext = _
 
-  lazy val actorSystem = SparkEnv.get.actorSystem
+  /** Ensures that the currently running [[org.apache.spark.SparkContext]] uses the provided configuration.
+    * If the configurations are different or force is `true` Spark context is stopped and started again
+    * with the given configuration. */
+  def useSparkConf(conf: SparkConf = SparkTemplate.defaultConf, force: Boolean = false): SparkContext = {
+    if (_sc.getConf.getAll.toMap != conf.getAll.toMap || force)
+      resetSparkContext(conf)
+    _sc
+  }
 
+  private def resetSparkContext(conf: SparkConf) = {
+    if (_sc != null) {
+      _sc.stop()
+    }
+
+    System.err.println("Starting SparkContext with the following configuration:\n" + defaultConf.toDebugString)
+    _sc = new SparkContext(conf)
+    _sc
+  }
+
+  /** Obtains the active [[org.apache.spark.SparkContext]] object. */
+  def sc: SparkContext = _sc
+
+  /** Obtains the [[akka.actor.ActorSystem]] associated with the active [[org.apache.spark.SparkEnv]]. */
+  def actorSystem: ActorSystem = SparkEnv.get.actorSystem
+
+  resetSparkContext(defaultConf)
 }

--- a/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/CassandraJavaUtilSpec.scala
+++ b/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/CassandraJavaUtilSpec.scala
@@ -12,6 +12,8 @@ import scala.collection.JavaConversions._
 class CassandraJavaUtilSpec extends SparkCassandraITFlatSpecBase with BeforeAndAfter {
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
+  useSparkConf(defaultSparkConf)
+
   val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
 
   before {

--- a/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaPairRDDSpec.scala
+++ b/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaPairRDDSpec.scala
@@ -15,6 +15,7 @@ case class SimpleClass(value: Integer)
 class CassandraJavaPairRDDSpec extends SparkCassandraITFlatSpecBase {
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
+  useSparkConf(defaultSparkConf)
 
   val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
 

--- a/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaRDDSpec.scala
+++ b/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaRDDSpec.scala
@@ -18,6 +18,7 @@ import scala.collection.JavaConversions._
 class CassandraJavaRDDSpec extends SparkCassandraITFlatSpecBase {
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
+  useSparkConf(defaultSparkConf)
 
   val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
 

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/RDDAndDStreamCommonJavaFunctions.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/RDDAndDStreamCommonJavaFunctions.java
@@ -177,7 +177,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                     new WriteConf(batchSize, writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                         writeConf.consistencyLevel(), writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
-                        writeConf.ttl(), writeConf.timestamp()));
+                        writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
             else
                 return this;
         }
@@ -195,7 +195,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), batchGroupingBufferSize, writeConf.batchGroupingKey(),
                         writeConf.consistencyLevel(), writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
-                        writeConf.ttl(), writeConf.timestamp()));
+                        writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
             else
                 return this;
         }
@@ -213,7 +213,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), batchGroupingKey,
                         writeConf.consistencyLevel(), writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
-                        writeConf.ttl(), writeConf.timestamp()));
+                        writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
             else
                 return this;
         }
@@ -231,7 +231,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                         consistencyLevel, writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
-                        writeConf.ttl(), writeConf.timestamp()));
+                        writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
             else
                 return this;
         }
@@ -249,13 +249,13 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                         writeConf.consistencyLevel(), parallelismLevel, writeConf.throughputMiBPS(),
-                        writeConf.ttl(), writeConf.timestamp()));
+                        writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
             else
                 return this;
         }
 
         /**
-         * Returns a copy of this builder with the new write configuration which has parallelism level changed to a
+         * Returns a copy of this builder with the new write configuration which has write throughput value changed to a
          * specified one.
          *
          * <p>If the same instance is passed as the one which is currently set, no copy of this builder is created.</p>
@@ -267,12 +267,28 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                         writeConf.consistencyLevel(), writeConf.parallelismLevel(), throughputMBPS,
-                        writeConf.ttl(), writeConf.timestamp()));
+                        writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
             else
               return this;
         }
 
 
+        /**
+         * Return a copy of this builder with the new write configuration which has task metrics set to enabled or disabled as specified.
+         *
+         * <p>If the same instance is passed as the one which is currently set, no copy of this builder is created.</p>
+         *
+         * @return this instance or copy to allow method invocation chaining
+         */
+        public WriterBuilder withTaskMetricsEnabled(boolean taskMetricsEnabled) {
+            if (writeConf.taskMetricsEnabled() != taskMetricsEnabled)
+                return withWriteConf(
+                        new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
+                                writeConf.consistencyLevel(), writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
+                                writeConf.ttl(), writeConf.timestamp(), taskMetricsEnabled));
+            else
+                return this;
+        }
 
       private WriterBuilder withTimestamp(TimestampOption timestamp) {
             return Objects.equals(writeConf.timestamp(), timestamp)
@@ -285,7 +301,8 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                     writeConf.parallelismLevel(),
                     writeConf.throughputMiBPS(),
                     writeConf.ttl(),
-                    timestamp));
+                    timestamp,
+                    writeConf.taskMetricsEnabled()));
         }
 
 
@@ -363,7 +380,8 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                     writeConf.parallelismLevel(),
                     writeConf.throughputMiBPS(),
                     ttl,
-                    writeConf.timestamp()));
+                    writeConf.timestamp(),
+                    writeConf.taskMetricsEnabled()));
         }
 
         /**

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/SparkCassandraITFlatSpecBase.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/SparkCassandraITFlatSpecBase.scala
@@ -13,15 +13,4 @@ trait SparkCassandraITWordSpecBase extends WordSpec with SparkCassandraITSpecBas
 trait SparkCassandraITAbstractSpecBase extends AbstractSpec with SparkCassandraITSpecBase
 
 trait SparkCassandraITSpecBase extends Suite with Matchers with SharedEmbeddedCassandra with SparkTemplate with BeforeAndAfterAll {
-  var sc: SparkContext = null
-
-  override def beforeAll(configMap: ConfigMap) {
-    sc = new SparkContext(conf)
-  }
-
-  override def afterAll(configMap: ConfigMap) {
-    if (sc != null) {
-      sc.stop()
-    }
-  }
 }

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraPartitionKeyWhereSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraPartitionKeyWhereSpec.scala
@@ -6,6 +6,8 @@ import com.datastax.spark.connector.embedded._
 class CassandraPartitionKeyWhereSpec extends SparkCassandraITFlatSpecBase {
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
+  useSparkConf(defaultSparkConf)
+
   val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
 
   conn.withSessionDo { session =>

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -45,6 +45,8 @@ class SubKeyValue extends SuperKeyValue {
 class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
+  useSparkConf(defaultSparkConf)
+
   val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
   val bigTableRowCount = 100000
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
@@ -25,6 +25,7 @@ case class DataCol(pk1: Int, pk2: Int, pk3: Int, d1: Int)
 class RDDSpec extends SparkCassandraITFlatSpecBase {
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
+  useSparkConf(defaultSparkConf)
 
   val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
   implicit val protocolVersion = conn.withClusterDo(_.getConfiguration.getProtocolOptions.getProtocolVersionEnum)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/repl/CassandraRDDReplSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/repl/CassandraRDDReplSpec.scala
@@ -6,6 +6,7 @@ import com.datastax.spark.connector.embedded._
 
 class CassandraRDDReplSpec extends SparkCassandraITFlatSpecBase with SparkRepl {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
+  useSparkConf(defaultSparkConf)
 
   val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLClusterLevelSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLClusterLevelSpec.scala
@@ -3,7 +3,7 @@ package com.datastax.spark.connector.sql
 import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.embedded.EmbeddedCassandra._
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.cassandra.CassandraSQLContext
 import org.scalatest._
 
@@ -40,7 +40,6 @@ class CassandraSQLClusterLevelSpec extends SparkCassandraITFlatSpecBase {
   var cc: CassandraSQLContext = null
 
   override def beforeAll(configMap: ConfigMap) {
-    sc = new SparkContext(conf)
     cc = new CassandraSQLContext(sc)
     val conf1 = new SparkConf(true)
       .set("spark.cassandra.connection.host", getHost(0).getHostAddress)
@@ -52,10 +51,10 @@ class CassandraSQLClusterLevelSpec extends SparkCassandraITFlatSpecBase {
       .set("spark.cassandra.connection.rpc.port", getRpcPort(1).toString)
     cc.addClusterLevelCassandraConnConf("cluster1", conf1)
       .addClusterLevelCassandraConnConf("cluster2", conf2)
-      .addClusterLevelReadConf("cluster1", conf)
-      .addClusterLevelWriteConf("cluster1", conf)
-      .addClusterLevelReadConf("cluster2", conf)
-      .addClusterLevelWriteConf("cluster2", conf)
+      .addClusterLevelReadConf("cluster1", sc.getConf)
+      .addClusterLevelWriteConf("cluster1", sc.getConf)
+      .addClusterLevelReadConf("cluster2", sc.getConf)
+      .addClusterLevelWriteConf("cluster2", sc.getConf)
   }
 
   it should "allow to join tables from different clusters" in {

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLPredicatePushdownSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLPredicatePushdownSpec.scala
@@ -3,17 +3,17 @@ package com.datastax.spark.connector.sql
 import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.embedded.EmbeddedCassandra
-import org.apache.spark.SparkContext
 import org.apache.spark.sql.cassandra.CassandraSQLContext
 import org.scalatest.ConfigMap
 
 class CassandraSQLPredicatePushdownSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
+  useSparkConf(defaultSparkConf)
+
   val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
   var cc: CassandraSQLContext = null
 
   override def beforeAll(configMap: ConfigMap) {
-    sc = new SparkContext(conf)
     cc = new CassandraSQLContext(sc)
     cc.setKeyspace("sql_test")
   }

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLSpec.scala
@@ -10,6 +10,8 @@ import org.scalatest.{ConfigMap, FlatSpec, Matchers}
 
 class CassandraSQLSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
+  useSparkConf(defaultSparkConf)
+
   val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
   var cc: CassandraSQLContext = null
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/streaming/ActorStreamSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/streaming/ActorStreamSpec.scala
@@ -2,12 +2,10 @@ package com.datastax.spark.connector.streaming
 
 import akka.actor.{ActorSystem, Props, Terminated}
 import akka.testkit.{ImplicitSender, TestKit}
-import com.datastax.spark.connector.{RowsInBatch, SomeColumns}
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.embedded._
 import com.datastax.spark.connector.streaming.StreamingEvent.ReceiverStarted
 import com.datastax.spark.connector.testkit._
-import com.datastax.spark.connector.writer.WriteConf
 import com.datastax.spark.connector._
 import org.apache.spark.{SparkContext, SparkEnv}
 import org.apache.spark.storage.StorageLevel
@@ -19,7 +17,7 @@ class ActorStreamingSpec extends ActorSpec with CounterFixture with ImplicitSend
   import com.datastax.spark.connector.testkit.TestEvent._
 
   /* Initializations - does not work in the actor test context in a static before() */
-  CassandraConnector(SparkTemplate.conf).withSessionDo { session =>
+  CassandraConnector(SparkTemplate.defaultConf).withSessionDo { session =>
     session.execute("CREATE KEYSPACE IF NOT EXISTS demo WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1 }")
     session.execute("CREATE TABLE IF NOT EXISTS demo.streaming_wordcount (word TEXT PRIMARY KEY, count COUNTER)")
     session.execute("CREATE TABLE IF NOT EXISTS demo.streaming_join (word TEXT PRIMARY KEY, count COUNTER)")
@@ -103,11 +101,11 @@ class TestStreamingActor extends TypedStreamingActor[String] with Counter {
 abstract class ActorSpec(var ssc: StreamingContext, _system: ActorSystem)
   extends TestKit(_system) with StreamingSpec {
 
-  def this() = this (new StreamingContext(new SparkContext(SparkTemplate.conf), Milliseconds(300)), SparkEnv.get.actorSystem)
+  def this() = this (new StreamingContext(SparkTemplate.useSparkConf(), Milliseconds(300)), SparkTemplate.actorSystem)
 
   before {
     //We can't re-use streaming contexts
-    ssc = new StreamingContext(ssc.sparkContext, Milliseconds(300))
+    ssc = new StreamingContext(sc, Milliseconds(300))
   }
 }
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterColumnNamesSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterColumnNamesSpec.scala
@@ -7,6 +7,8 @@ import com.datastax.spark.connector._
 class TableWriterColumnNamesSpec extends SparkCassandraITAbstractSpecBase {
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
+  useSparkConf(defaultSparkConf)
+
   val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
 
   case class KeyValue(key: Int, group: Long)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
@@ -27,6 +27,8 @@ class SubKeyValue(k: Int, v: String, val group: Long) extends SuperKeyValue(k, v
 class TableWriterSpec extends SparkCassandraITFlatSpecBase {
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
+  useSparkConf(defaultSparkConf)
+
   val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
 
   conn.withSessionDo { session =>

--- a/spark-cassandra-connector/src/it/scala/org/apache/spark/metrics/CassandraConnectorSourceSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/org/apache/spark/metrics/CassandraConnectorSourceSpec.scala
@@ -1,0 +1,63 @@
+package org.apache.spark.metrics
+
+import java.io.File
+
+import com.datastax.spark.connector.embedded.SparkTemplate
+import org.apache.commons.io.FileUtils
+import org.apache.spark.SparkConf
+import org.scalatest.{FlatSpec, Matchers}
+
+class CassandraConnectorSourceSpec extends FlatSpec with Matchers with SparkTemplate {
+
+  def prepareConf = {
+    val conf = new SparkConf(loadDefaults = false)
+    conf.setMaster("local[*]")
+    conf.setAppName("test")
+    conf
+  }
+
+  "CassandraConnectorSource" should "be initialized when it was specified in metrics properties" in {
+    val className = classOf[CassandraConnectorSource].getName
+    System.err.println(className)
+    val metricsPropertiesContent =
+      s"""
+         |*.source.cassandra-connector.class=$className
+       """.stripMargin
+
+    val metricsPropertiesFile = File.createTempFile("spark-cassandra-connector", "metrics.properties")
+    metricsPropertiesFile.deleteOnExit()
+    FileUtils.writeStringToFile(metricsPropertiesFile, metricsPropertiesContent)
+
+    val conf = prepareConf
+    conf.set("spark.metrics.conf", metricsPropertiesFile.getAbsolutePath)
+    useSparkConf(conf)
+    try {
+      CassandraConnectorSource.instance.isDefined shouldBe true
+    } finally {
+      sc.stop()
+    }
+
+    CassandraConnectorSource.instance.isDefined shouldBe false
+  }
+
+  "CassandraConnectorSource" should "not be initialized when it wasn't specified in metrics properties" in {
+    val metricsPropertiesContent =
+      s"""
+       """.stripMargin
+
+    val metricsPropertiesFile = File.createTempFile("spark-cassandra-connector", "metrics.properties")
+    metricsPropertiesFile.deleteOnExit()
+    FileUtils.writeStringToFile(metricsPropertiesFile, metricsPropertiesContent)
+
+    val conf = prepareConf
+    conf.set("spark.metrics.conf", metricsPropertiesFile.getAbsolutePath)
+
+    useSparkConf(conf)
+    try {
+      CassandraConnectorSource.instance.isDefined shouldBe false
+    } finally {
+      sc.stop()
+    }
+  }
+
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/metrics/InputMetricsUpdater.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/metrics/InputMetricsUpdater.scala
@@ -1,80 +1,156 @@
 package com.datastax.spark.connector.metrics
 
-import com.codahale.metrics.Timer
 import com.datastax.driver.core.Row
-import org.apache.spark.{SparkEnv, TaskContext}
+import com.datastax.spark.connector.rdd.ReadConf
+import org.apache.spark.TaskContext
 import org.apache.spark.executor.{DataReadMethod, InputMetrics}
 import org.apache.spark.metrics.CassandraConnectorSource
 
+/** A trait that provides a method to update read metrics which are collected for connector related tasks.
+  * The appropriate instance is created by the companion object.
+  *
+  * Instances of this trait are not thread-safe. They do not need to because a single instance should be
+  * created for each Cassandra read task. This remains valid as long as Cassandra read tasks are
+  * single-threaded.
+  */
 private[connector] trait InputMetricsUpdater extends MetricsUpdater {
-  def resultSetFetchTimer: Option[Timer]
-
-  def updateMetrics(row: Row): Row
-}
-
-private class DetailedInputMetricsUpdater(metrics: InputMetrics, groupSize: Int) extends InputMetricsUpdater {
-  require(groupSize > 0)
-
-  val resultSetFetchTimer = Some(CassandraConnectorSource.readPageWaitTimer)
-
-  private val taskTimer = CassandraConnectorSource.readTaskTimer.time()
-
-  private var cnt = 0
-  private var dataLength = metrics.bytesRead
-
-  def updateMetrics(row: Row): Row = {
-    for (i <- 0 until row.getColumnDefinitions.size() if !row.isNull(i))
-      metrics.bytesRead += row.getBytesUnsafe(i).remaining()
-
-    cnt += 1
-    if (cnt == groupSize)
-      update()
-    row
-  }
-
-  @inline
-  private def update(): Unit = {
-    CassandraConnectorSource.readRowMeter.mark(cnt)
-    CassandraConnectorSource.readByteMeter.mark(metrics.bytesRead - dataLength)
-    dataLength = metrics.bytesRead
-    cnt = 0
-  }
-
-  def finish(): Long = {
-    update()
-    val t = taskTimer.stop()
-    forceReport()
-    t
-  }
-}
-
-private class DummyInputMetricsUpdater extends InputMetricsUpdater {
-  private val taskTimer = System.nanoTime()
-
-  val resultSetFetchTimer = None
-
+  /** Updates the metrics being collected for the connector after reading each single row. This method
+    * is not thread-safe.
+    *
+    * @param row the row which has just been read
+    */
   def updateMetrics(row: Row): Row = row
 
-  def finish(): Long = {
-    System.nanoTime() - taskTimer
-  }
+  /** For internal use only */
+  private[metrics] def updateTaskMetrics(dataLength: Int): Unit = {}
+
+  /** For internal use only */
+  private[metrics] def updateCodahaleMetrics(count: Int, dataLength: Int): Unit = {}
 }
 
 object InputMetricsUpdater {
-  lazy val detailedMetricsEnabled =
-    SparkEnv.get.conf.getBoolean("spark.cassandra.input.metrics", defaultValue = true)
+  val DefaultGroupSize = 100
 
-  def apply(taskContext: TaskContext, groupSize: Int): InputMetricsUpdater = {
-    CassandraConnectorSource.ensureInitialized
+  /** Creates the appropriate instance of [[InputMetricsUpdater]].
+    *
+    * If [[ReadConf.taskMetricsEnabled]] is `true`, the created instance will be updating task metrics so
+    * that Spark will report them in the UI. Remember that this is supported for Spark 1.2+.
+    *
+    * If [[CassandraConnectorSource]] is registered in Spark metrics system, the created instance will be
+    * updating the included Codahale metrics. In order to register [[CassandraConnectorSource]] you need
+    * to add it to the metrics configuration file.
+    *
+    * @param taskContext task context of a task for which this metrics updater is created
+    * @param readConf read configuration
+    * @param groupSize allows to update Codahale metrics every the given number of rows in order to
+    *                  decrease overhead
+    */
+  def apply(
+    taskContext: TaskContext,
+    readConf: ReadConf,
+    groupSize: Int = DefaultGroupSize): InputMetricsUpdater = {
 
-    if (detailedMetricsEnabled) {
+    val source = CassandraConnectorSource.instance
+
+    if (readConf.taskMetricsEnabled) {
       val tm = taskContext.taskMetrics()
       if (tm.inputMetrics.isEmpty || tm.inputMetrics.get.readMethod != DataReadMethod.Hadoop)
         tm.inputMetrics = Some(new InputMetrics(DataReadMethod.Hadoop))
 
-      new DetailedInputMetricsUpdater(tm.inputMetrics.get, groupSize)
+      if (source.isDefined)
+        new CodahaleAndTaskMetricsUpdater(groupSize, source.get, tm.inputMetrics.get)
+      else
+        new TaskMetricsUpdater(groupSize, tm.inputMetrics.get)
+
     } else {
-      new DummyInputMetricsUpdater
+      if (source.isDefined)
+        new CodahaleMetricsUpdater(groupSize, source.get)
+      else
+        new DummyInputMetricsUpdater()
     }
   }
+
+  private abstract class CumulativeInputMetricsUpdater(groupSize: Int)
+    extends InputMetricsUpdater with Timer {
+
+    require(groupSize > 0)
+
+    private var cnt = 0
+    private var dataLength = 0
+
+    def getRowBinarySize(row: Row) = {
+      var size = 0
+      for (i <- 0 until row.getColumnDefinitions.size() if !row.isNull(i))
+        size += row.getBytesUnsafe(i).remaining()
+      size
+    }
+
+    override def updateMetrics(row: Row): Row = {
+      val binarySize = getRowBinarySize(row)
+
+      // updating task metrics is cheap
+      updateTaskMetrics(binarySize)
+
+      cnt += 1
+      dataLength += binarySize
+      if (cnt == groupSize) {
+        // Codahale metrics introduce some overhead so in order to minimize it we can update them not
+        // that often
+        updateCodahaleMetrics(cnt, dataLength)
+        cnt = 0
+        dataLength = 0
+      }
+      row
+    }
+
+    def finish(): Long = {
+      updateCodahaleMetrics(cnt, dataLength)
+      val t = stopTimer()
+      t
+    }
+  }
+
+  private trait CodahaleMetricsSupport extends InputMetricsUpdater {
+    val source: CassandraConnectorSource
+
+    @inline
+    override def updateCodahaleMetrics(count: Int, dataLength: Int): Unit = {
+      source.readByteMeter.mark(dataLength)
+      source.readRowMeter.mark(count)
+    }
+
+    val timer = source.readTaskTimer.time()
+  }
+
+  private trait TaskMetricsSupport extends InputMetricsUpdater {
+    val inputMetrics: InputMetrics
+
+    @inline
+    override def updateTaskMetrics(dataLength: Int): Unit = inputMetrics.bytesRead += dataLength
+  }
+
+  /** The implementation of [[InputMetricsUpdater]] which does not update anything. */
+  private class DummyInputMetricsUpdater extends InputMetricsUpdater with SimpleTimer {
+    def finish(): Long = stopTimer()
+  }
+
+  /** The implementation of [[InputMetricsUpdater]] which updates only task metrics. */
+  private class TaskMetricsUpdater(groupSize: Int, val inputMetrics: InputMetrics)
+    extends CumulativeInputMetricsUpdater(groupSize) with TaskMetricsSupport with SimpleTimer
+
+  /** The implementation of [[InputMetricsUpdater]] which updates only Codahale metrics defined in
+    * [[CassandraConnectorSource]]. */
+  private class CodahaleMetricsUpdater(groupSize: Int, val source: CassandraConnectorSource)
+    extends CumulativeInputMetricsUpdater(groupSize) with CodahaleMetricsSupport with CCSTimer
+
+  /** The implementation of [[InputMetricsUpdater]] which updates both Codahale and task metrics. */
+  private class CodahaleAndTaskMetricsUpdater(
+      groupSize: Int,
+      val source: CassandraConnectorSource,
+      val inputMetrics: InputMetrics)
+    extends CumulativeInputMetricsUpdater(groupSize)
+    with TaskMetricsSupport
+    with CodahaleMetricsSupport
+    with CCSTimer
+
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/metrics/MetricsUpdater.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/metrics/MetricsUpdater.scala
@@ -1,11 +1,40 @@
 package com.datastax.spark.connector.metrics
 
+import com.codahale.metrics.Timer.Context
 import org.apache.spark.SparkEnv
+import org.apache.spark.metrics.CassandraConnectorSource
 
+/** The base trait for metrics updaters implementations. The metrics updater is an object which provides
+  * a unified way to update all the relevant metrics which are collected for the particular type of
+  * activity. The connector provides [[InputMetricsUpdater]] and [[OutputMetricsUpdater]] which are aimed
+  * to update all the read and write metrics respectively.
+  */
 trait MetricsUpdater {
+  /** A method to be called when the task is finished. It stops the task timer and flushes data. */
   def finish(): Long
+}
 
-  def forceReport(): Unit = {
-    Option(SparkEnv.get).foreach(_.metricsSystem.report())
+/** Timer mixin allows to measure the time of a task - or, in other words - the time from creating an
+  * instance to calling [[com.codahale.metrics.Timer.Context.stopTimer()]] method.
+  */
+trait Timer {
+  def stopTimer(): Long
+}
+
+trait SimpleTimer extends Timer {
+  private val startTime = System.nanoTime()
+
+  override def stopTimer(): Long = System.nanoTime() - startTime
+}
+
+trait CCSTimer extends Timer {
+  def source: CassandraConnectorSource
+
+  val timer: Context
+
+  override def stopTimer(): Long = {
+    val t = timer.stop()
+    Option(SparkEnv.get).flatMap(env => Option(env.metricsSystem)).foreach(_.report())
+    t
   }
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
@@ -203,7 +203,7 @@ class CassandraJoinRDD[Left, Right] private[connector](
     implicit val pv = protocolVersion(session)
     val stmt = session.prepare(singleKeyCqlQuery).setConsistencyLevel(consistencyLevel)
     val bsb = new BoundStatementBuilder[Left](rowWriter, stmt, pv)
-    val metricsUpdater = InputMetricsUpdater(context, 20)
+    val metricsUpdater = InputMetricsUpdater(context, readConf)
     val rowIterator = fetchIterator(session, bsb, left.iterator(split, context))
     val countingIterator = new CountingIterator(rowIterator, limit)
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
@@ -1,6 +1,7 @@
 package com.datastax.spark.connector.rdd
 
 import com.datastax.driver.core.ConsistencyLevel
+import com.datastax.spark.connector.util.ConfigCheck
 import org.apache.spark.SparkConf
 
 /** Read settings for RDD
@@ -8,11 +9,13 @@ import org.apache.spark.SparkConf
   * @param splitSize number of Cassandra partitions to be read in a single Spark task
   * @param fetchSize number of CQL rows to fetch in a single round-trip to Cassandra
   * @param consistencyLevel consistency level for reads, default LOCAL_ONE;
-  *                         higher consistency level will disable data-locality */
+  *                         higher consistency level will disable data-locality
+  * @param taskMetricsEnabled whether or not enable task metrics updates (requires Spark 1.2+) */
 case class ReadConf(
   splitSize: Int = ReadConf.DefaultSplitSize,
   fetchSize: Int = ReadConf.DefaultFetchSize,
-  consistencyLevel: ConsistencyLevel = ReadConf.DefaultConsistencyLevel)
+  consistencyLevel: ConsistencyLevel = ReadConf.DefaultConsistencyLevel,
+  taskMetricsEnabled: Boolean = ReadConf.DefaultReadTaskMetricsEnabled)
 
 
 object ReadConf {
@@ -20,24 +23,31 @@ object ReadConf {
   val ReadFetchSizeProperty = "spark.cassandra.input.page.row.size"
   val ReadSplitSizeProperty = "spark.cassandra.input.split.size"
   val ReadConsistencyLevelProperty = "spark.cassandra.input.consistency.level"
+  val ReadTaskMetricsProperty = "spark.cassandra.input.metrics"
 
   //Whitelist for allowed Read environment variables
   val Properties = Seq(
     ReadFetchSizeProperty,
     ReadSplitSizeProperty,
-    ReadConsistencyLevelProperty
+    ReadConsistencyLevelProperty,
+    ReadTaskMetricsProperty
   )
 
   val DefaultSplitSize = 100000
   val DefaultFetchSize = 1000
   val DefaultConsistencyLevel = ConsistencyLevel.LOCAL_ONE
+  val DefaultReadTaskMetricsEnabled = true
 
   def fromSparkConf(conf: SparkConf): ReadConf = {
+
+    ConfigCheck.checkConfig(conf)
+
     ReadConf(
       fetchSize = conf.getInt(ReadFetchSizeProperty, DefaultFetchSize),
       splitSize = conf.getInt(ReadSplitSizeProperty, DefaultSplitSize),
       consistencyLevel = ConsistencyLevel.valueOf(
-        conf.get(ReadConsistencyLevelProperty, DefaultConsistencyLevel.name()))
+        conf.get(ReadConsistencyLevelProperty, DefaultConsistencyLevel.name())),
+      taskMetricsEnabled = conf.getBoolean(ReadTaskMetricsProperty, DefaultReadTaskMetricsEnabled)
     )
   }
 

--- a/spark-cassandra-connector/src/main/scala/com/google/common/cache/LongAdderBuilder.scala
+++ b/spark-cassandra-connector/src/main/scala/com/google/common/cache/LongAdderBuilder.scala
@@ -1,0 +1,25 @@
+package com.google.common.cache
+
+object LongAdderBuilder {
+
+  def apply(): LongAdderWrapper = new LongAdderWrapper
+
+  class LongAdderWrapper extends Number {
+    val longAdder = new LongAdder
+
+    def increment() = longAdder.increment()
+
+    def add(delta: Long) = longAdder.add(delta)
+
+    override def longValue() = longAdder.longValue()
+
+    override def intValue(): Int = longAdder.intValue()
+
+    override def floatValue(): Float = longAdder.floatValue()
+
+    override def doubleValue(): Double = longAdder.doubleValue()
+  }
+
+}
+
+

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/metrics/CassandraConnectorSource.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/metrics/CassandraConnectorSource.scala
@@ -4,7 +4,18 @@ import com.codahale.metrics
 import org.apache.spark.SparkEnv
 import org.apache.spark.metrics.source.Source
 
-object CassandraConnectorSource extends Source {
+/** This class is a Source implementation for Cassandra Connector related Codahale metrics. It is
+  * automatically instantiated and registered by Spark metrics system if this source is specified in
+  * metrics configuration file.
+  *
+  * Spark instantiates this class when [[org.apache.spark.SparkEnv SparkEnv]] is started. There can be
+  * only a single instance of [[org.apache.spark.SparkEnv SparkEnv]] so there can be at most a single
+  * active instance of [[CassandraConnectorSource]]. The active instance is assigned to
+  * `CassandraConnectorSource._instance` so that it can be retrieved from anywhere by
+  * [[CassandraConnectorSource.instance]] method. We need this because we have to access the meters from
+  * the task execution.
+  */
+class CassandraConnectorSource extends Source {
   override val sourceName = "cassandra-connector"
 
   override val metricRegistry = new metrics.MetricRegistry
@@ -14,14 +25,49 @@ object CassandraConnectorSource extends Source {
   val writeBatchTimer = metricRegistry.timer("write-batch-timer")
   val writeBatchWaitTimer = metricRegistry.timer("write-batch-wait-timer")
   val writeTaskTimer = metricRegistry.timer("write-task-timer")
-  
+
   val writeSuccessCounter = metricRegistry.counter("write-success-counter")
   val writeFailureCounter = metricRegistry.counter("write-failure-counter")
 
   val readByteMeter = metricRegistry.meter("read-byte-meter")
   val readRowMeter = metricRegistry.meter("read-row-meter")
-  val readPageWaitTimer = metricRegistry.timer("read-page-wait-timer")
   val readTaskTimer = metricRegistry.timer("read-task-timer")
 
-  lazy val ensureInitialized = SparkEnv.get.metricsSystem.registerSource(this)
+  CassandraConnectorSource.maybeSetInstance(this)
+}
+
+object CassandraConnectorSource {
+  @volatile
+  private var _instance: Option[CassandraConnectorSource] = None
+  @volatile
+  private var _env: SparkEnv = null
+
+  /** Returns an active instance of [[CassandraConnectorSource]] if it has been associated with the
+    * current [[org.apache.spark.SparkEnv SparkEnv]] and the current [[org.apache.spark.SparkEnv SparkEnv]]
+    * is running.
+    */
+  def instance = {
+    val curEnv = SparkEnv.get
+    // this simple check allows to control whether the CassandraConnectorSource was created for this
+    // particular SparkEnv. If not - we do not report it as enabled.
+    if (curEnv != null && !curEnv.isStopped && (curEnv eq _env))
+      _instance
+    else
+      None
+  }
+
+  /** This method sets the given instance of [[CassandraConnectorSource]] as the current active instance.
+    * It is allowed to call this method only once for the same `SparkEnv` instance which is currently
+    * up and running.
+    */
+  private def maybeSetInstance(ccs: CassandraConnectorSource): Unit = synchronized {
+    val curEnv = SparkEnv.get
+    assert(ccs != null, "ccs cannot be null")
+    assert(curEnv != null && !curEnv.isStopped, "SparkEnv must be up and running")
+    assert(curEnv ne _env, "instance has been already set for the current SparkEnv")
+
+    CassandraConnectorSource._instance = Some(ccs)
+    CassandraConnectorSource._env = curEnv
+  }
+
 }

--- a/spark-cassandra-connector/src/test/scala/com/datastax/driver/core/RowMock.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/driver/core/RowMock.scala
@@ -1,0 +1,39 @@
+package com.datastax.driver.core
+
+import java.nio.ByteBuffer
+
+class RowMock(columnSizes: Option[Int]*)
+  extends AbstractGettableData(ProtocolVersion.NEWEST_SUPPORTED) with Row {
+
+  val bufs = columnSizes.map {
+    case Some(size) => ByteBuffer.allocate(size)
+    case _ => null
+  }.toArray
+
+  val defs = new ColumnDefinitions(
+    columnSizes.map(i => new ColumnDefinitions.Definition("ks", "tab", s"c$i", DataType.text())).toArray)
+
+  override def getColumnDefinitions: ColumnDefinitions = defs
+
+  override def getBytesUnsafe(i: Int): ByteBuffer = bufs(i)
+
+  override def getBytesUnsafe(s: String): ByteBuffer = getBytesUnsafe(defs.getIndexOf(s))
+
+  override def isNull(i: Int): Boolean = bufs(i) == null
+
+  override def isNull(s: String): Boolean = isNull(defs.getIndexOf(s))
+
+  override def getIndexOf(name: String): Int = ???
+
+  override def getToken(i: Int): Token = ???
+
+  override def getToken(name: String): Token = ???
+
+  override def getPartitionKeyToken: Token = ???
+
+  override def getType(i: Int): DataType = ???
+
+  override def getValue(i: Int): ByteBuffer = ???
+
+  override def getName(i: Int): String = ???
+}

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/metrics/InputMetricsUpdaterSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/metrics/InputMetricsUpdaterSpec.scala
@@ -1,0 +1,127 @@
+package com.datastax.spark.connector.metrics
+
+import com.datastax.driver.core.RowMock
+import com.datastax.spark.connector.rdd.ReadConf
+import org.apache.spark.executor.{DataReadMethod, InputMetrics, TaskMetrics}
+import org.apache.spark.metrics.CassandraConnectorSource
+import org.apache.spark.{SparkConf, SparkEnv}
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+
+class InputMetricsUpdaterSpec extends FlatSpec with Matchers with BeforeAndAfter {
+
+  after {
+    SparkEnv.set(null)
+  }
+
+  "InputMetricsUpdater" should "initialize task metrics properly when they are empty" in {
+    val tc = new TaskContextMock
+    tc.metrics.inputMetrics = None
+
+    val conf = new SparkConf(loadDefaults = false)
+    conf.set("spark.cassandra.input.metrics", "true")
+
+    SparkEnv.set(new SparkEnvMock(conf))
+    val updater = InputMetricsUpdater(tc, ReadConf.fromSparkConf(conf), 3)
+
+    tc.metrics.inputMetrics.isDefined shouldBe true
+    tc.metrics.inputMetrics.get.readMethod shouldBe DataReadMethod.Hadoop
+    tc.metrics.inputMetrics.get.bytesRead shouldBe 0L
+  }
+
+  it should "initialize task metrics properly when they are defined" in {
+    val tc = new TaskContextMock
+    tc.metrics.inputMetrics = Some(new InputMetrics(DataReadMethod.Disk))
+
+    val conf = new SparkConf(loadDefaults = false)
+    conf.set("spark.cassandra.input.metrics", "true")
+
+    SparkEnv.set(new SparkEnvMock(conf))
+    val updater = InputMetricsUpdater(tc, ReadConf.fromSparkConf(conf), 3)
+
+    tc.metrics.inputMetrics.isDefined shouldBe true
+    tc.metrics.inputMetrics.get.readMethod shouldBe DataReadMethod.Hadoop
+    tc.metrics.inputMetrics.get.bytesRead shouldBe 0L
+  }
+
+  it should "create updater which uses task metrics" in {
+    val tc = new TaskContextMock
+    tc.metrics.inputMetrics = None
+
+    val conf = new SparkConf(loadDefaults = false)
+    conf.set("spark.cassandra.input.metrics", "true")
+
+    SparkEnv.set(new SparkEnvMock(conf))
+    val updater = InputMetricsUpdater(tc, ReadConf.fromSparkConf(conf), 3)
+
+    val row = new RowMock(Some(1), Some(2), Some(3), None, Some(4))
+    updater.updateMetrics(row)
+    tc.metrics.inputMetrics.get.bytesRead shouldBe 10L
+
+    updater.updateMetrics(row)
+    updater.updateMetrics(row)
+    updater.updateMetrics(row)
+    tc.metrics.inputMetrics.get.bytesRead shouldBe 40L
+  }
+
+  it should "create updater which does not use task metrics" in {
+    val tc = new TaskContextMock {
+      override def taskMetrics(): TaskMetrics = {
+        fail("This should not be called during this test")
+      }
+    }
+
+    val conf = new SparkConf(loadDefaults = false)
+    conf.set("spark.cassandra.input.metrics", "false")
+
+    SparkEnv.set(new SparkEnvMock(conf))
+    val updater = InputMetricsUpdater(tc, ReadConf.fromSparkConf(conf), 3)
+
+    val row = new RowMock(Some(1), Some(2), Some(3), None, Some(4))
+    updater.updateMetrics(row)
+
+    tc.metrics.inputMetrics shouldBe None
+  }
+
+  it should "create updater which uses Codahale metrics" in {
+    val tc = new TaskContextMock
+    val conf = new SparkConf(loadDefaults = false)
+    SparkEnv.set(new SparkEnvMock(conf))
+    val ccs = new CassandraConnectorSource
+    CassandraConnectorSource.instance should not be None
+
+    val updater = InputMetricsUpdater(tc, ReadConf.fromSparkConf(conf), 3)
+
+    val row = new RowMock(Some(1), Some(2), Some(3), None, Some(4))
+    updater.updateMetrics(row)
+    ccs.readRowMeter.getCount shouldBe 0
+    ccs.readByteMeter.getCount shouldBe 0
+
+    updater.updateMetrics(row)
+    updater.updateMetrics(row)
+    updater.updateMetrics(row)
+
+    ccs.readRowMeter.getCount shouldBe 3L
+    ccs.readByteMeter.getCount shouldBe 30L
+
+    updater.finish()
+    ccs.readTaskTimer.getCount shouldBe 1L
+  }
+
+  it should "create updater which doesn't use Codahale metrics" in {
+    val tc = new TaskContextMock
+    val conf = new SparkConf(loadDefaults = false)
+    SparkEnv.set(new SparkEnvMock(conf))
+
+    val updater = InputMetricsUpdater(tc, ReadConf.fromSparkConf(conf), 3)
+    val row = new RowMock(Some(1), Some(2), Some(3), None, Some(4))
+    updater.updateMetrics(row)
+    updater.updateMetrics(row)
+    updater.updateMetrics(row)
+    updater.updateMetrics(row)
+    CassandraConnectorSource.instance shouldBe None
+
+    updater.finish()
+  }
+
+
+}

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/metrics/OutputMetricsUpdaterSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/metrics/OutputMetricsUpdaterSpec.scala
@@ -1,0 +1,157 @@
+package com.datastax.spark.connector.metrics
+
+import java.util.concurrent.CountDownLatch
+
+import com.datastax.spark.connector.writer.WriteConf
+import org.apache.spark.executor.{DataWriteMethod, OutputMetrics, TaskMetrics}
+import org.apache.spark.metrics.CassandraConnectorSource
+import org.apache.spark.{SparkConf, SparkEnv}
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+
+class OutputMetricsUpdaterSpec extends FlatSpec with Matchers with BeforeAndAfter {
+
+  val ts = System.currentTimeMillis()
+
+  after {
+    SparkEnv.set(null)
+  }
+
+  "OutputMetricsUpdater" should "initialize task metrics properly when they are empty" in {
+    val tc = new TaskContextMock
+    tc.metrics.outputMetrics = None
+
+    val conf = new SparkConf(loadDefaults = false)
+    conf.set("spark.cassandra.output.metrics", "true")
+
+    SparkEnv.set(new SparkEnvMock(conf))
+    val updater = OutputMetricsUpdater(tc, WriteConf.fromSparkConf(conf))
+
+    tc.metrics.outputMetrics.isDefined shouldBe true
+    tc.metrics.outputMetrics.get.writeMethod shouldBe DataWriteMethod.Hadoop
+    tc.metrics.outputMetrics.get.bytesWritten shouldBe 0L
+  }
+
+  it should "initialize task metrics properly when they are defined" in {
+    val tc = new TaskContextMock
+    tc.metrics.outputMetrics = Some(new OutputMetrics(DataWriteMethod.Hadoop))
+
+    val conf = new SparkConf(loadDefaults = false)
+    conf.set("spark.cassandra.output.metrics", "true")
+
+    SparkEnv.set(new SparkEnvMock(conf))
+    val updater = OutputMetricsUpdater(tc, WriteConf.fromSparkConf(conf))
+
+    tc.metrics.outputMetrics.isDefined shouldBe true
+    tc.metrics.outputMetrics.get.writeMethod shouldBe DataWriteMethod.Hadoop
+    tc.metrics.outputMetrics.get.bytesWritten shouldBe 0L
+  }
+
+  it should "create updater which uses task metrics" in {
+    val tc = new TaskContextMock
+    tc.metrics.outputMetrics = None
+
+    val conf = new SparkConf(loadDefaults = false)
+    conf.set("spark.cassandra.output.metrics", "true")
+
+    SparkEnv.set(new SparkEnvMock(conf))
+    val updater = OutputMetricsUpdater(tc, WriteConf.fromSparkConf(conf))
+
+    val rc = new RichStatementMock(100, 10)
+    updater.batchFinished(success = true, rc, ts, ts)
+    tc.metrics.outputMetrics.get.bytesWritten shouldBe 100L // change registered when success
+
+    updater.batchFinished(success = false, rc, ts, ts)
+    tc.metrics.outputMetrics.get.bytesWritten shouldBe 100L // change not regsitered when failure
+  }
+
+  it should "create updater which does not use task metrics" in {
+    val tc = new TaskContextMock {
+      override def taskMetrics(): TaskMetrics = {
+        fail("This should not be called during this test")
+      }
+    }
+
+    val conf = new SparkConf(loadDefaults = false)
+    conf.set("spark.cassandra.output.metrics", "false")
+
+    SparkEnv.set(new SparkEnvMock(conf))
+    val updater = OutputMetricsUpdater(tc, WriteConf.fromSparkConf(conf))
+
+    val rc = new RichStatementMock(100, 10)
+    updater.batchFinished(success = true, rc, ts, ts)
+    updater.batchFinished(success = false, rc, ts, ts)
+
+    tc.metrics.outputMetrics shouldBe None
+  }
+
+  it should "create updater which uses Codahale metrics" in {
+    val tc = new TaskContextMock
+    val conf = new SparkConf(loadDefaults = false)
+    SparkEnv.set(new SparkEnvMock(conf))
+    val ccs = new CassandraConnectorSource
+    CassandraConnectorSource.instance should not be None
+
+    val updater = OutputMetricsUpdater(tc, WriteConf.fromSparkConf(conf))
+
+    val rc = new RichStatementMock(100, 10)
+    updater.batchFinished(success = true, rc, ts, ts)
+    ccs.writeRowMeter.getCount shouldBe 10L
+    ccs.writeByteMeter.getCount shouldBe 100L
+    ccs.writeSuccessCounter.getCount shouldBe 1L
+    ccs.writeFailureCounter.getCount shouldBe 0L
+
+    updater.batchFinished(success = false, rc, ts, ts)
+    ccs.writeRowMeter.getCount shouldBe 10L
+    ccs.writeByteMeter.getCount shouldBe 100L
+    ccs.writeSuccessCounter.getCount shouldBe 1L
+    ccs.writeFailureCounter.getCount shouldBe 1L
+
+    updater.finish()
+    ccs.writeTaskTimer.getCount shouldBe 1L
+  }
+
+  it should "create updater which doesn't use Codahale metrics" in {
+    val tc = new TaskContextMock
+    val conf = new SparkConf(loadDefaults = false)
+    SparkEnv.set(new SparkEnvMock(conf))
+
+    val updater = OutputMetricsUpdater(tc, WriteConf.fromSparkConf(conf))
+    val rc = new RichStatementMock(100, 10)
+    updater.batchFinished(success = true, rc, ts, ts)
+    updater.batchFinished(success = false, rc, ts, ts)
+
+    CassandraConnectorSource.instance shouldBe None
+
+    updater.finish()
+  }
+
+  it should "work correctly with multiple threads" in {
+    val tc = new TaskContextMock
+    tc.metrics.outputMetrics = None
+
+    val conf = new SparkConf(loadDefaults = false)
+    conf.set("spark.cassandra.output.metrics", "true")
+
+    SparkEnv.set(new SparkEnvMock(conf))
+    val updater = OutputMetricsUpdater(tc, WriteConf.fromSparkConf(conf))
+
+    val rc = new RichStatementMock(100, 10)
+
+    val latch = new CountDownLatch(32)
+    class TestThread extends Thread {
+      override def run(): Unit = {
+        latch.countDown()
+        latch.await()
+        for (i <- 1 to 100000)
+          updater.batchFinished(success = true, rc, ts, ts)
+      }
+    }
+
+    val threads = Array.fill(32)(new TestThread)
+    threads.foreach(_.start())
+    threads.foreach(_.join())
+
+    tc.metrics.outputMetrics.get.bytesWritten shouldBe 320000000L
+  }
+
+}

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/metrics/RichStatementMock.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/metrics/RichStatementMock.scala
@@ -1,0 +1,5 @@
+package com.datastax.spark.connector.metrics
+
+import com.datastax.spark.connector.writer.RichStatement
+
+class RichStatementMock(val bytesCount: Int, val rowsCount: Int) extends RichStatement

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/metrics/SparkEnvMock.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/metrics/SparkEnvMock.scala
@@ -1,0 +1,7 @@
+package com.datastax.spark.connector.metrics
+
+import org.apache.spark.{SparkConf, SparkEnv}
+
+class SparkEnvMock(conf: SparkConf) extends SparkEnv(
+  null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, conf
+)

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/metrics/TaskContextMock.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/metrics/TaskContextMock.scala
@@ -1,0 +1,31 @@
+package com.datastax.spark.connector.metrics
+
+import org.apache.spark.TaskContext
+import org.apache.spark.executor.TaskMetrics
+import org.apache.spark.util.TaskCompletionListener
+
+class TaskContextMock extends TaskContext {
+  val metrics = new TaskMetrics
+
+  override def isCompleted: Boolean = ???
+
+  override def addOnCompleteCallback(f: () => Unit): Unit = ???
+
+  override def taskMetrics(): TaskMetrics = metrics
+
+  override def isRunningLocally: Boolean = ???
+
+  override def isInterrupted: Boolean = ???
+
+  override def runningLocally(): Boolean = ???
+
+  override def partitionId(): Int = ???
+
+  override def addTaskCompletionListener(listener: TaskCompletionListener): TaskContext = ???
+
+  override def addTaskCompletionListener(f: (TaskContext) => Unit): TaskContext = ???
+
+  override def attemptId(): Long = ???
+
+  override def stageId(): Int = ???
+}


### PR DESCRIPTION
- enabling/disabling Codahale metrics via metric.properties file
- changed locking to LongAdder in output metrics (dozens times faster)
- removed one useless metric
- added several unit tests and some integration tests
- updated docs and changes