### PR TITLE
SPARKC-93:  Remove use of Thrift describe_ring.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+1.3.x (unreleased)
+ * Removed use of Thrift describe_ring and replaced it with native Java Driver
+   support for fetching TokenRanges (SPARKC-93)
+
+********************************************************************************
+
 1.2.0 RC 3
  * Select aliases are no longer ignored in CassandraRow objects (SPARKC-109)
  * Fix picking up username and password from SparkConf (SPARKC-108)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/Murmur3PartitionerTokenRangeSplitter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/Murmur3PartitionerTokenRangeSplitter.scala
@@ -24,7 +24,7 @@ class Murmur3PartitionerTokenRangeSplitter(cassandraPartitionsPerToken: Double) 
       new TokenRange[Long, LongToken](
         new LongToken(l),
         new LongToken(r),
-        range.endpoints,
+        range.replicas,
         Some((estimatedRows / n).toInt))
   }
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/RandomPartitionerTokenRangeSplitter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/RandomPartitionerTokenRangeSplitter.scala
@@ -29,7 +29,7 @@ class RandomPartitionerTokenRangeSplitter(cassandraPartitionsPerToken: Double) e
       new TokenRange[BigInt, BigIntToken](
         new BigIntToken(l.bigInteger),
         new BigIntToken(r.bigInteger),
-        range.endpoints,
+        range.replicas,
         Some((estimatedRows / n).toInt))
   }
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/ServerSideTokenRangeSplitter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/ServerSideTokenRangeSplitter.scala
@@ -7,10 +7,10 @@ import scala.collection.JavaConversions._
 import scala.util.{Failure, Success, Try}
 
 import org.apache.cassandra.thrift.CfSplit
+import org.apache.spark.Logging
 
 import com.datastax.spark.connector.cql.CassandraConnector
-import com.datastax.spark.connector.rdd.partitioner.dht.{CassandraNode, Token, TokenFactory, TokenRange}
-import org.apache.spark.Logging
+import com.datastax.spark.connector.rdd.partitioner.dht.{Token, TokenFactory, TokenRange}
 
 /** Delegates token range splitting to Cassandra server. */
 class ServerSideTokenRangeSplitter[V, T <: Token[V]](
@@ -20,13 +20,17 @@ class ServerSideTokenRangeSplitter[V, T <: Token[V]](
   tokenFactory: TokenFactory[V, T])
   extends TokenRangeSplitter[V, T] with Logging {
 
-  private def unthriftify(cfSplit: CfSplit, endpoints: Set[CassandraNode]): TokenRange[V, T] = {
+  private def unthriftify(cfSplit: CfSplit, endpoints: Set[InetAddress]): TokenRange[V, T] = {
     val left = tokenFactory.fromString(cfSplit.start_token)
     val right = tokenFactory.fromString(cfSplit.end_token)
     TokenRange(left, right, endpoints, Some(cfSplit.row_count))
   }
 
-  private def fetchSplits(range: TokenRange[V, T], endpoint: InetAddress, splitSize: Long): Seq[TokenRange[V, T]] = {
+  private def fetchSplits(
+      range: TokenRange[V, T],
+      endpoint: InetAddress,
+      splitSize: Long): Seq[TokenRange[V, T]] = {
+
     val startToken = tokenFactory.toString(range.start)
     val endToken = tokenFactory.toString(range.end)
 
@@ -35,24 +39,27 @@ class ServerSideTokenRangeSplitter[V, T <: Token[V]](
         client.set_keyspace(keyspaceName)
         client
           .describe_splits_ex(tableName, startToken, endToken, splitSize.toInt)
-          .map(unthriftify(_, range.endpoints))
+          .map(unthriftify(_, range.replicas))
     }
   }
 
-  def split(range: TokenRange[V, T], splitSize: Long) = {
+  def split(range: TokenRange[V, T], splitSize: Long): Seq[TokenRange[V, T]] = {
     val fetchResults =
-      for (endpoint <- range.endpoints.toStream)
-      yield Try(fetchSplits(range, endpoint.rpcAddress, splitSize))
+      for (replica <- range.replicas.toStream)
+      yield Try(fetchSplits(range, replica, splitSize))
 
     fetchResults
       .collectFirst { case Success(splits) => splits }
       .getOrElse {
         for (Failure(e) <- fetchResults)
           logError("Failure while fetching splits from Cassandra", e)
-        if (range.endpoints.isEmpty)
-          throw new IOException(s"Failed to fetch splits of $range because there are no replicas for the keyspace in the current datacenter.")
+        if (range.replicas.isEmpty)
+          throw new IOException(
+            s"Failed to fetch splits of $range " +
+              s"because there are no replicas for the keyspace in the current datacenter.")
         else
-          throw new IOException(s"Failed to fetch splits of $range from all endpoints: ${range.endpoints.mkString(", ")}")
+          throw new IOException(
+            s"Failed to fetch splits of $range from all endpoints: ${range.replicas.mkString(", ")}")
       }
   }
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/dht/TokenRange.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/dht/TokenRange.scala
@@ -3,18 +3,8 @@ package com.datastax.spark.connector.rdd.partitioner.dht
 import java.net.InetAddress
 
 
-case class CassandraNode(rpcAddress: InetAddress, localAddress: InetAddress) {
-  require(rpcAddress != InetAddress.getByName("0.0.0.0"), "rpcAddress must not be 0.0.0.0")
-  require(localAddress != InetAddress.getByName("0.0.0.0"), "localAddress must not be 0.0.0.0")
-  def allAddresses = Set(rpcAddress, localAddress)
-}
-
-object CassandraNode {
-  implicit def ordering: Ordering[CassandraNode] = Ordering.by(_.rpcAddress.toString)
-}
-
 case class TokenRange[V, T <: Token[V]] (
-    start: T, end: T, endpoints: Set[CassandraNode], rowCount: Option[Long]) {
+    start: T, end: T, replicas: Set[InetAddress], rowCount: Option[Long]) {
 
   def isWrapAround: Boolean =
     start >= end
@@ -23,8 +13,8 @@ case class TokenRange[V, T <: Token[V]] (
     val minToken = tokenFactory.minToken
     if (isWrapAround)
       Seq(
-        TokenRange(start, minToken, endpoints, rowCount.map(_ / 2)),
-        TokenRange(minToken, end, endpoints, rowCount.map(_ / 2)))
+        TokenRange(start, minToken, replicas, rowCount.map(_ / 2)),
+        TokenRange(minToken, end, replicas, rowCount.map(_ / 2)))
     else
       Seq(this)
   }

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/partitioner/Murmur3PartitionerTokenRangeSplitterTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/partitioner/Murmur3PartitionerTokenRangeSplitterTest.scala
@@ -2,10 +2,11 @@ package com.datastax.spark.connector.rdd.partitioner
 
 import java.net.InetAddress
 
-import com.datastax.spark.connector.rdd.partitioner.dht.{CassandraNode, LongToken}
-import com.datastax.spark.connector.rdd.partitioner.dht.TokenFactory.Murmur3TokenFactory
 import org.junit.Assert._
 import org.junit.Test
+
+import com.datastax.spark.connector.rdd.partitioner.dht.LongToken
+import com.datastax.spark.connector.rdd.partitioner.dht.TokenFactory.Murmur3TokenFactory
 
 class Murmur3PartitionerTokenRangeSplitterTest {
 
@@ -18,7 +19,7 @@ class Murmur3PartitionerTokenRangeSplitterTest {
 
   @Test
   def testSplit() {
-    val node = CassandraNode(InetAddress.getLocalHost, InetAddress.getLocalHost)
+    val node = InetAddress.getLocalHost
     val splitter = new Murmur3PartitionerTokenRangeSplitter(2.0)
     val range = new TokenRange(
       new com.datastax.spark.connector.rdd.partitioner.dht.LongToken(0),
@@ -31,7 +32,7 @@ class Murmur3PartitionerTokenRangeSplitterTest {
     assertEquals(0L, out.head.start.value)
     assertEquals(100L, out.last.end.value)
     assertTrue(out.forall(s => s.end.value - s.start.value == 10))
-    assertTrue(out.forall(_.endpoints == Set(node)))
+    assertTrue(out.forall(_.replicas == Set(node)))
     assertNoHoles(out)
   }
 

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/partitioner/RandomPartitionerTokenRangeSplitterTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/partitioner/RandomPartitionerTokenRangeSplitterTest.scala
@@ -2,10 +2,10 @@ package com.datastax.spark.connector.rdd.partitioner
 
 import java.net.InetAddress
 
-import com.datastax.spark.connector.rdd.partitioner.dht.{CassandraNode, BigIntToken, TokenFactory}
 import org.junit.Assert._
 import org.junit.Test
 
+import com.datastax.spark.connector.rdd.partitioner.dht.{BigIntToken, TokenFactory}
 
 class RandomPartitionerTokenRangeSplitterTest {
 
@@ -18,7 +18,7 @@ class RandomPartitionerTokenRangeSplitterTest {
 
   @Test
   def testSplit() {
-    val node = CassandraNode(InetAddress.getLocalHost, InetAddress.getLocalHost)
+    val node = InetAddress.getLocalHost
     val splitter = new RandomPartitionerTokenRangeSplitter(2.0)
     val rangeLeft = BigInt("0")
     val rangeRight = BigInt("100")
@@ -31,7 +31,7 @@ class RandomPartitionerTokenRangeSplitterTest {
     assertEquals(10, out.size)
     assertEquals(rangeLeft, out.head.start.value)
     assertEquals(rangeRight, out.last.end.value)
-    assertTrue(out.forall(_.endpoints == Set(node)))
+    assertTrue(out.forall(_.replicas == Set(node)))
     assertNoHoles(out)
   }
 

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/partitioner/TokenRangeClustererTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/partitioner/TokenRangeClustererTest.scala
@@ -2,25 +2,20 @@ package com.datastax.spark.connector.rdd.partitioner
 
 import java.net.InetAddress
 
-import com.datastax.spark.connector.rdd.partitioner.dht.{CassandraNode, LongToken}
 import org.junit.Assert._
 import org.junit.Test
+
+import com.datastax.spark.connector.rdd.partitioner.dht.LongToken
 
 class TokenRangeClustererTest {
 
   type TokenRange = com.datastax.spark.connector.rdd.partitioner.dht.TokenRange[Long, LongToken]
 
-  val addr1 = InetAddress.getByName("192.168.123.1")
-  val addr2 = InetAddress.getByName("192.168.123.2")
-  val addr3 = InetAddress.getByName("192.168.123.3")
-  val addr4 = InetAddress.getByName("192.168.123.4")
-  val addr5 = InetAddress.getByName("192.168.123.5")
-
-  val node1 = CassandraNode(addr1, addr1)
-  val node2 = CassandraNode(addr2, addr2)
-  val node3 = CassandraNode(addr3, addr3)
-  val node4 = CassandraNode(addr4, addr4)
-  val node5 = CassandraNode(addr5, addr5)
+  val node1 = InetAddress.getByName("192.168.123.1")
+  val node2 = InetAddress.getByName("192.168.123.2")
+  val node3 = InetAddress.getByName("192.168.123.3")
+  val node4 = InetAddress.getByName("192.168.123.4")
+  val node5 = InetAddress.getByName("192.168.123.5")
 
   private def token(x: Long) = new com.datastax.spark.connector.rdd.partitioner.dht.LongToken(x)
 
@@ -90,7 +85,7 @@ class TokenRangeClustererTest {
     val groups = trc.group(Seq(tr1, tr2, tr3, tr4))
     assertEquals(1, groups.size)
     assertEquals(4, groups.head.size)
-    assertFalse(groups.head.map(_.endpoints).reduce(_ intersect _).isEmpty)
+    assertFalse(groups.head.map(_.replicas).reduce(_ intersect _).isEmpty)
   }
 
   @Test


### PR DESCRIPTION
 Remove describe_ring call and replace it with native Java Driver support for fetching token ranges with corresponding replica sets from the Cluster metadata. Removed CassandraNode class, because now an endpoint is represented by only one address, taken from the Java driver Host object.  This is the first step towards removing thrift dependency from the connector code.