### PR TITLE
SPARKC-166: Refactoring: Decouple PredicatePushDown from SparkSQL

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,9 @@
 1.3.x (unreleased)
  * Removed use of Thrift describe_ring and replaced it with native Java Driver
    support for fetching TokenRanges (SPARKC-93)
+ * Decoupled PredicatePushDown logic from Spark (SPARKC-166)
+   - added support for Filter and Expression predicates
+   - improved code testability and added unit-tests
 
 ********************************************************************************
 

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraStrategies.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraStrategies.scala
@@ -6,7 +6,6 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.columnar.InMemoryRelation
 import org.apache.spark.sql.execution.SparkPlan
 
 private[cassandra] trait CassandraStrategies {
@@ -24,150 +23,15 @@ private[cassandra] trait CassandraStrategies {
     }
   }
 
-  /**
-   * Retrieves data using a CassandraTableScan.
-   * Partition pruning predicates are also detected an applied.
-   *  1. Only push down no-partition key column predicates with =, >, <, >=, <= predicate
-   *  2. Only push down primary key column predicates with = or IN predicate.
-   *  3. If there are regular columns in the pushdown predicates, they should have
-   *     at least one EQ expression on an indexed column and no IN predicates.
-   *  4. All partition column predicates must be included in the predicates to be pushed down,
-   *     only the last part of the partition key can be an IN predicate. For each partition column,
-   *     only one predicate is allowed.
-   *  5. For cluster column predicates, only last predicate can be non-EQ predicate
-   *     including IN predicate, and preceding column predicates must be EQ predicates.
-   *     If there is only one cluster column predicate, the predicates could be any non-IN predicate.
-   *  6. There is no pushdown predicates if there is any OR condition or NOT IN condition.
-   *  7. We're not allowed to push down multiple predicates for the same column if any of them
-   *     is equality or IN predicate.
-   */
-  // TODO: index on collection pushdown
+  /** Retrieves data using a CassandraTableScan.
+    * Partition pruning predicates are also detected an applied. */
   object CassandraTableScans extends Strategy with Logging {
-
-    private class PredicatePushDown(predicates: Seq[Expression], relation: CassandraRelation) {
-
-      private def isEqualTo(predicate: Expression): Boolean =
-        predicate.isInstanceOf[EqualTo]
-
-      private def isIn(predicate: Expression) : Boolean =
-        predicate.isInstanceOf[In] || predicate.isInstanceOf[InSet]
-
-      private def isRangeComparison(predicate: Expression) : Boolean = predicate match {
-        case _: LessThan           => true
-        case _: LessThanOrEqual    => true
-        case _: GreaterThan        => true
-        case _: GreaterThanOrEqual => true
-        case _                     => false
-      }
-
-      private def isSingleColumn(predicate: Expression) =
-        predicate.references.size == 1
-
-      private val partitionKeyColumns = relation.partitionColumns.map(_.name)
-      private val clusteringColumns = relation.clusterColumns.map(_.name)
-      private val indexedColumns = relation.indexedColumns.map(_.name)
-      private val regularColumns = relation.regularColumns.map(_.name)
-      private val allColumns = partitionKeyColumns ++ clusteringColumns ++ regularColumns
-
-      private val singleColumnPredicates = predicates.filter(isSingleColumn)
-
-      private val eqPredicates = singleColumnPredicates.filter(isEqualTo)
-      private val eqPredicatesByName = eqPredicates.groupBy(predicateColumnName)
-        .mapValues(_.take(1))       // take(1) in order not to push down more than one EQ predicate for the same column
-        .withDefaultValue(Seq.empty)
-
-      private val inPredicates = singleColumnPredicates.filter(isIn)
-      private val inPredicatesByName = inPredicates.groupBy(predicateColumnName)
-        .mapValues(_.take(1))      // take(1) in order not to push down more than one IN predicate for the same column
-        .withDefaultValue(Seq.empty)
-
-      private val rangePredicates = singleColumnPredicates.filter(isRangeComparison)
-      private val rangePredicatesByName = rangePredicates.groupBy(predicateColumnName).withDefaultValue(Seq.empty)
-
-      /** Returns the only column name referenced in the predicate */
-      private def predicateColumnName(predicate: Expression) = {
-        require(predicate.references.size == 1, "Given predicate is not a single column predicate: " + predicate)
-        predicate.references.head.name
-      }
-
-      /** Returns a first non-empty sequence. If not found, returns an empty sequence. */
-      private def firstNonEmptySeq[T](sequences: Seq[T]*): Seq[T] =
-        sequences.find(_.nonEmpty).getOrElse(Seq.empty[T])
-
-      /**
-       * Selects partition key predicates for pushdown:
-       * 1. Partition key predicates must be equality or IN predicates.
-       * 2. Only the last partition key column predicate can be an IN.
-       * 3. All partition key predicates must be used or none.
-       */
-      private val partitionKeyPredicatesToPushDown: Seq[Expression] = {
-        val (eqColumns, otherColumns) = partitionKeyColumns.span(eqPredicatesByName.contains)
-        val inColumns = otherColumns.headOption.toSeq.filter(inPredicatesByName.contains)
-        if (eqColumns.size + inColumns.size == partitionKeyColumns.size)
-          eqColumns.flatMap(eqPredicatesByName) ++ inColumns.flatMap(inPredicatesByName)
-        else
-          Nil
-      }
-
-      /**
-       * Selects clustering key predicates for pushdown:
-       * 1. Clustering column predicates must be equality predicates, except the last one.
-       * 2. The last predicate is allowed to be an equality or a range predicate.
-       * 3. The last predicate is allowed to be an IN predicate only if it was preceded by an equality predicate.
-       * 4. Consecutive clustering columns must be used, but, contrary to partition key, the tail can be skipped.
-       */
-      private val clusteringColumnPredicatesToPushDown: Seq[Expression] = {
-        val (eqColumns, otherColumns) = clusteringColumns.span(eqPredicatesByName.contains)
-        val eqPredicates = eqColumns.flatMap(eqPredicatesByName)
-        val optionalNonEqPredicate = for {
-          c <- otherColumns.headOption.toSeq
-          p <- firstNonEmptySeq(rangePredicatesByName(c), inPredicatesByName(c).filter(
-            _ => c==clusteringColumns.last))
-        } yield p
-
-        eqPredicates ++ optionalNonEqPredicate
-      }
-
-      /**
-       * Selects indexed and regular column predicates for pushdown:
-       * 1. At least one indexed column must be present in an equality predicate to be pushed down.
-       * 2. Regular column predicates can be either equality or range predicates.
-       * 3. If multiple predicates use the same column, equality predicates are preferred over range predicates.
-       */
-      private val indexedColumnPredicatesToPushDown: Seq[Expression] = {
-        val inPredicateInPrimaryKey = partitionKeyPredicatesToPushDown.exists(isIn)
-        val eqIndexedColumns = indexedColumns.filter(eqPredicatesByName.contains)
-        val eqIndexedPredicates = eqIndexedColumns.flatMap(eqPredicatesByName)
-        // Don't include partition predicates as None-indexed predicates if partition predicates can't
-        // be pushed down because we use token range query which already has partition columns in the
-        // where clause and it can't have other partial partition columns in where clause any more.
-        val nonIndexedPredicates = for {
-          c <- allColumns if !partitionKeyPredicatesToPushDown.isEmpty && !eqIndexedColumns.contains(c) ||
-                              partitionKeyPredicatesToPushDown.isEmpty && !eqIndexedColumns.contains(c) &&
-                               !partitionKeyColumns.contains(c)
-          p <- firstNonEmptySeq(eqPredicatesByName(c), rangePredicatesByName(c))
-        } yield p
-
-        if (!inPredicateInPrimaryKey && eqIndexedColumns.nonEmpty)
-          eqIndexedPredicates ++ nonIndexedPredicates
-        else
-          Nil
-      }
-
-      val predicatesToPushDown = (
-        partitionKeyPredicatesToPushDown ++
-        clusteringColumnPredicatesToPushDown ++
-        indexedColumnPredicatesToPushDown).distinct
-
-      val predicatesToPreserve = predicates.filterNot(predicatesToPushDown.toSet.contains)
-    }
-
 
     def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
       case PhysicalOperation(projectList, predicates, relation: CassandraRelation) =>
         logInfo(s"projectList: ${projectList.toString()}")
         logInfo(s"predicates: ${predicates.toString()}")
-        val pushDown = new PredicatePushDown(predicates, relation)
+        val pushDown = new PredicatePushDown(predicates, relation.tableDef)
         val pushdownPredicates = pushDown.predicatesToPushDown
         val otherPredicates = pushDown.predicatesToPreserve
         logInfo(s"pushdown predicates:  ${pushdownPredicates.toString()}")

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraStrategies.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraStrategies.scala
@@ -31,9 +31,9 @@ private[cassandra] trait CassandraStrategies {
       case PhysicalOperation(projectList, predicates, relation: CassandraRelation) =>
         logInfo(s"projectList: ${projectList.toString()}")
         logInfo(s"predicates: ${predicates.toString()}")
-        val pushDown = new PredicatePushDown(predicates, relation.tableDef)
-        val pushdownPredicates = pushDown.predicatesToPushDown
-        val otherPredicates = pushDown.predicatesToPreserve
+        val pushDown = new PredicatePushDown(predicates.toSet, relation.tableDef)
+        val pushdownPredicates = pushDown.predicatesToPushDown.toSeq
+        val otherPredicates = pushDown.predicatesToPreserve.toSeq
         logInfo(s"pushdown predicates:  ${pushdownPredicates.toString()}")
         logInfo(s"remaining predicates: ${otherPredicates.toString()}")
 

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/PredicateOps.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/PredicateOps.scala
@@ -1,0 +1,93 @@
+package org.apache.spark.sql.cassandra
+
+import org.apache.spark.sql.catalyst.expressions
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.sources
+import org.apache.spark.sql.sources.Filter
+
+/** A unified API for predicates, used by [[PredicatePushDown]].
+  *
+  * Keeps all the Spark-specific stuff out of `PredicatePushDown`
+  * It is also easy to plug-in custom predicate implementations for unit-testing.
+  */
+trait PredicateOps[Predicate] {
+
+  /** Returns the column name of the only column in the predicate.
+    * Will throw `IllegalArgumentException` if predicate is not a single-column predicate. */
+  def columnName(p: Predicate): String
+
+  /** Returns true if the predicate restricts exactly one column. */
+  def isSingleColumnPredicate(p: Predicate): Boolean
+
+  /** Returns true for predicates of type: column = value */
+  def isEqualToPredicate(p: Predicate): Boolean
+
+  /** Returns true for predicates of type: column (< | <= | >= | >) value */
+  def isRangePredicate(p: Predicate): Boolean
+
+  /** Returns true for predicates of type: column IN (value1, value2, ...) */
+  def isInPredicate(p: Predicate): Boolean
+}
+
+/** Provides `PredicateOps` adapters for Expression and Filter classes */
+object PredicateOps {
+
+  /** Adapts the API of Catalyst `Expression` to the API expected by `PredicatePushDown` */
+  implicit object ExpressionOps extends PredicateOps[Expression] {
+
+    override def columnName(p: Expression): String = {
+      require(isSingleColumnPredicate(p), s"Not a single-column predicate: $p")
+      p.references.head.name
+    }
+
+    override def isSingleColumnPredicate(p: Expression): Boolean =
+      p.references.size == 1
+
+    override def isRangePredicate(p: Expression): Boolean = p match {
+      case _: expressions.LessThan => true
+      case _: expressions.LessThanOrEqual => true
+      case _: expressions.GreaterThan => true
+      case _: expressions.GreaterThanOrEqual => true
+      case _ => false
+    }
+
+    override def isEqualToPredicate(p: Expression): Boolean =
+      p.isInstanceOf[expressions.EqualTo]
+
+    override def isInPredicate(p: Expression): Boolean =
+      p.isInstanceOf[expressions.In] || p.isInstanceOf[expressions.InSet]
+
+  }
+
+  /** Adapts the API of Catalyst `Filter` to the API expected by `PredicatePushDown` */
+  implicit object FilterOps extends PredicateOps[Filter] {
+
+    override def columnName(p: Filter): String = p match {
+      case eq: sources.EqualTo => eq.attribute
+      case lt: sources.LessThan => lt.attribute
+      case lte: sources.LessThanOrEqual => lte.attribute
+      case gt: sources.GreaterThan => gt.attribute
+      case gte: sources.GreaterThanOrEqual => gte.attribute
+      case in: sources.In => in.attribute
+      case _ => throw new IllegalArgumentException(
+        s"Don't know how to get column name from the predicate: $p")
+    }
+
+    override def isSingleColumnPredicate(p: Filter): Boolean =
+      isRangePredicate(p) || isEqualToPredicate(p) || isInPredicate(p)
+
+    override def isRangePredicate(p: Filter): Boolean = p match {
+      case _: sources.LessThan => true
+      case _: sources.LessThanOrEqual => true
+      case _: sources.GreaterThan => true
+      case _: sources.GreaterThanOrEqual => true
+      case _ => false
+    }
+
+    override def isEqualToPredicate(p: Filter): Boolean =
+      p.isInstanceOf[sources.EqualTo]
+
+    override def isInPredicate(p: Filter): Boolean =
+      p.isInstanceOf[sources.In]
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/PredicatePushDown.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/PredicatePushDown.scala
@@ -1,0 +1,135 @@
+package org.apache.spark.sql.cassandra
+
+import com.datastax.spark.connector.cql.TableDef
+
+/**
+ *  Determines which filter predicates can be pushed down to Cassandra.
+ *
+ *  1. Only push down no-partition key column predicates with =, >, <, >=, <= predicate
+ *  2. Only push down primary key column predicates with = or IN predicate.
+ *  3. If there are regular columns in the pushdown predicates, they should have
+ *     at least one EQ expression on an indexed column and no IN predicates.
+ *  4. All partition column predicates must be included in the predicates to be pushed down,
+ *     only the last part of the partition key can be an IN predicate. For each partition column,
+ *     only one predicate is allowed.
+ *  5. For cluster column predicates, only last predicate can be non-EQ predicate
+ *     including IN predicate, and preceding column predicates must be EQ predicates.
+ *     If there is only one cluster column predicate, the predicates could be any non-IN predicate.
+ *  6. There is no pushdown predicates if there is any OR condition or NOT IN condition.
+ *  7. We're not allowed to push down multiple predicates for the same column if any of them
+ *     is equality or IN predicate.
+ *
+ *  The list of predicates to be pushed down is available in `predicatesToPushDown` property.
+ *  The list of predicates that cannot be pushed down is available in `predicatesToPreserve` property.
+ *
+ * @param predicates list of filter predicates available in the user query
+ * @param table Cassandra table definition
+ */
+class PredicatePushDown[Predicate : PredicateOps](predicates: Seq[Predicate], table: TableDef) {
+
+  private val Predicates = implicitly[PredicateOps[Predicate]]
+
+  private val partitionKeyColumns = table.partitionKey.map(_.columnName)
+  private val clusteringColumns = table.clusteringColumns.map(_.columnName)
+  private val regularColumns = table.regularColumns.map(_.columnName)
+  private val allColumns = partitionKeyColumns ++ clusteringColumns ++ regularColumns
+  private val indexedColumns = table.allColumns.filter(_.isIndexedColumn).map(_.columnName)
+
+  private val singleColumnPredicates = predicates.filter(Predicates.isSingleColumnPredicate)
+
+  private val eqPredicates = singleColumnPredicates.filter(Predicates.isEqualToPredicate)
+  private val eqPredicatesByName = eqPredicates.groupBy(Predicates.columnName)
+    .mapValues(_.take(1))       // don't push down more than one EQ predicate for the same column
+    .withDefaultValue(Seq.empty)
+
+  private val inPredicates = singleColumnPredicates.filter(Predicates.isInPredicate)
+  private val inPredicatesByName = inPredicates.groupBy(Predicates.columnName)
+    .mapValues(_.take(1))      // don't push down more than one IN predicate for the same column
+    .withDefaultValue(Seq.empty)
+
+  private val rangePredicates = singleColumnPredicates.filter(Predicates.isRangePredicate)
+  private val rangePredicatesByName = rangePredicates
+    .groupBy(Predicates.columnName)
+    .withDefaultValue(Seq.empty)
+
+  /** Returns a first non-empty sequence. If not found, returns an empty sequence. */
+  private def firstNonEmptySeq[T](sequences: Seq[T]*): Seq[T] =
+    sequences.find(_.nonEmpty).getOrElse(Seq.empty[T])
+
+  /**
+   * Selects partition key predicates for pushdown:
+   * 1. Partition key predicates must be equality or IN predicates.
+   * 2. Only the last partition key column predicate can be an IN.
+   * 3. All partition key predicates must be used or none.
+   */
+  private val partitionKeyPredicatesToPushDown: Seq[Predicate] = {
+    val (eqColumns, otherColumns) = partitionKeyColumns.span(eqPredicatesByName.contains)
+    val inColumns = otherColumns.headOption.toSeq.filter(inPredicatesByName.contains)
+    if (eqColumns.size + inColumns.size == partitionKeyColumns.size)
+      eqColumns.flatMap(eqPredicatesByName) ++ inColumns.flatMap(inPredicatesByName)
+    else
+      Nil
+  }
+
+  /**
+   * Selects clustering key predicates for pushdown:
+   * 1. Clustering column predicates must be equality predicates, except the last one.
+   * 2. The last predicate is allowed to be an equality or a range predicate.
+   * 3. The last predicate is allowed to be an IN predicate only if it was preceded by
+   *    an equality predicate.
+   * 4. Consecutive clustering columns must be used, but, contrary to partition key,
+   *    the tail can be skipped.
+   */
+  private val clusteringColumnPredicatesToPushDown: Seq[Predicate] = {
+    val (eqColumns, otherColumns) = clusteringColumns.span(eqPredicatesByName.contains)
+    val eqPredicates = eqColumns.flatMap(eqPredicatesByName)
+    val optionalNonEqPredicate = for {
+      c <- otherColumns.headOption.toSeq
+      p <- firstNonEmptySeq(
+        rangePredicatesByName(c),
+        inPredicatesByName(c).filter(_ => c == clusteringColumns.last))
+    } yield p
+
+    eqPredicates ++ optionalNonEqPredicate
+  }
+
+  /**
+   * Selects indexed and regular column predicates for pushdown:
+   * 1. At least one indexed column must be present in an equality predicate to be pushed down.
+   * 2. Regular column predicates can be either equality or range predicates.
+   * 3. If multiple predicates use the same column, equality predicates are preferred over range
+   *    predicates.
+   */
+  private val indexedColumnPredicatesToPushDown: Seq[Predicate] = {
+    val inPredicateInPrimaryKey = partitionKeyPredicatesToPushDown.exists(Predicates.isInPredicate)
+    val eqIndexedColumns = indexedColumns.filter(eqPredicatesByName.contains)
+    val eqIndexedPredicates = eqIndexedColumns.flatMap(eqPredicatesByName)
+
+    // Don't include partition predicates in nonIndexedPredicates if partition predicates can't
+    // be pushed down because we use token range query which already has partition columns in the
+    // where clause and it can't have other partial partition columns in where clause any more.
+    val nonIndexedPredicates = for {
+      c <- allColumns if
+        partitionKeyPredicatesToPushDown.nonEmpty && !eqIndexedColumns.contains(c) ||
+        partitionKeyPredicatesToPushDown.isEmpty && !eqIndexedColumns.contains(c) &&
+          !partitionKeyColumns.contains(c)
+      p <- firstNonEmptySeq(eqPredicatesByName(c), rangePredicatesByName(c))
+    } yield p
+
+    if (!inPredicateInPrimaryKey && eqIndexedColumns.nonEmpty)
+      eqIndexedPredicates ++ nonIndexedPredicates
+    else
+      Nil
+  }
+
+  /** Returns the set of predicates that can be safely pushed down to Cassandra */
+  val predicatesToPushDown: Seq[Predicate] = (
+    partitionKeyPredicatesToPushDown ++
+      clusteringColumnPredicatesToPushDown ++
+      indexedColumnPredicatesToPushDown).distinct
+
+  /** Returns the set of predicates that cannot be pushed down to Cassandra,
+    * so they must be applied by Spark  */
+  val predicatesToPreserve: Seq[Predicate] =
+    predicates.filterNot(predicatesToPushDown.toSet.contains)
+}

--- a/spark-cassandra-connector/src/test/scala/org/apache/spark/sql/cassandra/PredicatePushDownSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/org/apache/spark/sql/cassandra/PredicatePushDownSpec.scala
@@ -1,0 +1,255 @@
+package org.apache.spark.sql.cassandra
+
+import org.scalatest.{Matchers, FlatSpec}
+
+import com.datastax.spark.connector.cql._
+import com.datastax.spark.connector.types.IntType
+
+class PredicatePushDownSpec extends FlatSpec with Matchers {
+
+  // We don't want this test to rely on any Spark code,
+  // so we're using our own Filters
+  trait Filter
+  case class EqFilter(columnName: String) extends Filter
+  case class InFilter(columnName: String) extends Filter
+  case class LtFilter(columnName: String) extends Filter
+  case class GtFilter(columnName: String) extends Filter
+  case object UnsupportedFilter extends Filter
+
+  implicit object FilterOps extends PredicateOps[Filter] {
+    override def columnName(p: Filter) = p match {
+      case EqFilter(name) => name
+      case InFilter(name) => name
+      case LtFilter(name) => name
+      case GtFilter(name) => name
+      case UnsupportedFilter => throw new IllegalArgumentException("Unsupported predicate")
+    }
+    override def isRangePredicate(p: Filter) = p.isInstanceOf[LtFilter] || p.isInstanceOf[GtFilter]
+    override def isSingleColumnPredicate(p: Filter) = p != UnsupportedFilter
+    override def isEqualToPredicate(p: Filter) = p.isInstanceOf[EqFilter]
+    override def isInPredicate(p: Filter) = p.isInstanceOf[InFilter]
+  }
+
+  val pk1 = ColumnDef("pk1", PartitionKeyColumn, IntType)
+  val pk2 = ColumnDef("pk2", PartitionKeyColumn, IntType)
+  val c1 = ColumnDef("c1", ClusteringColumn(0), IntType)
+  val c2 = ColumnDef("c2", ClusteringColumn(1), IntType)
+  val c3 = ColumnDef("c3", ClusteringColumn(2), IntType)
+  val i1 = ColumnDef("i1", RegularColumn, IntType, indexed = true)
+  val i2 = ColumnDef("i2", RegularColumn, IntType, indexed = true)
+  val r1 = ColumnDef("r1", RegularColumn, IntType)
+  val r2 = ColumnDef("r2", RegularColumn, IntType)
+
+  val table = TableDef(
+    keyspaceName = "test",
+    tableName = "test",
+    partitionKey = Seq(pk1, pk2),
+    clusteringColumns = Seq(c1, c2, c3),
+    regularColumns = Seq(i1, i2, r1, r2)
+  )
+
+  "PredicatePushDown" should "push down all equality predicates restricting partition key columns" in {
+    val f1 = EqFilter("pk1")
+    val f2 = EqFilter("pk2")
+    val ppd = new PredicatePushDown(Seq[Filter](f1, f2), table)
+    ppd.predicatesToPushDown should contain allOf(f1, f2)
+    ppd.predicatesToPreserve shouldBe empty
+  }
+
+  it should "not push down a partition key predicate for a part of the partition key" in {
+    val f1 = EqFilter("pk1")
+    val ppd1 = new PredicatePushDown(Seq[Filter](f1), table)
+    ppd1.predicatesToPushDown shouldBe empty
+    ppd1.predicatesToPreserve should contain(f1)
+
+    val f2 = EqFilter("pk2")
+    val ppd2 = new PredicatePushDown(Seq[Filter](f2), table)
+    ppd2.predicatesToPushDown shouldBe empty
+    ppd2.predicatesToPreserve should contain(f2)
+  }
+
+  it should "not push down a range partition key predicate" in {
+    val f1 = EqFilter("pk1")
+    val f2 = LtFilter("pk2")
+    val ppd = new PredicatePushDown(Seq[Filter](f1, f2), table)
+    ppd.predicatesToPushDown shouldBe empty
+    ppd.predicatesToPreserve should contain allOf(f1, f2)
+  }
+
+  it should "push down an IN partition key predicate on the last partition key column" in {
+    val f1 = EqFilter("pk1")
+    val f2 = InFilter("pk2")
+    val ppd = new PredicatePushDown(Seq[Filter](f1, f2), table)
+    ppd.predicatesToPushDown should contain allOf(f1, f2)
+    ppd.predicatesToPreserve shouldBe empty
+  }
+
+  it should "not push down an IN partition key predicate on the non-last partition key column" in {
+    val f1 = InFilter("pk1")
+    val f2 = EqFilter("pk2")
+    val ppd = new PredicatePushDown(Seq[Filter](f1, f2), table)
+    ppd.predicatesToPushDown shouldBe empty
+    ppd.predicatesToPreserve should contain allOf(f1, f2)
+  }
+
+  it should "push down the first clustering column predicate" in {
+    val f1 = EqFilter("c1")
+    val ppd = new PredicatePushDown(Seq[Filter](f1), table)
+    ppd.predicatesToPushDown shouldBe Seq(f1)
+    ppd.predicatesToPreserve shouldBe empty
+  }
+
+  it should "push down the first and the second clustering column predicate" in {
+    val f1 = EqFilter("c1")
+    val f2 = LtFilter("c2")
+    val ppd = new PredicatePushDown(Seq[Filter](f1, f2), table)
+    ppd.predicatesToPushDown should contain only(f1, f2)
+    ppd.predicatesToPreserve shouldBe empty
+  }
+
+  it should "push down restrictions on only the initial clustering columns" in {
+    val f1 = EqFilter("c1")
+    val f2 = EqFilter("c3")
+    
+    val ppd1 = new PredicatePushDown(Seq[Filter](f1, f2), table)
+    ppd1.predicatesToPushDown should contain only f1
+    ppd1.predicatesToPreserve should contain only f2
+
+    val ppd2 = new PredicatePushDown(Seq[Filter](f2), table)
+    ppd2.predicatesToPushDown shouldBe empty
+    ppd2.predicatesToPreserve should contain only f2
+  }
+
+  it should "push down only one range predicate restricting the first clustering column, " +
+      "if there are more range predicates on different clustering columns" in {
+    val f1 = LtFilter("c1")
+    val f2 = LtFilter("c2")
+    val ppd = new PredicatePushDown(Seq[Filter](f1, f2), table)
+    ppd.predicatesToPushDown shouldBe Seq(f1)
+    ppd.predicatesToPreserve shouldBe Seq(f2)
+  }
+
+  it should "push down multiple range predicates for the same clustering column" in {
+    val f1 = LtFilter("c1")
+    val f2 = GtFilter("c1")
+    val ppd = new PredicatePushDown(Seq[Filter](f1, f2), table)
+    ppd.predicatesToPushDown should contain allOf (f1, f2)
+    ppd.predicatesToPreserve shouldBe empty
+  }
+
+  it should "push down clustering column predicates when the last clustering column is restricted by IN" in {
+    val f1 = EqFilter("c1")
+    val f2 = EqFilter("c2")
+    val f3 = InFilter("c3")
+    val ppd = new PredicatePushDown(Seq[Filter](f1, f2, f3), table)
+    ppd.predicatesToPushDown should contain only(f1, f2, f3)
+    ppd.predicatesToPreserve shouldBe empty
+  }
+
+  it should "stop pushing down clustering column predicates on the first range predicate" in {
+    val f1 = EqFilter("c1")
+    val f2 = LtFilter("c2")
+    val f3 = EqFilter("c3")
+    val ppd = new PredicatePushDown(Seq[Filter](f1, f2, f3), table)
+    ppd.predicatesToPushDown should contain only(f1, f2)
+    ppd.predicatesToPreserve shouldBe Seq(f3)
+  }
+
+  it should "not push down IN restriction on non-last column" in {
+    val f1 = EqFilter("c1")
+    val f2 = InFilter("c2")
+    val f3 = EqFilter("c3")
+    val ppd = new PredicatePushDown(Seq[Filter](f1, f2, f3), table)
+    ppd.predicatesToPushDown should contain only f1
+    ppd.predicatesToPreserve should contain only (f2, f3)
+  }
+
+  it should "not push down any clustering column predicates, if the first clustering column is missing" in {
+    val f1 = EqFilter("c2")
+    val ppd = new PredicatePushDown(Seq[Filter](f1), table)
+    ppd.predicatesToPushDown shouldBe empty
+    ppd.predicatesToPreserve shouldBe Seq(f1)
+  }
+
+  it should "push down equality predicates on regular indexed columns" in {
+    val f1 = EqFilter("i1")
+    val ppd = new PredicatePushDown(Seq[Filter](f1), table)
+    ppd.predicatesToPushDown shouldBe Seq(f1)
+    ppd.predicatesToPreserve shouldBe empty
+  }
+
+  it should "not push down range predicates on regular indexed columns" in {
+    val f1 = LtFilter("i1")
+    val ppd = new PredicatePushDown(Seq[Filter](f1), table)
+    ppd.predicatesToPushDown shouldBe empty
+    ppd.predicatesToPreserve shouldBe Seq(f1)
+  }
+
+  it should "not push down IN predicates on regular indexed columns" in {
+    val f1 = InFilter("i1")
+    val ppd = new PredicatePushDown(Seq[Filter](f1), table)
+    ppd.predicatesToPushDown shouldBe empty
+    ppd.predicatesToPreserve shouldBe Seq(f1)
+  }
+
+  it should "push down predicates on regular non-indexed and indexed columns" in {
+    val f1 = EqFilter("r1")
+    val f2 = EqFilter("r2")
+    val f3 = EqFilter("i1")
+    val ppd = new PredicatePushDown(Seq[Filter](f1, f2, f3), table)
+    ppd.predicatesToPushDown should contain allOf(f1, f2, f3)
+    ppd.predicatesToPreserve shouldBe empty
+  }
+
+  it should "not push down predicates on regular non-indexed columns if indexed ones are not included" in {
+    val f1 = EqFilter("r1")
+    val f2 = EqFilter("r2")
+    val ppd = new PredicatePushDown(Seq[Filter](f1, f2), table)
+    ppd.predicatesToPushDown shouldBe empty
+    ppd.predicatesToPreserve should contain allOf(f1, f2)
+  }
+
+  it should "not rely on given predicates order (1)" in {
+    val f1 = EqFilter("c1")
+    val f2 = LtFilter("c2")
+    val f3 = EqFilter("c3")
+    val ppd = new PredicatePushDown(Seq[Filter](f2, f3, f1), table)
+    ppd.predicatesToPushDown should contain only(f1, f2)
+    ppd.predicatesToPreserve shouldBe Seq(f3)
+  }
+
+  it should "not rely on given predicates order (2)" in {
+    val f1 = EqFilter("c1")
+    val f2 = LtFilter("c2")
+    val f3 = EqFilter("c3")
+    val ppd = new PredicatePushDown(Seq[Filter](f3, f2, f1), table)
+    ppd.predicatesToPushDown should contain only(f1, f2)
+    ppd.predicatesToPreserve shouldBe Seq(f3)
+  }
+
+  it should "not rely on given predicates order (3)" in {
+    val f1 = EqFilter("c1")
+    val f2 = EqFilter("c2")
+    val f3 = InFilter("c3")
+    val ppd = new PredicatePushDown(Seq[Filter](f2, f3, f1), table)
+    ppd.predicatesToPushDown should contain only(f1, f2, f3)
+    ppd.predicatesToPreserve shouldBe empty
+  }
+
+  it should "prefer to push down equality predicates over range predicates" in {
+    val f1 = EqFilter("c1")
+    val f2 = EqFilter("c2")
+    val f3 = LtFilter("c2")
+    val ppd = new PredicatePushDown(Seq[Filter](f1, f2, f3), table)
+    ppd.predicatesToPushDown should contain only(f1, f2)
+    ppd.predicatesToPreserve should contain only f3
+  }
+
+  it should "not push down unsupported predicates" in {
+    val f1 = EqFilter("i1")
+    val f2 = UnsupportedFilter
+    val ppd = new PredicatePushDown(Seq[Filter](f1, f2), table)
+    ppd.predicatesToPushDown should contain only f1
+    ppd.predicatesToPreserve should contain only f2
+  }
+}


### PR DESCRIPTION
PredicatePushDown class was tied to Spark code by depending on Spark's
internal Expression class. This caused a problem when we wanted to
unit-test it separately or when we wanted to support other
representation of predicates like the new Filter class introduced by
Spark Data Sources API.

Therefore in this ticket, PredicatePushDown class has been moved out
from CassandraStrategies into its own file. Then all Spark-specific
code has been factored out to a separate PredicateOps typeclass.
PredicatePushDown has been generified to take predicate class type
parameter. This way, it can work with any type of predicate that is
in PredicateOps. PredicateOps is available for Expression and Filter.
It is very easy to add support for other types of predicates in the
future without changing PredicatePushDown code. Additionally, there
is less risk Spark API changes ever break our unit-tests.