### PR TITLE
SPARKC-126: Populate HostName & Address in preferredIps

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
@@ -144,7 +144,7 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
     val part = new ReplicaPartitioner(partitionsPerHost, connector)
     val repart = rdd.keyByCassandraReplica(keyspaceName, tableName).partitionBy(part)
     val output = repart.mapPartitions(_.map(_._2), preservesPartitioning = true)
-    new CassandraPartitionedRDD[T](output)
+    new CassandraPartitionedRDD[T](output, keyspaceName, tableName)
   }
 
   /**

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
@@ -124,7 +124,7 @@ class CassandraTableScanRDD[R] private[connector](
 
   override def getPreferredLocations(split: Partition): Seq[String] =
     split.asInstanceOf[CassandraPartition]
-      .endpoints.map(_.getHostName).toSeq
+      .endpoints.flatMap(inet => Seq(inet.getHostName, inet.getHostAddress)).toSeq.distinct
 
   private def tokenRangeToCqlQuery(range: CqlTokenRange): (String, Seq[Any]) = {
     val columns = selectedColumnRefs.map(_.cql).mkString(", ")

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartitionedRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartitionedRDD.scala
@@ -1,15 +1,26 @@
 package com.datastax.spark.connector.rdd.partitioner
 
+import java.net.InetAddress
+
+import com.datastax.spark.connector.cql.CassandraConnector
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{Partition, Partitioner, TaskContext}
+import org.apache.cassandra.thrift.TokenRange
 
+import scala.collection.JavaConversions._
 import scala.reflect.ClassTag
 
 /**
  * RDD created by repartitionByCassandraReplica with preferred locations mapping to the CassandraReplicas
  * each partition was created for.
  */
-class CassandraPartitionedRDD[T](prev: RDD[T])(implicit ct: ClassTag[T]) extends RDD[T](prev) {
+class CassandraPartitionedRDD[T](
+    prev: RDD[T],
+    keyspace:String,
+    table:String)(
+  implicit
+    ct: ClassTag[T])
+  extends RDD[T](prev) {
 
   //We aren't going to change the data
   override def compute(split: Partition, context: TaskContext): Iterator[T] = prev.iterator(split, context)
@@ -22,15 +33,43 @@ class CassandraPartitionedRDD[T](prev: RDD[T])(implicit ct: ClassTag[T]) extends
   override def getPartitions: Array[Partition] = {
     partitioner match {
       case Some(rp: ReplicaPartitioner) => prev.partitions.map(partition => rp.getEndpointPartition(partition))
-      case _ => throw new IllegalArgumentException("CassandraPartitionedRDD hasn't been partitioned by ReplicaPartitioner. This should be impossible")
+      case _ => throw new IllegalArgumentException("CassandraPartitionedRDD hasn't been " +
+        "partitioned by ReplicaPartitioner. Unable to do any work with data locality.")
     }
   }
 
-  override def getPreferredLocations(split: Partition): Seq[String] = {
-    split match {
-      case epp: ReplicaPartition =>
-        epp.endpoints.map(_.getHostAddress).toSeq
-      case other: Partition => throw new IllegalArgumentException("CassandraPartitionedRDD doesn't have Endpointed Partitions. This should be impossible.")
-    }
+  /**
+   * This method currently uses thrift to determine the local endpoint and rpc endpoints
+   * from whatever endpoint the partition belongs to. This gives us a better chance of matching
+   * the bound interface of the Spark Executor. In addition we will add the HostName and
+   * HostAddress that we get for each of these endpoints to cover all of the logical choices.
+   */
+  override def getPreferredLocations(split: Partition): Seq[String] = split match {
+    case epp: ReplicaPartition =>
+      val rpcToLocalAddress = rpcToLocalAddressMap
+      val localToRpcAddress = rpcToLocalAddress.map(_.swap)
+
+      epp.endpoints.flatMap { origInet =>
+        val rpcIps = localToRpcAddress.get(origInet)
+        val localIps = rpcToLocalAddress.get(origInet)
+        val possibleIps = Seq(Some(origInet), rpcIps, localIps).flatten
+        possibleIps.flatMap(ip => Seq(ip.getHostAddress, ip.getHostName))
+      }.toSeq.distinct
+
+    case other: Partition => throw new IllegalArgumentException(
+      "CassandraPartitionedRDD doesn't have Endpointed Partitions. PrefferedLocations cannot be" +
+        "deterimined")
   }
+
+  private def rpcToLocalAddressMap: Map[InetAddress, InetAddress] = (
+    for {
+      tr <- localDcRing(keyspace)
+      rpcIps = tr.rpc_endpoints.map(InetAddress.getByName)
+      localIps = tr.endpoints.map(InetAddress.getByName)
+      (rpc, local) <- rpcIps.zip(localIps)
+    } yield (rpc, local)).toMap
+
+  private def localDcRing(keyspace: String): Seq[TokenRange] =
+    CassandraConnector(prev.sparkContext.getConf)
+      .withCassandraClientDo(_.describe_local_ring(keyspace))
 }


### PR DESCRIPTION
For the preferredLocations method of the repartitionByCassandraReplica
use the Broadcast and Local Endpoints if possible.

For all usages make sure that the both hostname and address are used.