### PR TITLE
SPARKC-157: Move type conversions back to RowWriters.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+1.2.2 (unreleased)
+ * Fixed a bug preventing a custom type converter from being used
+   when saving data. RowWriter implementations must
+   perform type conversions now. (SPARKC-157)
+
 1.2.1
  * Fixed problems with mixed case keyspaces in ReplicaMapper (SPARKC-159)
 

--- a/doc/6_advanced_mapper.md
+++ b/doc/6_advanced_mapper.md
@@ -95,6 +95,38 @@ use the new converter for.
 Additionally, defining the `StringToEMailConverter` as an implicit object 
 allows to use generic `CassandraRow#get` with your custom `EMail` field type.
  
+The following table specifies the relationship between a Cassandra column type and 
+the type of needed `TypeConverter`.
+
+Cassandra column type | Object type to convert from / to
+-----------------------------------------------------------------
+ `ascii`              | `java.lang.String`                                         
+ `bigint`             | `java.lang.Long`                                       
+ `blob`               | `java.nio.ByteBuffer` 
+ `boolean`            | `java.lang.Boolean`              
+ `counter`            | `java.lang.Long`                       
+ `decimal`            | `java.math.BigDecimal` 
+ `double`             | `java.lang.Double`    
+ `float`              | `java.lang.Float`    
+ `inet`               | `java.net.InetAddress` 
+ `int`                | `java.lang.Integer`  
+ `text`               | `java.lang.String` 
+ `timestamp`          | `java.util.Date` 
+ `uuid`               | `java.util.UUID` 
+ `timeuuid`           | `java.util.UUID` 
+ `varchar`            | `java.lang.String` 
+ `varint`             | `java.math.BigInteger`
+ user defined         | `com.datastax.spark.connector.UDTValue`
+
+Custom converters for collections are not supported.
+ 
+When defining your own `TypeConverter` make sure it is `Serializable` and
+works properly after being deserialized. For example, if you want to 
+register a custom TypeConverter producing
+Cassandra UDT values, you must register a converter converting to connector's
+UDTValue class, not Java Driver's UDTValue. This is because many Java Driver's classes are not
+Serializable and would not be possible for such converter to be properly serialized/deserialized.  
+
 ### Low-level control over mapping
 The `ColumnMapper` API cannot be used to express every possible mapping, e.g., for classes that do not expose
 separate accessors for reading/writing every column. 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/PrimitiveColumnType.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/PrimitiveColumnType.scala
@@ -14,79 +14,111 @@ trait PrimitiveColumnType[T] extends ColumnType[T] {
 case object TextType extends PrimitiveColumnType[String] {
   def scalaTypeTag = TypeTag.synchronized { implicitly[TypeTag[String]] }
   def cqlTypeName = "text"
+  def converterToCassandra =
+    new TypeConverter.OptionToNullConverter(TypeConverter.forType[String])
 }
 
 case object AsciiType extends PrimitiveColumnType[String] {
   def scalaTypeTag = TypeTag.synchronized { implicitly[TypeTag[String]] }
   def cqlTypeName = "ascii"
+  def converterToCassandra =
+    new TypeConverter.OptionToNullConverter(TypeConverter.forType[String])
 }
 
 case object VarCharType extends PrimitiveColumnType[String] {
   def scalaTypeTag = TypeTag.synchronized { implicitly[TypeTag[String]] }
   def cqlTypeName = "varchar"
+  def converterToCassandra =
+    new TypeConverter.OptionToNullConverter(TypeConverter.forType[String])
 }
 
 case object IntType extends PrimitiveColumnType[Int] {
   def scalaTypeTag = TypeTag.synchronized { implicitly[TypeTag[Int]] }
   def cqlTypeName = "int"
+  def converterToCassandra =
+    new TypeConverter.OptionToNullConverter(TypeConverter.forType[java.lang.Integer])
 }
 
 case object BigIntType extends PrimitiveColumnType[Long] {
   def scalaTypeTag = TypeTag.synchronized { implicitly[TypeTag[Long]] }
   def cqlTypeName = "bigint"
+  def converterToCassandra =
+    new TypeConverter.OptionToNullConverter(TypeConverter.forType[java.lang.Long])
 }
 
 case object FloatType extends PrimitiveColumnType[Float] {
   def scalaTypeTag = TypeTag.synchronized { implicitly[TypeTag[Float]] }
   def cqlTypeName = "float"
+  def converterToCassandra =
+    new TypeConverter.OptionToNullConverter(TypeConverter.forType[java.lang.Float])
 }
 
 case object DoubleType extends PrimitiveColumnType[Double] {
   def scalaTypeTag = TypeTag.synchronized { implicitly[TypeTag[Double]] }
   def cqlTypeName = "double"
+  def converterToCassandra =
+    new TypeConverter.OptionToNullConverter(TypeConverter.forType[java.lang.Double])
 }
 
 case object BooleanType extends PrimitiveColumnType[Boolean] {
   def scalaTypeTag = TypeTag.synchronized { implicitly[TypeTag[Boolean]] }
   def cqlTypeName = "boolean"
+  def converterToCassandra =
+    new TypeConverter.OptionToNullConverter(TypeConverter.forType[java.lang.Boolean])
 }
 
 case object VarIntType extends PrimitiveColumnType[BigInt] {
   def scalaTypeTag = TypeTag.synchronized { implicitly[TypeTag[BigInt]] }
   def cqlTypeName = "varint"
+  def converterToCassandra =
+    new TypeConverter.OptionToNullConverter(TypeConverter.forType[java.math.BigInteger])
 }
 
 case object DecimalType extends PrimitiveColumnType[BigDecimal] {
   def scalaTypeTag = TypeTag.synchronized { implicitly[TypeTag[BigDecimal]] }
   def cqlTypeName = "decimal"
+  def converterToCassandra =
+    new TypeConverter.OptionToNullConverter(TypeConverter.forType[java.math.BigDecimal])
 }
 
 case object TimestampType extends PrimitiveColumnType[Date] {
   def scalaTypeTag = TypeTag.synchronized { implicitly[TypeTag[Date]] }
   def cqlTypeName = "timestamp"
+  def converterToCassandra =
+    new TypeConverter.OptionToNullConverter(TypeConverter.forType[java.util.Date])
 }
 
 case object InetType extends PrimitiveColumnType[InetAddress] {
   def scalaTypeTag = TypeTag.synchronized { implicitly[TypeTag[InetAddress]] }
   def cqlTypeName = "inet"
+  def converterToCassandra =
+    new TypeConverter.OptionToNullConverter(TypeConverter.forType[InetAddress])
 }
 
 case object UUIDType extends PrimitiveColumnType[UUID] {
   def scalaTypeTag = TypeTag.synchronized { implicitly[TypeTag[UUID]] }
   def cqlTypeName = "uuid"
+  def converterToCassandra =
+    new TypeConverter.OptionToNullConverter(TypeConverter.forType[UUID])
 }
 
 case object TimeUUIDType extends PrimitiveColumnType[UUID] {
   def scalaTypeTag = TypeTag.synchronized { implicitly[TypeTag[UUID]] }
   def cqlTypeName = "timeuuid"
+  def converterToCassandra =
+    new TypeConverter.OptionToNullConverter(TypeConverter.forType[UUID])
 }
 
 case object CounterType extends PrimitiveColumnType[Long] {
   def scalaTypeTag = TypeTag.synchronized { implicitly[TypeTag[Long]] }
   def cqlTypeName = "counter"
+  def converterToCassandra =
+    new TypeConverter.OptionToNullConverter(TypeConverter.forType[java.lang.Long])
 }
 
 case object BlobType extends PrimitiveColumnType[ByteBuffer] {
   def scalaTypeTag = TypeTag.synchronized { implicitly[TypeTag[ByteBuffer]] }
   def cqlTypeName = "blob"
+  def converterToCassandra =
+    new TypeConverter.OptionToNullConverter(TypeConverter.forType[java.nio.ByteBuffer])
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/CassandraRowWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/CassandraRowWriter.scala
@@ -8,9 +8,15 @@ class CassandraRowWriter(table: TableDef, selectedColumns: Seq[String]) extends 
 
   val columnNames = selectedColumns
 
+  private val columns = columnNames.map(table.columnByName).toIndexedSeq
+  private val converters = columns.map(_.columnType.converterToCassandra)
+
   override def readColumnValues(data: CassandraRow, buffer: Array[Any]) = {
-    for ((c, i) <- columnNames.zipWithIndex)
-      buffer(i) = data.getRaw(c)
+    for ((c, i) <- columnNames.zipWithIndex) {
+      val value = data.getRaw(c)
+      val convertedValue = converters(i).convert(value)
+      buffer(i) = convertedValue
+    }
   }
 }
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/DefaultRowWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/DefaultRowWriter.scala
@@ -55,12 +55,15 @@ class DefaultRowWriter[T : ColumnMapper](table: TableDef, selectedColumns: Seq[S
 
   private val columnNameToPropertyName = (columnNames zip propertyNames).toMap
   private val extractor = new PropertyExtractor(cls, propertyNames)
+  private val columns = columnNames.map(table.columnByName).toIndexedSeq
+  private val converters = columns.map(_.columnType.converterToCassandra)
 
   override def readColumnValues(data: T, buffer: Array[Any]) = {
     for ((c, i) <- columnNames.zipWithIndex) {
       val propertyName = columnNameToPropertyName(c)
       val value = extractor.extractProperty(data, propertyName)
-      buffer(i) = value
+      val convertedValue = converters(i).convert(value)
+      buffer(i) = convertedValue
     }
   }
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/RowWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/RowWriter.scala
@@ -1,7 +1,9 @@
 package com.datastax.spark.connector.writer
 
 
-/** `RowWriter` knows how to extract column names and values from custom row objects. */
+/** `RowWriter` knows how to extract column names and values from custom row objects
+  * and how to convert them to values that can be written to Cassandra.
+  * `RowWriter` is required to apply any user-defined data type conversion. */
 trait RowWriter[T] extends Serializable {
 
   /** List of columns this `RowWriter` is going to write.

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/SqlRowWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/SqlRowWriter.scala
@@ -6,12 +6,16 @@ import org.apache.spark.sql.catalyst.expressions.Row
 /** A [[RowWriter]] that can write SparkSQL `Row` objects. */
 class SqlRowWriter(val table: TableDef, val columnNames: Seq[String]) extends RowWriter[Row] {
 
+  private val columns = columnNames.map(table.columnByName).toIndexedSeq
+  private val converters = columns.map(_.columnType.converterToCassandra)
+
   /** Extracts column values from `data` object and writes them into the given buffer
     * in the same order as they are listed in the columnNames sequence. */
   override def readColumnValues(row: Row, buffer: Array[Any]) = {
     require(row.size == columnNames.size, s"Invalid row size: ${row.size} instead of ${columnNames.size}.")
-    for (i <- 0 until row.size)
-      buffer(i) = row(i)
+    for (i <- row.indices)
+      buffer(i) = converters(i).convert(row(i))
+
   }
 }
 

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/DefaultRowWriterTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/DefaultRowWriterTest.scala
@@ -1,18 +1,99 @@
 package com.datastax.spark.connector.writer
 
-import com.datastax.spark.connector.cql.TableDef
-import org.apache.commons.lang3.SerializationUtils
-import org.junit.Test
-
 import scala.collection.immutable.Map
+import scala.reflect.runtime.universe._
+
+import org.apache.commons.lang3.SerializationUtils
+
+import org.junit.Test
+import org.junit.Assert._
+
+import com.datastax.spark.connector.cql._
+import com.datastax.spark.connector.types._
+import com.datastax.spark.connector.UDTValue
+
+case class StringWrapper(str: String)
+
+object StringWrapperConverter extends TypeConverter[String] {
+  override def targetTypeTag = typeTag[String]
+  override def convertPF = {
+    case StringWrapper(str) => str
+  }
+}
 
 class DefaultRowWriterTest {
 
-//  @Test
-//  def testSerializability() {
-//    val table = TableDef("test", "table", Nil, Nil, Nil)
-//    val rowWriter = new DefaultRowWriter[DefaultRowWriterTest](table, Nil, Map.empty)
-//    SerializationUtils.roundtrip(rowWriter)
-//  }
+  @Test
+  def testSerializability(): Unit = {
+    val table = TableDef("test", "table", Nil, Nil, Nil)
+    val rowWriter = new DefaultRowWriter[DefaultRowWriterTest](table, Nil, Map.empty)
+    SerializationUtils.roundtrip(rowWriter)
+  }
 
+  case class RowOfStrings(c1: String, c2: String, c3: String)
+
+  @Test
+  def testTypeConversionsAreApplied(): Unit = {
+    val column1 = ColumnDef("c1", PartitionKeyColumn, IntType)
+    val column2 = ColumnDef("c2", ClusteringColumn(0), DecimalType)
+    val column3 = ColumnDef("c3", RegularColumn, TimestampType)
+    val table = TableDef("test", "table", Seq(column1), Seq(column2), Seq(column3))
+    val rowWriter = new DefaultRowWriter[RowOfStrings](
+      table, table.allColumns.map(_.columnName), Map.empty)
+
+    val obj = RowOfStrings("1", "1.11", "2015-01-01 12:11:34")
+    val buf = Array.ofDim[Any](3)
+    rowWriter.readColumnValues(obj, buf)
+    val i1 = rowWriter.columnNames.indexOf("c1")
+    val i2 = rowWriter.columnNames.indexOf("c2")
+    val i3 = rowWriter.columnNames.indexOf("c3")
+
+    assertEquals(java.lang.Integer.valueOf(1), buf(i1))
+    assertEquals(new java.math.BigDecimal("1.11"), buf(i2))
+    assertTrue(buf(i3).isInstanceOf[java.util.Date])
+  }
+
+  case class RowWithUDT(c1: UDTValue)
+
+  @Test
+  def testTypeConversionsInUDTValuesAreApplied(): Unit = {
+    val udtColumn = FieldDef("field", IntType)
+    val udt = UserDefinedType("udt", Seq(udtColumn))
+
+    val column = ColumnDef("c1", PartitionKeyColumn, udt)
+    val table = TableDef("test", "table", Seq(column), Nil, Nil)
+    val rowWriter = new DefaultRowWriter[RowWithUDT](table, Seq("c1"), Map.empty)
+
+    // we deliberately put a String 12345 here:
+    val udtValue = UDTValue.fromMap(Map("field" -> "12345"))
+    val obj = RowWithUDT(udtValue)
+
+    val buf = Array.ofDim[Any](1)
+    rowWriter.readColumnValues(obj, buf)
+
+    // UDTValue should not be converted to any other type,
+    // because column is of UserDefinedType
+    assertTrue(buf(0).isInstanceOf[UDTValue])
+
+    // the field value must be converted to java.lang.Integer, because its field type is IntType
+    assertEquals(java.lang.Integer.valueOf(12345), buf(0).asInstanceOf[UDTValue].getRaw("field"))
+  }
+
+  case class RowWithStringWrapper(c1: StringWrapper)
+
+  @Test
+  def testCustomTypeConvertersAreUsed(): Unit = {
+    TypeConverter.registerConverter(StringWrapperConverter)
+    val column = ColumnDef("c1", PartitionKeyColumn, TextType)
+    val table = TableDef("test", "table", Seq(column), Nil, Nil)
+    val rowWriter = new DefaultRowWriter[RowWithStringWrapper](table, Seq("c1"), Map.empty)
+
+    val obj = RowWithStringWrapper(StringWrapper("some text"))
+    val buf = Array.ofDim[Any](1)
+    rowWriter.readColumnValues(obj, buf)
+
+    // if our custom type converter wasn't used,
+    // we'd get "StringWrapper(some text)" here instead of "some text":
+    assertEquals("some text", buf(0))
+  }
 }


### PR DESCRIPTION
RowWriter is always created at the application driver site and
serialized to Spark executors. RowWriter also has full
type information about the columns it writes. Therefore
it is a good place to instantiate proper TypeConverters and
completely handle the process of converting the RDD item object of
some type T to values that can be passed to the Java Driver API for
saving as a Cassandra row. When TypeConverters are instantiated
together with RowWriter, custom TypeConverters registered in the
driver application can be found.

Unfortunately this approach requires changes to how
TypeConverters are obtained. Some type converters, like the converter
used for converting UDTValues to objects passable to the Java Driver
API, depend strongly on Java Driver objects like DataType or
ProtocolVersion. Some of those objects are not Serializable and would
prevent sending such a TypeConverter to Spark Executors. Therefore in
this commit the conversion process has been split into two phases.

First phase of conversion is done by the TypeConverters associated
with the RowWriter, as described in the first paragraph. Those
TypeConverters are based on ColumnTypes and
don't use any Java Driver APIs, hence they are Serializable. However,
this way they would not be able to create UDTValue objects required
by the Java Driver.

So in the second phase, another set of
TypeConverters is obtained on the Executor side. They do not need to
be Serializable, they are based on ColumnDefinitions / DataTypes
obtained from the Java Driver and they know the right ProtocolVersion.
They are able to convert connector's UDTValue to Java Driver UDTValue.

Note that in the second phase there is no access to user-registered
TypeConverters. If you want to register a custom converter creating
UDT values, you must register a converter converting to connector's
UDTValue class, not Java Driver's UDTValue. This way it would be
properly selected and used by the RowWriter.