### PR TITLE
SPARKC-139: Fix overflow bugs in RateLimiter

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -129,7 +129,7 @@ class TableWriter[T] private (
       val batchKeyGenerator = batchRoutingKey(session, routingKeyGenerator) _
       val batchBuilder = new GroupingBatchBuilder(boundStmtBuilder, batchStmtBuilder, batchKeyGenerator,
         writeConf.batchSize, writeConf.batchGroupingBufferSize, rowIterator)
-      val rateLimiter = new RateLimiter(writeConf.throughputMiBPS * 1024 * 1024, 1024 * 1024)
+      val rateLimiter = new RateLimiter(writeConf.throughputMiBPS * 1024L * 1024L, 1024L * 1024L)
 
       logDebug(s"Writing data partition to $keyspaceName.$tableName in batches of ${writeConf.batchSize}.")
 

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/RateLimiterSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/RateLimiterSpec.scala
@@ -1,9 +1,13 @@
 package com.datastax.spark.connector.writer
 
 import org.scalamock.scalatest.MockFactory
+import org.scalatest.concurrent.Eventually
 import org.scalatest.{FlatSpec, Matchers}
 
-class RateLimiterSpec extends FlatSpec with Matchers with MockFactory {
+
+class RateLimiterSpec extends FlatSpec with Matchers with MockFactory with Eventually{
+
+ val TestRates = Seq(1L, 2L, 4L, 6L, 8L, 16L, 32L, WriteConf.DefaultThroughputMiBPS.toLong)
 
   "RateLimiter" should "not cause delays if rate is not exceeded" in {
     var now: Long = 0
@@ -35,7 +39,35 @@ class RateLimiterSpec extends FlatSpec with Matchers with MockFactory {
     for (i <- 1 to iterations)
       limiter.maybeSleep(1)
 
-    sleepTime should be ((iterations - bucketSize) * 1000L / rate)
+    sleepTime should be((iterations - bucketSize) * 1000L / rate)
+  }
+
+  it should "sleep and leak properly with different Rates" in {
+    for (rate <- TestRates) {
+      val bucketSize = rate * 2
+      var now: Long = 0
+      var sleepTime: Long = 0
+
+      def sleep(delay: Long) = {
+        sleepTime += delay
+        now += delay
+      }
+
+      val limiter = new RateLimiter(rate, rate * 2, () => now, sleep)
+      for (leakNum <- 1 to 1000) {
+        assert(
+          limiter.bucketFill.get() >= 0,
+          "bucketFill has been overflowed, or has had a large negative number added to it")
+        limiter.maybeSleep(rate)
+      }
+
+      eventually {
+        limiter.leak()
+        val delay = (limiter.bucketFill.get() - bucketSize) * 1000 / rate
+        assert(delay <= 0, "Rate limiter was unable to leak it's way back to 0 delay")
+      }
+      sleepTime should not be (0)
+    }
   }
 
 }


### PR DESCRIPTION
Two possible overflows fixed here,

Elapsed time * rate can overflow when lastTime is 0 --> Fixed this by starting last time at time()
rate at it's default will overflow since it is Int.MaxValue * 1024 * 1024 --> Fixed this by changing default to 1000000mbps

Also I set elapsed time to always be positive or 0 incase of ntp sync disrupting the clock and sending
time backwards.