### PR TITLE
SPARKC-140 Create a custom DDL Parser for metastore

### DIFF
--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraDDLParser.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraDDLParser.scala
@@ -1,0 +1,118 @@
+package org.apache.spark.sql.cassandra
+
+import org.apache.spark.sql.catalyst.AbstractSparkSQLParser
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.sources.DDLException
+
+/** A customer parser to add custom commands for Cassandra SQL metastore */
+private [cassandra] class CassandraDDLParser(parseQuery: String => LogicalPlan) extends AbstractSparkSQLParser {
+
+  def apply(input: String, exceptionOnError: Boolean): Option[LogicalPlan] = {
+    try {
+      Some(apply(input))
+    } catch {
+      case ddlException: DDLException => throw ddlException
+      case _ if !exceptionOnError => None
+      case x: Throwable => throw x
+    }
+  }
+
+  protected val USE  = Keyword("USE")
+  protected val SHOW  = Keyword("SHOW")
+  protected val DROP  = Keyword("DROP")
+  protected val CREATE  = Keyword("CREATE")
+  protected val ALTER  = Keyword("ALTER")
+  protected val RENAME  = Keyword("RENAME")
+  protected val SET  = Keyword("SET")
+  protected val REMOVE  = Keyword("REMOVE")
+  protected val IN  = Keyword("IN")
+  protected val CLUSTER  = Keyword("CLUSTER")
+  protected val DATABASE  = Keyword("DATABASE")
+  protected val TABLE  = Keyword("TABLE")
+  protected val CLUSTERS  = Keyword("CLUSTERS")
+  protected val DATABASES  = Keyword("DATABASES")
+  protected val TABLES  = Keyword("TABLES")
+  protected val OPTION  = Keyword("OPTION")
+  protected val SCHEMA  = Keyword("SCHEMA")
+  protected val TO  = Keyword("TO")
+
+  protected lazy val start: Parser[LogicalPlan] =
+    useCluster | useDatabase | showDatabases | showTables | showClusters |
+    createDatabase | createCluster | dropDatabase | dropCluster | dropTable |
+    renameTable | setTableOption | removeTableOption | removeTableSchema | setTableSchema
+
+  private lazy val useCluster: Parser[LogicalPlan] =
+    USE ~ CLUSTER ~> restInput ^^ {
+      case input => UseCluster(input.trim)
+    }
+
+  private lazy val useDatabase: Parser[LogicalPlan] =
+    USE ~ DATABASE ~> rep1sep(ident, ".") ^^ {
+      case input => UseDatabase(input)
+    }
+
+  private lazy val showClusters: Parser[LogicalPlan] =
+    SHOW ~ CLUSTERS ^^ {
+      case input => ShowClusters()
+    }
+
+  private lazy val showDatabases: Parser[LogicalPlan] =
+    SHOW ~ DATABASES ~ opt(IN) ~> repsep(ident, ".") ^^ {
+      case input => ShowDatabases(input)
+    }
+
+  private lazy val showTables: Parser[LogicalPlan] =
+    SHOW ~ TABLES  ~ opt(IN) ~> repsep(ident, ".") ^^ {
+      case input => ShowTables(input)
+    }
+
+  private lazy val createDatabase: Parser[LogicalPlan] =
+    CREATE ~ DATABASE ~> rep1sep(ident, ".") ^^ {
+      case input => CreateDatabase(input)
+    }
+
+  private lazy val createCluster: Parser[LogicalPlan] =
+    CREATE ~ CLUSTER  ~> restInput ^^ {
+      case input => CreateCluster(input.trim)
+    }
+
+  private lazy val dropDatabase: Parser[LogicalPlan] =
+    DROP ~ DATABASE ~> rep1sep(ident, ".") ^^ {
+      case input => DropDatabase(input)
+    }
+
+  private lazy val dropCluster: Parser[LogicalPlan] =
+    DROP ~ CLUSTER  ~> restInput ^^ {
+      case input => DropCluster(input.trim)
+    }
+
+  private lazy val dropTable: Parser[LogicalPlan] =
+    DROP ~ TABLE ~> rep1sep(ident, ".") ^^ {
+      case input => DropTable(input)
+    }
+
+  private lazy val renameTable: Parser[LogicalPlan] =
+    (ALTER ~ TABLE ~> rep1sep(ident, ".")) ~ (RENAME ~ TO ~> restInput) ^^ {
+      case oldName ~ newName => RenameTable(oldName, newName.trim)
+    }
+
+  private lazy val setTableOption: Parser[LogicalPlan] =
+    (ALTER ~ TABLE ~> rep1sep(ident, ".")) ~ (SET ~ OPTION) ~ ("(" ~> stringLit) ~ ("," ~> stringLit <~ ")") ^^ {
+      case table ~ opt ~ key ~ value => SetTableOption(table, key.trim, value.trim)
+    }
+
+  private lazy val removeTableOption: Parser[LogicalPlan] =
+    (ALTER ~ TABLE ~> rep1sep(ident, ".")) ~ (REMOVE ~ OPTION ~> restInput) ^^ {
+      case table ~ key => RemoveTableOption(table, key.trim)
+    }
+
+  private lazy val setTableSchema: Parser[LogicalPlan] =
+    (ALTER ~ TABLE ~> rep1sep(ident, ".")) ~ (SET ~ SCHEMA ~> restInput) ^^ {
+      case table ~ schema => SetTableSchema(table, schema.trim)
+    }
+
+  private lazy val removeTableSchema: Parser[LogicalPlan] =
+    (ALTER ~ TABLE ~> rep1sep(ident, ".")) ~ (REMOVE ~ SCHEMA) ^^ {
+      case table ~ remove => RemoveTableSchema(table)
+    }
+}

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/Commands.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/Commands.scala
@@ -1,0 +1,136 @@
+package org.apache.spark.sql.cassandra
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.execution.RunnableCommand
+import org.apache.spark.sql.SQLContext
+
+/**
+ * Drops a table from the metastore and removes it if it is cached.
+ */
+private[cassandra] case class DropTable(tableIdentifier: Seq[String]) extends RunnableCommand {
+  override def run(sqlContext: SQLContext) = {
+    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    Seq.empty[Row]
+  }
+}
+
+/**
+ * Rename a table from the metastore.
+ */
+private[cassandra] case class RenameTable(tableIdentifier: Seq[String], newName: String) extends RunnableCommand {
+  override def run(sqlContext: SQLContext) = {
+    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    Seq.empty[Row]
+  }
+}
+
+/** Set table schema */
+private[cassandra] case class SetTableSchema(tableIdentifier: Seq[String], schemaJsonString: String) extends RunnableCommand {
+  override def run(sqlContext: SQLContext) = {
+    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    Seq.empty[Row]
+  }
+}
+
+/** Set an option of table options */
+private[cassandra] case class SetTableOption(
+    tableIdentifier: Seq[String],
+    key: String,
+    value: String) extends RunnableCommand {
+  override def run(sqlContext: SQLContext) = {
+    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    Seq.empty[Row]
+  }
+}
+
+/** Remove an option of table options */
+private[cassandra] case class RemoveTableOption(tableIdentifier: Seq[String], key: String) extends RunnableCommand {
+  override def run(sqlContext: SQLContext) = {
+    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    Seq.empty[Row]
+  }
+}
+
+/** Remove table schema */
+private[cassandra] case class RemoveTableSchema(tableIdentifier: Seq[String]) extends RunnableCommand {
+  override def run(sqlContext: SQLContext) = {
+    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    Seq.empty[Row]
+  }
+}
+
+/** Change the current used cluster */
+private[cassandra] case class UseCluster(cluster: String) extends RunnableCommand {
+  override def run(sqlContext: SQLContext) = {
+    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    Seq.empty[Row]
+  }
+}
+
+/** Change the current used database */
+private[cassandra] case class UseDatabase(databaseIdentifier: Seq[String]) extends RunnableCommand {
+  override def run(sqlContext: SQLContext) = {
+    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    Seq.empty[Row]
+  }
+}
+
+/** Show table names for a database of a cluster */
+private[cassandra] case class ShowTables(databaseIdentifier: Seq[String]) extends RunnableCommand {
+  override def run(sqlContext: SQLContext) = {
+    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    Seq.empty[Row]
+  }
+}
+
+/** Show database names for a cluster */
+private[cassandra] case class ShowDatabases(clusterIdentifier: Seq[String]) extends RunnableCommand {
+  override def run(sqlContext: SQLContext) = {
+    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    Seq.empty[Row]
+  }
+}
+
+/** Show cluster names */
+private[cassandra] case class ShowClusters() extends RunnableCommand {
+  override def run(sqlContext: SQLContext) = {
+    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    Seq.empty[Row]
+  }
+}
+
+/** Create a database in metastore */
+private[cassandra] case class CreateDatabase(databaseIdentifier: Seq[String]) extends RunnableCommand {
+  override def run(sqlContext: SQLContext) = {
+    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    //cc.createDatabase(databaseName, Option(clusterName))
+    Seq.empty[Row]
+  }
+}
+
+/** Create a cluster in metastore */
+private[cassandra] case class CreateCluster(cluster: String) extends RunnableCommand {
+  override def run(sqlContext: SQLContext) = {
+    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    //cc.createCluster(cluster)
+    Seq.empty[Row]
+  }
+}
+
+/** Drop a database from metastore */
+private[cassandra] case class DropDatabase(databaseIdentifier: Seq[String]) extends RunnableCommand {
+  override def run(sqlContext: SQLContext) = {
+    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    //cc.unregisterDatabase(databaseName, Option(clusterName))
+    Seq.empty[Row]
+  }
+}
+
+/** Drop a cluster from metastore */
+private[cassandra] case class DropCluster(cluster: String) extends RunnableCommand {
+  override def run(sqlContext: SQLContext) = {
+    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    //cc.unregisterCluster(cluster)
+    Seq.empty[Row]
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/Commands.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/Commands.scala
@@ -3,6 +3,7 @@ package org.apache.spark.sql.cassandra
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.RunnableCommand
 import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
 
 /**
  * Drops a table from the metastore and removes it if it is cached.
@@ -12,6 +13,8 @@ private[cassandra] case class DropTable(tableIdentifier: Seq[String]) extends Ru
     val cc = sqlContext.asInstanceOf[CassandraSQLContext]
     Seq.empty[Row]
   }
+
+  override def output: Seq[Attribute] = Seq.empty
 }
 
 /**
@@ -22,6 +25,8 @@ private[cassandra] case class RenameTable(tableIdentifier: Seq[String], newName:
     val cc = sqlContext.asInstanceOf[CassandraSQLContext]
     Seq.empty[Row]
   }
+
+  override def output: Seq[Attribute] = Seq.empty
 }
 
 /** Set table schema */
@@ -30,6 +35,8 @@ private[cassandra] case class SetTableSchema(tableIdentifier: Seq[String], schem
     val cc = sqlContext.asInstanceOf[CassandraSQLContext]
     Seq.empty[Row]
   }
+
+  override def output: Seq[Attribute] = Seq.empty
 }
 
 /** Set an option of table options */
@@ -41,6 +48,8 @@ private[cassandra] case class SetTableOption(
     val cc = sqlContext.asInstanceOf[CassandraSQLContext]
     Seq.empty[Row]
   }
+
+  override def output: Seq[Attribute] = Seq.empty
 }
 
 /** Remove an option of table options */
@@ -49,6 +58,8 @@ private[cassandra] case class RemoveTableOption(tableIdentifier: Seq[String], ke
     val cc = sqlContext.asInstanceOf[CassandraSQLContext]
     Seq.empty[Row]
   }
+
+  override def output: Seq[Attribute] = Seq.empty
 }
 
 /** Remove table schema */
@@ -57,6 +68,8 @@ private[cassandra] case class RemoveTableSchema(tableIdentifier: Seq[String]) ex
     val cc = sqlContext.asInstanceOf[CassandraSQLContext]
     Seq.empty[Row]
   }
+
+  override def output: Seq[Attribute] = Seq.empty
 }
 
 /** Change the current used cluster */
@@ -65,6 +78,8 @@ private[cassandra] case class UseCluster(cluster: String) extends RunnableComman
     val cc = sqlContext.asInstanceOf[CassandraSQLContext]
     Seq.empty[Row]
   }
+
+  override def output: Seq[Attribute] = Seq.empty
 }
 
 /** Change the current used database */
@@ -73,6 +88,8 @@ private[cassandra] case class UseDatabase(databaseIdentifier: Seq[String]) exten
     val cc = sqlContext.asInstanceOf[CassandraSQLContext]
     Seq.empty[Row]
   }
+
+  override def output: Seq[Attribute] = Seq.empty
 }
 
 /** Show table names for a database of a cluster */
@@ -80,6 +97,13 @@ private[cassandra] case class ShowTables(databaseIdentifier: Seq[String]) extend
   override def run(sqlContext: SQLContext) = {
     val cc = sqlContext.asInstanceOf[CassandraSQLContext]
     Seq.empty[Row]
+  }
+
+  override val output: Seq[Attribute] = {
+    val schema = StructType(
+      StructField("tableName", StringType, false) :: Nil)
+
+    schema.toAttributes
   }
 }
 
@@ -89,6 +113,13 @@ private[cassandra] case class ShowDatabases(clusterIdentifier: Seq[String]) exte
     val cc = sqlContext.asInstanceOf[CassandraSQLContext]
     Seq.empty[Row]
   }
+
+  override val output: Seq[Attribute] = {
+    val schema = StructType(
+      StructField("databaseName", StringType, false) :: Nil)
+
+    schema.toAttributes
+  }
 }
 
 /** Show cluster names */
@@ -96,6 +127,13 @@ private[cassandra] case class ShowClusters() extends RunnableCommand {
   override def run(sqlContext: SQLContext) = {
     val cc = sqlContext.asInstanceOf[CassandraSQLContext]
     Seq.empty[Row]
+  }
+
+  override val output: Seq[Attribute] = {
+    val schema = StructType(
+      StructField("clusterName", StringType, false) :: Nil)
+
+    schema.toAttributes
   }
 }
 
@@ -106,6 +144,8 @@ private[cassandra] case class CreateDatabase(databaseIdentifier: Seq[String]) ex
     //cc.createDatabase(databaseName, Option(clusterName))
     Seq.empty[Row]
   }
+
+  override def output: Seq[Attribute] = Seq.empty
 }
 
 /** Create a cluster in metastore */
@@ -115,6 +155,8 @@ private[cassandra] case class CreateCluster(cluster: String) extends RunnableCom
     //cc.createCluster(cluster)
     Seq.empty[Row]
   }
+
+  override def output: Seq[Attribute] = Seq.empty
 }
 
 /** Drop a database from metastore */
@@ -124,6 +166,8 @@ private[cassandra] case class DropDatabase(databaseIdentifier: Seq[String]) exte
     //cc.unregisterDatabase(databaseName, Option(clusterName))
     Seq.empty[Row]
   }
+
+  override def output: Seq[Attribute] = Seq.empty
 }
 
 /** Drop a cluster from metastore */
@@ -133,4 +177,6 @@ private[cassandra] case class DropCluster(cluster: String) extends RunnableComma
     //cc.unregisterCluster(cluster)
     Seq.empty[Row]
   }
+
+  override def output: Seq[Attribute] = Seq.empty
 }


### PR DESCRIPTION
Create a custom DDL parser to manage metadata and
metastore.

It supports the following syntax
 - USE CLUSTER cluster_name
 - USE DATABASE database_name
 - SHOW CLUSTERS
 - SHOW DATABASES [IN] [cluster_name]
 - SHOW TABLES [IN] [database_name]
 - CREATE DATABASE database_name
 - CREATE CLUSTER cluster_name
 - DROP CLUSTER cluster_name
 - DROP DATABASE database_name
 - DROP TABLE table_name
 - ALTER TABLE table_name RENAME  TO new_name
 - ALTER TABLE table_name SET OPTION ('key', 'value')
 - ALTER TABLE table_name REMOVE OPTION key
 - ALTER TABLE table_name SET SCHEMA schemaJsonString
 - ALTER TABLE table_name REMOVE SCHEMA

Mock commands are created as well for the above
queries