### PR TITLE
SPARKC-139: Fix overflow bugs in RateLimiter

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
@@ -78,7 +78,7 @@ object WriteConf {
   val DefaultParallelismLevel = 8
   val DefaultBatchGroupingBufferSize = 1000
   val DefaultBatchGroupingKey = BatchGroupingKey.Partition
-  val DefaultThroughputMiBPS = Int.MaxValue
+  val DefaultThroughputMiBPS = 1000000
   val DefaultWriteTaskMetricsEnabled = true
 
   def fromSparkConf(conf: SparkConf): WriteConf = {


### PR DESCRIPTION
Two possible overflows fixed here,

Elapsed time * rate can over flow when lastTime is 0
rate at it's default will overflow since it is Int.MaxValue * 1024 * 1024

Also I set elapsed time to always be positive or 0 incase of ntp sync disrupting the clock and sending
time backwards.