### PR TITLE
SPARKS-162 Add keyspce level/cluster level Conf settings

### DIFF
--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSourceRelation.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSourceRelation.scala
@@ -169,7 +169,7 @@ object CassandraSourceRelation {
    * Consolidate Cassandra conf settings in the order of table level -> keyspace level ->
    * cluster level -> default. Use the first available setting
    */
-  def consolidateConfs(sqlContext: SQLContext, tableRef: TableRef, cassandraConfs: Map[String, String]) : SparkConf = {
+  def consolidateConfs(sqlContext: SQLContext, tableRef: TableRef, tableConf: Map[String, String]) : SparkConf = {
     //Default settings
     val conf = sqlContext.sparkContext.getConf.clone()
     //Keyspace/Cluster level settings
@@ -182,7 +182,7 @@ object CassandraSourceRelation {
       val keyspaceLevelValue = sqlConf.get(s"$cluster:${tableRef.keyspace}/$prop")
       if (keyspaceLevelValue.nonEmpty)
         conf.set(prop, keyspaceLevelValue.get)
-      val tableLevelValue = cassandraConfs.get(prop)
+      val tableLevelValue = tableConf.get(prop)
       if (tableLevelValue.nonEmpty)
         conf.set(prop, tableLevelValue.get)
     }

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSourceRelation.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSourceRelation.scala
@@ -1,6 +1,6 @@
 package org.apache.spark.sql.cassandra
 
-import org.apache.spark.Logging
+import org.apache.spark.{SparkConf, Logging}
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.cassandra.CassandraSQLRow.CassandraSQLRowReader
@@ -139,19 +139,15 @@ object CassandraSourceRelation {
     tableSizeInBytesProperty
   )
 
+  val defaultClusterName = "default"
+
   def apply(
       tableRef: TableRef,
       sqlContext: SQLContext,
       options: CassandraSourceOptions = CassandraSourceOptions(),
       schema : Option[StructType] = None) : CassandraSourceRelation = {
 
-    val conf = sqlContext.sparkContext.getConf.clone()
-    for (prop <- DefaultSource.confProperties) {
-      val tableLevelValue = options.cassandraConfs.get(prop)
-      if (tableLevelValue.nonEmpty)
-        conf.set(prop, tableLevelValue.get)
-    }
-
+    val conf = consolidateConfs(sqlContext, tableRef, options.cassandraConfs)
     val tableSizeInBytesString = conf.getOption(tableSizeInBytesProperty)
     val tableSizeInBytes = if (tableSizeInBytesString.nonEmpty) Option(tableSizeInBytesString.get.toLong) else None
     val cassandraConnector = new CassandraConnector(CassandraConnectorConf(conf))
@@ -167,5 +163,29 @@ object CassandraSourceRelation {
       readConf = readConf,
       writeConf = writeConf,
       sqlContext = sqlContext)
+  }
+
+  /**
+   * Consolidate Cassandra conf settings in the order of table level -> keyspace level ->
+   * cluster level -> default. Use the first available setting
+   */
+  def consolidateConfs(sqlContext: SQLContext, tableRef: TableRef, cassandraConfs: Map[String, String]) : SparkConf = {
+    //Default settings
+    val conf = sqlContext.sparkContext.getConf.clone()
+    //Keyspace/Cluster level settings
+    val sqlConf = sqlContext.getAllConfs
+    for (prop <- DefaultSource.confProperties) {
+      val cluster = tableRef.cluster.getOrElse(defaultClusterName)
+      val clusterLevelValue = sqlConf.get(s"$cluster/$prop")
+      if (clusterLevelValue.nonEmpty)
+        conf.set(prop, clusterLevelValue.get)
+      val keyspaceLevelValue = sqlConf.get(s"$cluster:${tableRef.keyspace}/$prop")
+      if (keyspaceLevelValue.nonEmpty)
+        conf.set(prop, keyspaceLevelValue.get)
+      val tableLevelValue = cassandraConfs.get(prop)
+      if (tableLevelValue.nonEmpty)
+        conf.set(prop, tableLevelValue.get)
+    }
+    conf
   }
 }

--- a/spark-cassandra-connector/src/test/scala/org/apache/spark/sql/cassandra/ConsolidateSettingsSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/org/apache/spark/sql/cassandra/ConsolidateSettingsSpec.scala
@@ -1,0 +1,27 @@
+package org.apache.spark.sql.cassandra
+
+import com.datastax.spark.connector.embedded.SparkTemplate
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.SQLContext
+import org.scalatest.{Matchers, FlatSpec}
+import org.apache.spark.sql.cassandra.CassandraSourceRelation._
+
+class ConsolidateSettingsSpec extends FlatSpec with Matchers {
+
+  it should "consolidate Cassandra conf settings in order of table level -> keyspace -> cluster -> default" in {
+    val tableRef = TableRef("table", "keyspace", Option("cluster"))
+    val conf = SparkTemplate.defaultConf
+    val rowSize = "spark.cassandra.input.page.row.size"
+    conf.set(rowSize, "10")
+    conf.set("spark.driver.allowMultipleContexts", "true")
+    val sc = new SparkContext(conf)
+    val sqlContext = new SQLContext(sc)
+    consolidateConfs(sqlContext, tableRef, Map.empty).get(rowSize) shouldBe "10"
+    sqlContext.setConf(s"cluster/$rowSize", "100")
+    consolidateConfs(sqlContext, tableRef, Map.empty).get(rowSize) shouldBe "100"
+    sqlContext.setConf(s"cluster:keyspace/$rowSize", "200")
+    consolidateConfs(sqlContext, tableRef, Map.empty).get(rowSize) shouldBe "200"
+    val tableConf = Map(rowSize -> "1000")
+    consolidateConfs(sqlContext, tableRef, tableConf).get(rowSize) shouldBe "1000"
+  }
+}


### PR DESCRIPTION
Store keyspace level settings as cluster.keyspace/xx.xx.xx.xx
and cluseter level settings as cluster/xx.xx.xx.xx in
SQLConf

Retrieve settings in the order of
table level -> keyspace -> cluster -> default. Use the one
first available.