### PR TITLE
SPARKC-99: Code formatting and cleanup.

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
@@ -14,71 +14,111 @@ import org.apache.spark.{Partition, TaskContext}
 import scala.reflect.ClassTag
 
 /**
- * An RDD that will do a selecting join between `prev:RDD` and the specified Cassandra Table
+ * An `RDD` that will do a selecting join between `left` RDD and the specified Cassandra Table
  * This will perform individual selects to retrieve the rows from Cassandra and will take
- * advantage of RDD's that have been partitioned with the [[com.datastax.spark.connector.rdd.partitioner.ReplicaPartitioner]]
+ * advantage of RDDs that have been partitioned with the
+ * [[com.datastax.spark.connector.rdd.partitioner.ReplicaPartitioner]]
  */
-class CassandraJoinRDD[Left, Right] private[connector](prev: RDD[Left],
-                                                val keyspaceName: String,
-                                                val tableName: String,
-                                                val connector: CassandraConnector,
-                                                val columnNames: ColumnSelector = AllColumns,
-                                                val joinColumns: ColumnSelector = PartitionKeyColumns,
-                                                val where: CqlWhereClause = CqlWhereClause.empty,
-                                                val limit: Option[Long] = None,
-                                                val clusteringOrder: Option[ClusteringOrder] = None,
-                                                val readConf: ReadConf = ReadConf())
-                                                      (implicit oldTag: ClassTag[Left], val rct: ClassTag[Right],
-                                                       @transient val rwf: RowWriterFactory[Left], @transient val rtf: RowReaderFactory[Right])
-  extends CassandraRDD[(Left, Right)](prev.sparkContext, prev.dependencies) with CassandraTableRowReaderProvider[Right] {
+class CassandraJoinRDD[Left, Right] private[connector](
+    left: RDD[Left],
+    val keyspaceName: String,
+    val tableName: String,
+    val connector: CassandraConnector,
+    val columnNames: ColumnSelector = AllColumns,
+    val joinColumns: ColumnSelector = PartitionKeyColumns,
+    val where: CqlWhereClause = CqlWhereClause.empty,
+    val limit: Option[Long] = None,
+    val clusteringOrder: Option[ClusteringOrder] = None,
+    val readConf: ReadConf = ReadConf())(
+  implicit
+    leftClassTag: ClassTag[Left],
+    rightClassTag: ClassTag[Right],
+    @transient val rowWriterFactory: RowWriterFactory[Left],
+    @transient val rowReaderFactory: RowReaderFactory[Right])
+  extends CassandraRDD[(Left, Right)](left.sparkContext, left.dependencies)
+  with CassandraTableRowReaderProvider[Right] {
 
-  //Make sure copy operations make new CJRDDs and not CRDDs
-  override protected def copy(columnNames: ColumnSelector = columnNames,
-                              where: CqlWhereClause = where,
-                              limit: Option[Long] = limit,
-                              clusteringOrder: Option[ClusteringOrder] = None,
-                              readConf: ReadConf = readConf,
-                              connector: CassandraConnector = connector) =
-    new CassandraJoinRDD[Left, Right](prev, keyspaceName, tableName, connector, columnNames, joinColumns, where, limit, clusteringOrder, readConf).asInstanceOf[this.type]
+  override type Self = CassandraJoinRDD[Left, Right]
+
+  override protected val classTag = rightClassTag
+
+  override protected def copy(
+    columnNames: ColumnSelector = columnNames,
+    where: CqlWhereClause = where,
+    limit: Option[Long] = limit,
+    clusteringOrder: Option[ClusteringOrder] = None,
+    readConf: ReadConf = readConf,
+    connector: CassandraConnector = connector): Self = {
+
+    new CassandraJoinRDD[Left, Right](
+      left = left,
+      keyspaceName = keyspaceName,
+      tableName = tableName,
+      connector = connector,
+      columnNames = columnNames,
+      joinColumns = joinColumns,
+      where = where,
+      limit = limit,
+      clusteringOrder = clusteringOrder,
+      readConf = readConf)
+  }
 
   lazy val joinColumnNames: Seq[NamedColumnRef] = joinColumns match {
-    case AllColumns => throw new IllegalArgumentException("Unable to join against all columns in a Cassandra Table. Only primary key columns allowed.")
-    case PartitionKeyColumns => tableDef.partitionKey.map(col => col.columnName: NamedColumnRef).toSeq
-    case SomeColumns(cs@_*) => {
+    case AllColumns => throw new IllegalArgumentException(
+      "Unable to join against all columns in a Cassandra Table. Only primary key columns allowed.")
+    case PartitionKeyColumns =>
+      tableDef.partitionKey.map(col => col.columnName: NamedColumnRef)
+    case SomeColumns(cs @ _*) =>
       checkColumnsExistence(cs)
       cs.map {
         case c: NamedColumnRef => c
-        case _ => throw new IllegalArgumentException("Unable to join against unnamed columns. No CQL Functions allowed.")
+        case _ => throw new IllegalArgumentException(
+          "Unable to join against unnamed columns. No CQL Functions allowed.")
       }
-    }
   }
 
   override def count(): Long = {
     columnNames match {
-      case SomeColumns(_) => logWarning("You are about to count rows but an explicit projection has been specified.")
+      case SomeColumns(_) =>
+        logWarning("You are about to count rows but an explicit projection has been specified.")
       case _ =>
     }
-    new CassandraJoinRDD[Left, Long](prev, keyspaceName, tableName, connector, SomeColumns(RowCountRef), joinColumns, where, limit, clusteringOrder, readConf).map(_._2).reduce(_ + _)
+
+    val counts =
+      new CassandraJoinRDD[Left, Long](
+        left = left,
+        connector = connector,
+        keyspaceName = keyspaceName,
+        tableName = tableName,
+        columnNames = SomeColumns(RowCountRef),
+        joinColumns = joinColumns,
+        where = where,
+        limit = limit,
+        clusteringOrder = clusteringOrder,
+        readConf= readConf)
+
+    counts.map(_._2).reduce(_ + _)
   }
 
-  /**
-   * This method will create the RowWriter required before the RDD is serialized. This is called during getPartitions
-   */
+  /** This method will create the RowWriter required before the RDD is serialized.
+    * This is called during getPartitions */
   protected def checkValidJoin(): Seq[NamedColumnRef] = {
-    val regularColumnNames = tableDef.regularColumns.map(_.columnName).toSet
     val partitionKeyColumnNames = tableDef.partitionKey.map(_.columnName).toSet
+    val primaryKeyColumnNames = tableDef.primaryKey.map(_.columnName).toSet
     val colNames = joinColumnNames.map(_.columnName).toSet
 
-    //Initialize RowWriter and Query to be used for accessing Cassandra
+    // Initialize RowWriter and Query to be used for accessing Cassandra
     rowWriter.columnNames
-    singleKeyCqlQuery.size
+    singleKeyCqlQuery.length
 
     def checkSingleColumn(column: NamedColumnRef): Unit = {
-      if (regularColumnNames.contains(column.columnName))
-        throw new IllegalArgumentException(s"Can't pushdown join on column $column because it is not part of the PRIMARY KEY")
+      require(
+        primaryKeyColumnNames.contains(column.columnName),
+        s"Can't pushdown join on column $column because it is not part of the PRIMARY KEY")
     }
 
-    //Make sure we have all of the clustering indexes between the 0th position and the max requested in the join
+    // Make sure we have all of the clustering indexes between the 0th position and the max requested
+    // in the join:
     val chosenClusteringColumns = tableDef.clusteringColumns
       .filter(cc => colNames.contains(cc.columnName))
     if (!tableDef.clusteringColumns.startsWith(chosenClusteringColumns)) {
@@ -86,14 +126,15 @@ class CassandraJoinRDD[Left, Right] private[connector](prev: RDD[Left],
       val maxIndex = maxCol.componentIndex.get
       val requiredColumns = tableDef.clusteringColumns.takeWhile(_.componentIndex.get <= maxIndex)
       val missingColumns = requiredColumns.toSet -- chosenClusteringColumns.toSet
-      if (!missingColumns.isEmpty)
-        throw new IllegalArgumentException(s"Can't pushdown join on column $maxCol without also specifying [ $missingColumns ]")
-      }
-    val missingPartitionKeys = partitionKeyColumnNames -- colNames
-    if (missingPartitionKeys.size != 0) {
-      throw new IllegalArgumentException(s"Can't join without the full partition key. Missing: [ ${missingPartitionKeys} ]")
+      throw new IllegalArgumentException(
+        s"Can't pushdown join on column $maxCol without also specifying [ $missingColumns ]")
     }
-    joinColumnNames.foreach { case c: NamedColumnRef => checkSingleColumn(c)}
+    val missingPartitionKeys = partitionKeyColumnNames -- colNames
+    require(
+      missingPartitionKeys.size == 0,
+      s"Can't join without the full partition key. Missing: [ $missingPartitionKeys ]")
+
+    joinColumnNames.foreach { case c: NamedColumnRef => checkSingleColumn(c) }
     joinColumnNames
   }
 
@@ -106,7 +147,17 @@ class CassandraJoinRDD[Left, Right] private[connector](prev: RDD[Left],
   )
 
   def on(joinColumns: ColumnSelector): CassandraJoinRDD[Left, Right] = {
-    new CassandraJoinRDD[Left, Right](prev, keyspaceName, tableName, connector, columnNames, joinColumns, where, limit, clusteringOrder, readConf).asInstanceOf[this.type]
+    new CassandraJoinRDD[Left, Right](
+      left = left,
+      connector = connector,
+      keyspaceName = keyspaceName,
+      tableName = tableName,
+      columnNames = columnNames,
+      joinColumns = joinColumns,
+      where = where,
+      limit = limit,
+      clusteringOrder = clusteringOrder,
+      readConf = readConf)
   }
 
   //We need to make sure we get selectedColumnRefs before serialization so that our RowReader is
@@ -120,7 +171,10 @@ class CassandraJoinRDD[Left, Right] private[connector](prev: RDD[Left],
       case InListPredicate(c, _) if partitionKeys.contains(c) => c
       case RangePredicate(c, _, _) if partitionKeys.contains(c) => c
     }.toSet
-    require(partitionKeyPredicates.isEmpty, s"No partition keys allowed in where on joins with Cassandra. Found : $partitionKeyPredicates")
+
+    require(
+      partitionKeyPredicates.isEmpty,
+      s"No partition keys allowed in where on joins with Cassandra. Found : $partitionKeyPredicates")
 
     logDebug("Generating Single Key Query Prepared Statement String")
     logDebug(s"SelectedColumns : $selectedColumnRefs -- JoinColumnNames : $joinColumnNames")
@@ -131,7 +185,10 @@ class CassandraJoinRDD[Left, Right] private[connector](prev: RDD[Left],
     val filter = (where.predicates ++ joinWhere).mkString(" AND ")
     val quotedKeyspaceName = quote(keyspaceName)
     val quotedTableName = quote(tableName)
-    val query = s"SELECT $columns FROM $quotedKeyspaceName.$quotedTableName WHERE $filter $limitClause $orderBy"
+    val query =
+      s"SELECT $columns " +
+        s"FROM $quotedKeyspaceName.$quotedTableName " +
+        s"WHERE $filter $limitClause $orderBy"
     logDebug(s"Query : $query")
     query
   }
@@ -139,7 +196,7 @@ class CassandraJoinRDD[Left, Right] private[connector](prev: RDD[Left],
   /**
    * When computing a CassandraPartitionKeyRDD the data is selected via single CQL statements
    * from the specified C* Keyspace and Table. This will be preformed on whatever data is
-   * avaliable in the previous RDD in the chain.
+   * available in the previous RDD in the chain.
    */
   override def compute(split: Partition, context: TaskContext): Iterator[(Left, Right)] = {
     val session = connector.openSession()
@@ -147,17 +204,25 @@ class CassandraJoinRDD[Left, Right] private[connector](prev: RDD[Left],
     val stmt = session.prepare(singleKeyCqlQuery).setConsistencyLevel(consistencyLevel)
     val bsb = new BoundStatementBuilder[Left](rowWriter, stmt, pv)
     val metricsUpdater = InputMetricsUpdater(context, 20)
-    val rowIterator = fetchIterator(session, bsb, prev.iterator(split, context))
+    val rowIterator = fetchIterator(session, bsb, left.iterator(split, context))
     val countingIterator = new CountingIterator(rowIterator, limit)
+
     context.addTaskCompletionListener { (context) =>
       val duration = metricsUpdater.finish() / 1000000000d
-      logDebug(f"Fetched ${countingIterator.count} rows from $keyspaceName.$tableName for partition ${split.index} in $duration%.3f s.")
+      logDebug(
+        f"Fetched ${countingIterator.count} rows " +
+          f"from $keyspaceName.$tableName " +
+          f"for partition ${split.index} in $duration%.3f s.")
       session.close()
     }
     countingIterator
   }
 
-  private def fetchIterator(session: Session, bsb: BoundStatementBuilder[Left], lastIt: Iterator[Left]): Iterator[(Left, Right)] = {
+  private def fetchIterator(
+    session: Session,
+    bsb: BoundStatementBuilder[Left],
+    lastIt: Iterator[Left]): Iterator[(Left, Right)] = {
+
     val columnNamesArray = selectedColumnRefs.map(_.selectedFromCassandraAs).toArray
     implicit val pv = protocolVersion(session)
     for (leftSide <- lastIt;
@@ -171,10 +236,19 @@ class CassandraJoinRDD[Left, Right] private[connector](prev: RDD[Left],
   override protected def getPartitions: Array[Partition] = {
     verify()
     checkValidJoin()
-    prev.partitions
+    left.partitions
   }
 
-  override def getPreferredLocations(split: Partition): Seq[String] = prev.preferredLocations(split)
+  override def getPreferredLocations(split: Partition): Seq[String] = left.preferredLocations(split)
 
-  override def toEmptyCassandraRDD(): EmptyCassandraRDD[(Left, Right)] = new EmptyCassandraRDD[(Left, Right)](prev.sparkContext, keyspaceName, tableName, columnNames, where, limit, clusteringOrder, readConf)
+  override def toEmptyCassandraRDD: EmptyCassandraRDD[(Left, Right)] =
+    new EmptyCassandraRDD[(Left, Right)](
+      sc = left.sparkContext,
+      keyspaceName = keyspaceName,
+      tableName = tableName,
+      columnNames = columnNames,
+      where = where,
+      limit = limit,
+      clusteringOrder = clusteringOrder,
+      readConf = readConf)
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
@@ -12,10 +12,19 @@ import org.apache.spark.{Dependency, SparkContext}
 import scala.language.existentials
 import scala.reflect.ClassTag
 
-abstract class CassandraRDD[R](_sc: SparkContext, dep: Seq[Dependency[_]])(implicit ct: ClassTag[R]) extends RDD[R](_sc, dep) {
+abstract class CassandraRDD[R : ClassTag](
+    sc: SparkContext,
+    dep: Seq[Dependency[_]])
+  extends RDD[R](sc, dep) {
 
-  //Check for valid Spark configuration
-  ConfigCheck.checkConfig(_sc.getConf)
+  /** This is slightly different than Scala this.type.
+    * this.type is the unique singleton type of an object which is not compatible with other
+    * instances of the same type, so returning anything other than `this` is not really possible
+    * without lying to the compiler by explicit casts.
+    * Here SelfType is used to return a copy of the object - a different instance of the same type */
+  type Self <: CassandraRDD[R]
+  
+  ConfigCheck.checkConfig(sc.getConf)
 
   protected def keyspaceName: String
 
@@ -35,30 +44,32 @@ abstract class CassandraRDD[R](_sc: SparkContext, dep: Seq[Dependency[_]])(impli
 
   protected def connector: CassandraConnector
 
-  def toEmptyCassandraRDD(): EmptyCassandraRDD[R]
+  def toEmptyCassandraRDD: EmptyCassandraRDD[R]
+
+  /** Allows to copy this RDD with changing some of the properties */
+  protected def copy(
+    columnNames: ColumnSelector = columnNames,
+    where: CqlWhereClause = where,
+    limit: Option[Long] = limit,
+    clusteringOrder: Option[ClusteringOrder] = None,
+    readConf: ReadConf = readConf,
+    connector: CassandraConnector = connector): Self
 
   /** Allows to set custom read configuration, e.g. consistency level or fetch size. */
-  def withReadConf(readConf: ReadConf) = {
+  def withReadConf(readConf: ReadConf): Self =
     copy(readConf = readConf)
-  }
-
-  protected def copy(columnNames: ColumnSelector = columnNames,
-                     where: CqlWhereClause = where,
-                     limit: Option[Long] = limit,
-                     clusteringOrder: Option[ClusteringOrder] = None,
-                     readConf: ReadConf = readConf,
-                     connector: CassandraConnector = connector): CassandraRDD[R]
-
+  
   /** Returns a copy of this Cassandra RDD with specified connector */
-  def withConnector(connector: CassandraConnector): CassandraRDD[R] = {
+  def withConnector(connector: CassandraConnector): Self = {
     copy(connector = connector)
   }
 
   /** Adds a CQL `WHERE` predicate(s) to the query.
     * Useful for leveraging secondary indexes in Cassandra.
-    * Implicitly adds an `ALLOW FILTERING` clause to the WHERE clause, however beware that some predicates
-    * might be rejected by Cassandra, particularly in cases when they filter on an unindexed, non-clustering column. */
-  def where(cql: String, values: Any*): CassandraRDD[R] = {
+    * Implicitly adds an `ALLOW FILTERING` clause to the WHERE clause, 
+    * however beware that some predicates might be rejected by Cassandra, 
+    * particularly in cases when they filter on an unindexed, non-clustering column. */
+  def where(cql: String, values: Any*): Self = {
     copy(where = where and CqlWhereClause(Seq(cql), values))
   }
 
@@ -74,7 +85,7 @@ abstract class CassandraRDD[R](_sc: SparkContext, dep: Seq[Dependency[_]])(impli
     * just column names (which is also backward compatible) and optional add `.ttl` or `.writeTime`
     * suffix in order to create an appropriate [[NamedColumnRef]] instance.
     */
-  def select(columns: SelectableColumnRef*): CassandraRDD[R] = {
+  def select(columns: SelectableColumnRef*): Self = {
     copy(columnNames = SomeColumns(narrowColumnSelection(columns): _*))
   }
 
@@ -85,7 +96,7 @@ abstract class CassandraRDD[R](_sc: SparkContext, dep: Seq[Dependency[_]])(impli
     * The main purpose of passing limit clause is to fetch top n rows from a single Cassandra
     * partition when the table is designed so that it uses clustering keys and a partition key
     * predicate is passed to the where clause. */
-  def limit(rowLimit: Long): CassandraRDD[R] = {
+  def limit(rowLimit: Long): Self = {
     copy(limit = Some(rowLimit))
   }
 
@@ -94,13 +105,13 @@ abstract class CassandraRDD[R](_sc: SparkContext, dep: Seq[Dependency[_]])(impli
     * pushed down in `where`.
     * It is useful when the default direction of ordering rows within a single Cassandra partition
     * needs to be changed. */
-  def clusteringOrder(order: ClusteringOrder): CassandraRDD[R] = {
+  def clusteringOrder(order: ClusteringOrder): Self = {
     copy(clusteringOrder = Some(order))
   }
 
-  def withAscOrder: CassandraRDD[R] = clusteringOrder(Ascending)
-
-  def withDescOrder: CassandraRDD[R] = clusteringOrder(Descending)
+  def withAscOrder: Self = clusteringOrder(Ascending)
+  
+  def withDescOrder: Self = clusteringOrder(Descending)
 
   override def take(num: Int): Array[R] = {
     limit match {
@@ -114,36 +125,45 @@ abstract class CassandraRDD[R](_sc: SparkContext, dep: Seq[Dependency[_]])(impli
   // Needed to be public for JavaAPI
   val selectedColumnRefs: Seq[SelectableColumnRef]
 
-  //convertTo must be implmented for classes which wish to support `.as`
-  protected def convertTo[B](implicit ct: ClassTag[B], rrf: RowReaderFactory[B]): CassandraRDD[B] =
+  // convertTo must be implemented for classes which wish to support `.as`
+  protected def convertTo[B : ClassTag : RowReaderFactory]: CassandraRDD[B] =
     throw new NotImplementedError(s"convertTo not implemented for this class")
 
-  /** Maps each row into object of a different type using provided function taking column value(s) as argument(s).
-    * Can be used to convert each row to a tuple or a case class object:
+  /** Maps each row into object of a different type using provided function taking column
+    * value(s) as argument(s). Can be used to convert each row to a tuple or a case class object:
     * {{{
-    * sc.cassandraTable("ks", "table").select("column1").as((s: String) => s)                 // yields CassandraRDD[String]
-    * sc.cassandraTable("ks", "table").select("column1", "column2").as((_: String, _: Long))  // yields CassandraRDD[(String, Long)]
+    * sc.cassandraTable("ks", "table")
+    *   .select("column1")
+    *   .as((s: String) => s)                 // yields CassandraRDD[String]
+    *
+    * sc.cassandraTable("ks", "table")
+    *   .select("column1", "column2")
+    *   .as((_: String, _: Long))             // yields CassandraRDD[(String, Long)]
     *
     * case class MyRow(key: String, value: Long)
-    * sc.cassandraTable("ks", "table").select("column1", "column2").as(MyRow)                 // yields CassandraRDD[MyRow]
+    * sc.cassandraTable("ks", "table")
+    *   .select("column1", "column2")
+    *   .as(MyRow)                            // yields CassandraRDD[MyRow]
     * }}} */
   def as[B: ClassTag, A0: TypeConverter](f: A0 => B): CassandraRDD[B] = {
     implicit val ft = new FunctionBasedRowReader1(f)
     convertTo[B]
   }
 
-  def as[B: ClassTag, A0: TypeConverter, A1: TypeConverter](f: (A0, A1) => B) = {
+  def as[B: ClassTag, A0: TypeConverter, A1: TypeConverter](f: (A0, A1) => B): CassandraRDD[B] = {
     implicit val ft = new FunctionBasedRowReader2(f)
     convertTo[B]
   }
 
-  def as[B: ClassTag, A0: TypeConverter, A1: TypeConverter, A2: TypeConverter](f: (A0, A1, A2) => B) = {
+  def as[B: ClassTag, A0: TypeConverter, A1: TypeConverter, A2: TypeConverter]
+    (f: (A0, A1, A2) => B): CassandraRDD[B] = {
+
     implicit val ft = new FunctionBasedRowReader3(f)
     convertTo[B]
   }
 
   def as[B: ClassTag, A0: TypeConverter, A1: TypeConverter, A2: TypeConverter,
-  A3: TypeConverter](f: (A0, A1, A2, A3) => B) = {
+         A3: TypeConverter](f: (A0, A1, A2, A3) => B) = {
     implicit val ft = new FunctionBasedRowReader4(f)
     convertTo[B]
   }
@@ -195,9 +215,10 @@ abstract class CassandraRDD[R](_sc: SparkContext, dep: Seq[Dependency[_]])(impli
   }
 
   def as[B: ClassTag, A0: TypeConverter, A1: TypeConverter, A2: TypeConverter, A3: TypeConverter,
-  A4: TypeConverter, A5: TypeConverter, A6: TypeConverter, A7: TypeConverter, A8: TypeConverter,
-  A9: TypeConverter, A10: TypeConverter, A11: TypeConverter](
-                                                              f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => B) = {
+         A4: TypeConverter, A5: TypeConverter, A6: TypeConverter, A7: TypeConverter, A8: TypeConverter,
+         A9: TypeConverter, A10: TypeConverter, A11: TypeConverter](
+    f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11) => B) = {
+
     implicit val ft = new FunctionBasedRowReader12(f)
     convertTo[B]
   }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/CassandraStreamingRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/CassandraStreamingRDD.scala
@@ -24,4 +24,13 @@ class CassandraStreamingRDD[R] private[connector] (
   implicit
     ct : ClassTag[R],
     @transient val rrf: RowReaderFactory[R])
-  extends CassandraTableScanRDD[R](sctx.sparkContext, connector, keyspace, table, columns, where, limit, clusteringOrder, readConf)
+  extends CassandraTableScanRDD[R](
+    sc = sctx.sparkContext,
+    connector = connector,
+    keyspaceName = keyspace,
+    tableName = table,
+    columnNames = columns,
+    where = where,
+    limit = limit,
+    clusteringOrder = clusteringOrder,
+    readConf = readConf)


### PR DESCRIPTION
Limit line length to 105 columns. No logic changed.