### PR TITLE
SPARKC-148: Update to Spark 1.3.1 in Version.scala

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -47,7 +47,7 @@ object Versions {
   val ScalaTest       = "2.2.2"
   val Scalactic       = "2.2.2"
   val Slf4j           = "1.6.1"//1.7.7"
-  val Spark           = "1.3.0"
+  val Spark           = "1.3.1"
   val JSR166e         = "1.1.0"
   val SparkJetty      = "8.1.14.v20131031"
 


### PR DESCRIPTION
JIRA: https://datastax-oss.atlassian.net/browse/SPARKC-148

I have tested the lastest commit in master(https://github.com/datastax/spark-cassandra-connector/commit/72cd1e31cee2a60c0a27b4e9a3feb2287ef8f069), it works fine with Spark 1.3.1. 
