### PR TITLE
SPARKC-96: Allow RateLimiter to use an alternative time source and sleep...

### DIFF
--- a/project/CassandraSparkBuild.scala
+++ b/project/CassandraSparkBuild.scala
@@ -167,7 +167,8 @@ object Dependencies {
     object Test {
       val akkaTestKit       = "com.typesafe.akka"       %% "akka-testkit"           % Akka      % "test,it"       // ApacheV2
       val commonsIO         = "commons-io"              % "commons-io"              % CommonsIO % "test,it"       // ApacheV2
-      val scalatest         = "org.scalatest"           %% "scalatest"              % ScalaTest % "test,it"       // ApacheV2
+      val scalaMock         = "org.scalamock"           %% "scalamock-scalatest-support" % ScalaMock % "test,it"  // BSD
+      val scalaTest         = "org.scalatest"           %% "scalatest"              % ScalaTest % "test,it"       // ApacheV2
       val scalactic         = "org.scalactic"           %% "scalactic"              % Scalactic % "test,it"       // ApacheV2
       val mockito           = "org.mockito"             % "mockito-all"             % "1.10.19" % "test,it"       // MIT
       val junit             = "junit"                   % "junit"                   % "4.11"    % "test,it"
@@ -183,7 +184,7 @@ object Dependencies {
   val metrics = Seq(Metrics.metricsCore, Metrics.metricsJson)
 
   val testKit = Seq(Test.akkaTestKit, Test.commonsIO, Test.junit,
-   Test.junitInterface, Test.scalatest, Test.scalactic, Test.mockito)
+   Test.junitInterface, Test.scalaMock, Test.scalaTest, Test.scalactic, Test.mockito)
 
   val akka = Seq(akkaActor, akkaRemote, akkaSlf4j)
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -43,6 +43,7 @@ object Versions {
   val Kafka210        = "0.8.1.1"
   val Lzf             = "0.8.4"
   val CodaHaleMetrics = "3.0.2"
+  val ScalaMock       = "3.2"
   val ScalaTest       = "2.2.2"
   val Scalactic       = "2.2.2"
   val Slf4j           = "1.6.1"//1.7.7"


### PR DESCRIPTION
... method. Make the test independent from the wall-clock time nd JVM performance hiccups.