### PR TITLE
SPARKC-141: BP SPARKC-126 (Pref Hostname and Adr)

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
@@ -304,7 +304,7 @@ class CassandraRDD[R] private[connector] (
 
   override def getPreferredLocations(split: Partition) =
     split.asInstanceOf[CassandraPartition]
-      .endpoints.map(_.getHostName).toSeq
+    .endpoints.flatMap(inet => Seq(inet.getHostName, inet.getHostAddress)).toSeq.distinct
 
   private def tokenRangeToCqlQuery(range: CqlTokenRange): (String, Seq[Any]) = {
     val columns = selectedColumnNames.map(quote).mkString(", ")


### PR DESCRIPTION
Back porting SPARKC-126 to b1.1 branch, to help with task locality