### PR TITLE
SPARKC-162 Add keyspce level/cluster level Conf settings

### DIFF
--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSourceRelation.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSourceRelation.scala
@@ -1,6 +1,6 @@
 package org.apache.spark.sql.cassandra
 
-import org.apache.spark.Logging
+import org.apache.spark.{SparkConf, Logging}
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.cassandra.CassandraSQLRow.CassandraSQLRowReader
@@ -140,19 +140,17 @@ object CassandraSourceRelation {
     tableSizeInBytesProperty
   )
 
+  val defaultClusterName = "default"
+
   def apply(
       tableRef: TableRef,
       sqlContext: SQLContext,
       options: CassandraSourceOptions = CassandraSourceOptions(),
       schema : Option[StructType] = None) : CassandraSourceRelation = {
 
-    val conf = sqlContext.sparkContext.getConf.clone()
-    for (prop <- DefaultSource.confProperties) {
-      val tableLevelValue = options.cassandraConfs.get(prop)
-      if (tableLevelValue.nonEmpty)
-        conf.set(prop, tableLevelValue.get)
-    }
-
+    val sparkConf = sqlContext.sparkContext.getConf
+    val sqlConf = sqlContext.getAllConfs
+    val conf = consolidateConfs(sparkConf, sqlConf, tableRef, options.cassandraConfs)
     val tableSizeInBytesString = conf.getOption(tableSizeInBytesProperty)
     val tableSizeInBytes = if (tableSizeInBytesString.nonEmpty) Option(tableSizeInBytesString.get.toLong) else None
     val cassandraConnector = new CassandraConnector(CassandraConnectorConf(conf))
@@ -168,5 +166,29 @@ object CassandraSourceRelation {
       readConf = readConf,
       writeConf = writeConf,
       sqlContext = sqlContext)
+  }
+
+  /**
+   * Consolidate Cassandra conf settings in the order of table level -> keyspace level ->
+   * cluster level -> default. Use the first available setting. Default settings are
+   * stored in SparkConf
+   */
+  def consolidateConfs(sparkConf: SparkConf, sqlConf: Map[String, String], tableRef: TableRef, tableConf: Map[String, String]) : SparkConf = {
+    //Default settings
+    val conf = sparkConf.clone()
+    //Keyspace/Cluster level settings
+    for (prop <- DefaultSource.confProperties) {
+      val cluster = tableRef.cluster.getOrElse(defaultClusterName)
+      val clusterLevelValue = sqlConf.get(s"$cluster/$prop")
+      if (clusterLevelValue.nonEmpty)
+        conf.set(prop, clusterLevelValue.get)
+      val keyspaceLevelValue = sqlConf.get(s"$cluster:${tableRef.keyspace}/$prop")
+      if (keyspaceLevelValue.nonEmpty)
+        conf.set(prop, keyspaceLevelValue.get)
+      val tableLevelValue = tableConf.get(prop)
+      if (tableLevelValue.nonEmpty)
+        conf.set(prop, tableLevelValue.get)
+    }
+    conf
   }
 }

--- a/spark-cassandra-connector/src/test/scala/org/apache/spark/sql/cassandra/ConsolidateSettingsSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/org/apache/spark/sql/cassandra/ConsolidateSettingsSpec.scala
@@ -6,21 +6,30 @@ import org.apache.spark.sql.cassandra.CassandraSourceRelation._
 
 class ConsolidateSettingsSpec extends FlatSpec with Matchers {
 
-  it should "consolidate Cassandra conf settings in order of table level -> keyspace -> cluster -> default" in {
+  it should "consolidate Cassandra conf settings in order of " +
+    "table level -> keyspace -> cluster -> default" in {
     val tableRef = TableRef("table", "keyspace", Option("cluster"))
     val sparkConf = new SparkConf
     val rowSize = "spark.cassandra.input.page.row.size"
 
     sparkConf.set(rowSize, "10")
-    consolidateConfs(sparkConf, Map.empty, tableRef, Map.empty).get(rowSize) shouldBe "10"
+    val consolidatedConf =
+      consolidateConfs(sparkConf, Map.empty, tableRef, Map.empty)
+    consolidatedConf.get(rowSize) shouldBe "10"
 
     val sqlConf = Map[String, String](s"cluster/$rowSize" -> "100")
-    consolidateConfs(sparkConf, sqlConf, tableRef, Map.empty).get(rowSize) shouldBe "100"
+    val confWithClusterLevelSettings =
+      consolidateConfs(sparkConf, sqlConf, tableRef, Map.empty)
+    confWithClusterLevelSettings.get(rowSize) shouldBe "100"
 
     val sqlConf1 = sqlConf + (s"cluster:keyspace/$rowSize" -> "200")
-    consolidateConfs(sparkConf, sqlConf1, tableRef, Map.empty).get(rowSize) shouldBe "200"
+    val confWithKeyspaceLevelSettings =
+      consolidateConfs(sparkConf, sqlConf1, tableRef, Map.empty)
+    confWithKeyspaceLevelSettings.get(rowSize) shouldBe "200"
 
     val tableConf = Map(rowSize -> "1000")
-    consolidateConfs(sparkConf, sqlConf1, tableRef, tableConf).get(rowSize) shouldBe "1000"
+    val confWithTableLevelSettings =
+      consolidateConfs(sparkConf, sqlConf1, tableRef, tableConf)
+    confWithTableLevelSettings.get(rowSize) shouldBe "1000"
   }
 }

--- a/spark-cassandra-connector/src/test/scala/org/apache/spark/sql/cassandra/ConsolidateSettingsSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/org/apache/spark/sql/cassandra/ConsolidateSettingsSpec.scala
@@ -1,0 +1,26 @@
+package org.apache.spark.sql.cassandra
+
+import org.scalatest.{Matchers, FlatSpec}
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.cassandra.CassandraSourceRelation._
+
+class ConsolidateSettingsSpec extends FlatSpec with Matchers {
+
+  it should "consolidate Cassandra conf settings in order of table level -> keyspace -> cluster -> default" in {
+    val tableRef = TableRef("table", "keyspace", Option("cluster"))
+    val sparkConf = new SparkConf
+    val rowSize = "spark.cassandra.input.page.row.size"
+
+    sparkConf.set(rowSize, "10")
+    consolidateConfs(sparkConf, Map.empty, tableRef, Map.empty).get(rowSize) shouldBe "10"
+
+    val sqlConf = Map[String, String](s"cluster/$rowSize" -> "100")
+    consolidateConfs(sparkConf, sqlConf, tableRef, Map.empty).get(rowSize) shouldBe "100"
+
+    val sqlConf1 = sqlConf + (s"cluster:keyspace/$rowSize" -> "200")
+    consolidateConfs(sparkConf, sqlConf1, tableRef, Map.empty).get(rowSize) shouldBe "200"
+
+    val tableConf = Map(rowSize -> "1000")
+    consolidateConfs(sparkConf, sqlConf1, tableRef, tableConf).get(rowSize) shouldBe "1000"
+  }
+}


### PR DESCRIPTION
Store keyspace level settings as cluster.keyspace/xx.xx.xx.xx
and cluseter level settings as cluster/xx.xx.xx.xx in
SQLConf

Retrieve settings in the order of
table level -> keyspace -> cluster -> default. Use the one
first available.