### PR TITLE
Add extra partitionKeyExtractor parameter for the repartitionByCassandra...

### DIFF
--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/RDDJavaFunctions.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/RDDJavaFunctions.java
@@ -132,6 +132,7 @@ public class RDDJavaFunctions<T> extends RDDAndDStreamCommonJavaFunctions<T> {
     public JavaRDD<T> repartitionByCassandraReplica(
             String keyspaceName,
             String tableName,
+            ColumnSelector partitionKeyMapper,
             int partitionsPerHost,
             RowWriterFactory<T> rowWriterFactory
     ) {
@@ -141,6 +142,7 @@ public class RDDJavaFunctions<T> extends RDDAndDStreamCommonJavaFunctions<T> {
         CassandraPartitionedRDD<T> newRDD = rddFunctions.repartitionByCassandraReplica(
                 keyspaceName,
                 tableName,
+                partitionKeyMapper,
                 partitionsPerHost,
                 connector,
                 ctT,

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
@@ -138,11 +138,11 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
    * event.
    * The calling RDD must have rows that can be converted into the partition key of the given Cassandra Table.
    **/
-  def repartitionByCassandraReplica(keyspaceName: String, tableName: String, partitionsPerHost: Int = 10)
+  def repartitionByCassandraReplica(keyspaceName: String, tableName: String, partitionKeyMapper:ColumnSelector = PartitionKeyColumns, partitionsPerHost: Int = 10)
                                    (implicit connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
                                     currentType: ClassTag[T], rwf: RowWriterFactory[T]) = {
     val part = new ReplicaPartitioner(partitionsPerHost, connector)
-    val repart = rdd.keyByCassandraReplica(keyspaceName, tableName).partitionBy(part)
+    val repart = rdd.keyByCassandraReplica(keyspaceName, tableName,partitionKeyMapper).partitionBy(part)
     val output = repart.mapPartitions(_.map(_._2), preservesPartitioning = true)
     new CassandraPartitionedRDD[T](output)
   }
@@ -152,10 +152,10 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
    * of the data specified by that row.
    * The calling RDD must have rows that can be converted into the partition key of the given Cassandra Table.
    */
-  def keyByCassandraReplica(keyspaceName: String, tableName: String)
+  def keyByCassandraReplica(keyspaceName: String, tableName: String, partitionKeyMapper:ColumnSelector = PartitionKeyColumns)
                            (implicit connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
                             currentType: ClassTag[T], rwf: RowWriterFactory[T]): RDD[(Set[InetAddress], T)] = {
-    val converter = ReplicaMapper[T](connector, keyspaceName, tableName)
+    val converter = ReplicaMapper[T](connector, keyspaceName, tableName,partitionKeyMapper)
     rdd.mapPartitions(primaryKey =>
       converter.keyByReplicas(primaryKey)
     )

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/DStreamFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/DStreamFunctions.scala
@@ -40,6 +40,7 @@ class DStreamFunctions[T](dstream: DStream[T]) extends WritableToCassandra[T] wi
   def repartitionByCassandraReplica(
     keyspaceName: String,
     tableName: String,
+    partitionKeyMapper:ColumnSelector = PartitionKeyColumns,
     partitionsPerHost: Int = 10)(
   implicit
     connector: CassandraConnector = CassandraConnector(conf),
@@ -47,7 +48,7 @@ class DStreamFunctions[T](dstream: DStream[T]) extends WritableToCassandra[T] wi
     rwf: RowWriterFactory[T]): DStream[T] = {
 
     dstream.transform(rdd =>
-      rdd.repartitionByCassandraReplica(keyspaceName, tableName, partitionsPerHost))
+      rdd.repartitionByCassandraReplica(keyspaceName, tableName, partitionKeyMapper, partitionsPerHost))
   }
 
   /**

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/ReplicaMapper.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/ReplicaMapper.scala
@@ -5,6 +5,7 @@ import java.io.IOException
 import java.net.InetAddress
 
 import com.datastax.driver.core._
+import com.datastax.spark.connector.ColumnSelector
 import com.datastax.spark.connector.cql._
 import org.apache.spark.Logging
 
@@ -83,7 +84,8 @@ object ReplicaMapper {
   def apply[T: RowWriterFactory](
       connector: CassandraConnector,
       keyspaceName: String,
-      tableName: String): ReplicaMapper[T] = {
+      tableName: String,
+      partitionKeyMapper:ColumnSelector): ReplicaMapper[T] = {
 
     val schema = Schema.fromCassandra(connector, Some(keyspaceName), Some(tableName))
     val tableDef = schema.tables.headOption
@@ -92,7 +94,7 @@ object ReplicaMapper {
     val rowWriter = implicitly[RowWriterFactory[T]].rowWriter(
       tableDef,
       selectedColumns,
-      Map.empty.withDefault(x => x)
+      partitionKeyMapper.aliases
     )
     new ReplicaMapper[T](connector, tableDef, rowWriter)
   }


### PR DESCRIPTION
...Replica() method to make it work with tuples

**Warning**: this pull request should be applied AFTER https://github.com/datastax/spark-cassandra-connector/pull/634

