### PR TITLE
SPARKC-129 Add custom UUIDType and InetAddressType

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -28,6 +28,9 @@
    - improved code testability and added unit-tests
  * Basic Datasource API integration and keyspace/cluster level settings (SPARKC-112, SPARKC-162)
  * Added support to use aliases with Tuples (SPARKC-125)
+ * Add Custom UUIDType and InetAddressType to Spark Sql data type mapping (SPARKC-129)
+
+
 ********************************************************************************
 
 ********************************************************************************

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLSpec.scala
@@ -331,9 +331,15 @@ class CassandraSQLSpec extends SparkCassandraITFlatSpecBase {
     }
     val cc = new CassandraSQLContext(sc)
     cc.setKeyspace("sql_test")
-    val result = cc.cassandraSql("select k, v, a, b from custom_type where CAST(a as string) > '/74.125.239.135'").collect()
+    val result = cc.cassandraSql(
+      "select k, v, a, b " +
+      "from custom_type " +
+      "where CAST(a as string) > '/74.125.239.135'").collect()
     result should have length 1
-    val result1 = cc.cassandraSql("select k, v,  a, b from custom_type where CAST(b as string) < '123e4567-e89b-12d3-a456-426655440000'").collect()
+    val result1 = cc.cassandraSql(
+      "select k, v,  a, b " +
+      "from custom_type " +
+      "where CAST(b as string) < '123e4567-e89b-12d3-a456-426655440000'").collect()
     result1 should have length 1
   }
 }

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraRelation.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraRelation.scala
@@ -1,13 +1,9 @@
 package org.apache.spark.sql.cassandra
 
-import com.datastax.spark.connector
 import com.datastax.spark.connector.cql.{ColumnDef, TableDef}
-import com.datastax.spark.connector.types.UDTFieldDef
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.catalyst.plans.logical.{Statistics, LeafNode}
-import org.apache.spark.sql.types.StructField
-import org.apache.spark.sql.{catalyst, types}
 
 private[cassandra] case class CassandraRelation
     (tableDef: TableDef, alias: Option[String], cluster: Option[String] = None)
@@ -25,7 +21,7 @@ private[cassandra] case class CassandraRelation
 
   def columnToAttribute(column: ColumnDef): AttributeReference = {
     // Since data can be dumped in randomly with no validation, everything is nullable.
-    val catalystType = ColumnDataType.catalystDataType(column.columnType, nullable = true)
+    val catalystType = DataTypeConverter.catalystDataType(column.columnType, nullable = true)
     val qualifiers = tableDef.tableName +: alias.toSeq
     new AttributeReference(column.columnName, catalystType, nullable = true)(qualifiers = qualifiers)
   }
@@ -41,42 +37,3 @@ private[cassandra] case class CassandraRelation
   def tableName = tableDef.tableName
 }
 
-object ColumnDataType {
-
-  private val primitiveTypeMap = Map[connector.types.ColumnType[_], types.DataType](
-    connector.types.TextType       -> types.StringType,
-    connector.types.AsciiType      -> types.StringType,
-    connector.types.VarCharType    -> types.StringType,
-
-    connector.types.BooleanType    -> types.BooleanType,
-
-    connector.types.IntType        -> types.IntegerType,
-    connector.types.BigIntType     -> types.LongType,
-    connector.types.CounterType    -> types.LongType,
-    connector.types.FloatType      -> types.FloatType,
-    connector.types.DoubleType     -> types.DoubleType,
-  
-    connector.types.VarIntType     -> types.DecimalType(), // no native arbitrary-size integer type
-    connector.types.DecimalType    -> types.DecimalType(),
-
-    connector.types.TimestampType  -> types.TimestampType,
-    connector.types.InetType       -> types.StringType,
-    connector.types.UUIDType       -> types.StringType,
-    connector.types.TimeUUIDType   -> types.StringType,
-    connector.types.BlobType       -> types.ByteType
-  )
-
-  def catalystDataType(cassandraType: connector.types.ColumnType[_], nullable: Boolean): types.DataType = {
-
-    def catalystStructField(field: UDTFieldDef): StructField =
-      StructField(field.columnName, catalystDataType(field.columnType, nullable = true), nullable = true)
-
-    cassandraType match {
-      case connector.types.SetType(et)                => types.ArrayType(primitiveTypeMap(et), nullable)
-      case connector.types.ListType(et)               => types.ArrayType(primitiveTypeMap(et), nullable)
-      case connector.types.MapType(kt, vt)            => types.MapType(primitiveTypeMap(kt), primitiveTypeMap(vt), nullable)
-      case connector.types.UserDefinedType(_, fields) => types.StructType(fields.map(catalystStructField))
-      case _                                          => primitiveTypeMap(cassandraType)
-    }
-  }
-}

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/DataTypeConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/DataTypeConverter.scala
@@ -2,6 +2,7 @@ package org.apache.spark.sql.cassandra
 
 import com.datastax.spark.connector.types.UDTFieldDef
 import org.apache.spark.Logging
+import org.apache.spark.sql.cassandra.types.{UUIDType, InetAddressType}
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.{types => catalystTypes}
 
@@ -28,9 +29,9 @@ object DataTypeConverter extends Logging {
     connector.types.DecimalType    -> catalystTypes.DecimalType(),
 
     connector.types.TimestampType  -> catalystTypes.TimestampType,
-    connector.types.InetType       -> catalystTypes.StringType,
-    connector.types.UUIDType       -> catalystTypes.StringType,
-    connector.types.TimeUUIDType   -> catalystTypes.StringType,
+    connector.types.InetType       -> InetAddressType,
+    connector.types.UUIDType       -> UUIDType,
+    connector.types.TimeUUIDType   -> UUIDType,
     connector.types.BlobType       -> catalystTypes.BinaryType
   )
 

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/types/InetAddressType.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/types/InetAddressType.scala
@@ -39,12 +39,12 @@ class InetAddressType private() extends NativeType with PrimitiveType with Loggi
   //
   // Convert to host address to compare InetAddress because it doesn't support comparison.
   // It's not a good solution though.
-  private[sql] val ordering = new Ordering[JvmType] {
-    def compare(x: InetAddress, y: InetAddress) = {
-      logWarning("InetAddress doesn't support comparison. Convert it to host address to compare.")
-      x.getHostAddress.compareTo(y.getHostAddress)
-    }
-  }
+  import Ordering.Implicits._
+  def unsignedByte(x: Byte) = (x + 256) % 256
+  def address(inet: InetAddress): Iterable[Int] =
+    inet.getAddress.map(unsignedByte)
+  val ord = Ordering by address
+  private[sql] val ordering = ord
   /**
    * The default size of a value of the InetAddressType is 16 bytes.
    */

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/types/InetAddressType.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/types/InetAddressType.scala
@@ -1,0 +1,45 @@
+package org.apache.spark.sql.cassandra.types
+
+
+import scala.reflect.runtime.universe.typeTag
+
+import java.net.InetAddress
+
+import org.apache.spark.Logging
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.sql.catalyst.ScalaReflectionLock
+import org.apache.spark.sql.types.{PrimitiveType, NativeType}
+
+
+/**
+ * :: DeveloperApi ::
+ *
+ * The data type representing `InetAddress` values.
+ *
+ * @group dataType
+ */
+@DeveloperApi
+class InetAddressType private() extends NativeType with PrimitiveType with Logging {
+  // The companion object and this class is separated so the companion object also subclasses
+  // this type. Otherwise, the companion object would be of type "InetAddressType$" in byte code.
+  // Defined with a private constructor so the companion object is the only possible instantiation.
+  private[sql] type JvmType = InetAddress
+  @transient private[sql] lazy val tag = ScalaReflectionLock.synchronized { typeTag[JvmType] }
+
+  // Convert to host address to compare InetAddress because it doesn't support comparison.
+  // It's not a good solution though.
+  private[sql] val ordering = new Ordering[JvmType] {
+    def compare(x: InetAddress, y: InetAddress) = {
+      logWarning("InetAddress doesn't support comparison. Convert it to host address to compare.")
+      x.getHostAddress.compareTo(y.getHostAddress)
+    }
+  }
+  /**
+   * The default size of a value of the InetAddressType is 16 bytes.
+   */
+  override def defaultSize: Int = 16
+
+  private[spark] override def asNullable: InetAddressType = this
+}
+
+case object InetAddressType extends InetAddressType

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/types/InetAddressType.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/types/InetAddressType.scala
@@ -40,11 +40,11 @@ class InetAddressType private() extends NativeType with PrimitiveType with Loggi
   // Convert to host address to compare InetAddress because it doesn't support comparison.
   // It's not a good solution though.
   import Ordering.Implicits._
-  def unsignedByte(x: Byte) = (x + 256) % 256
-  def address(inet: InetAddress): Iterable[Int] =
+  private[sql] def unsignedByte(x: Byte) = (x + 256) % 256
+  private[sql] def address(inet: InetAddress): Iterable[Int] =
     inet.getAddress.map(unsignedByte)
-  val ord = Ordering by address
-  private[sql] val ordering = ord
+
+  private[sql] val ordering = Ordering by address
   /**
    * The default size of a value of the InetAddressType is 16 bytes.
    */

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/types/UUIDType.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/types/UUIDType.scala
@@ -1,0 +1,36 @@
+package org.apache.spark.sql.cassandra.types
+
+import scala.reflect.runtime.universe.typeTag
+
+import java.util.UUID
+
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.sql.catalyst.ScalaReflectionLock
+import org.apache.spark.sql.types.{PrimitiveType, NativeType}
+
+/**
+ * :: DeveloperApi ::
+ *
+ * The data type representing `UUID` values.
+ *
+ * @group dataType
+ */
+@DeveloperApi
+class UUIDType private() extends NativeType with PrimitiveType {
+  // The companion object and this class is separated so the companion object also subclasses
+  // this type. Otherwise, the companion object would be of type "UUIDType$" in byte code.
+  // Defined with a private constructor so the companion object is the only possible instantiation.
+  private[sql] type JvmType = UUID
+  @transient private[sql] lazy val tag = ScalaReflectionLock.synchronized { typeTag[JvmType] }
+  private[sql] val ordering = new Ordering[JvmType] {
+    def compare(x: UUID, y: UUID) = x.compareTo(y)
+  }
+  /**
+   * The default size of a value of the UUIDType is 16 bytes.
+   */
+  override def defaultSize: Int = 16
+
+  private[spark] override def asNullable: UUIDType = this
+}
+
+case object UUIDType extends UUIDType


### PR DESCRIPTION
Add custom UUIDType and InetAddressType

UUIDType uses JVM data type UUID as base
InetAddressType uses JVM data type InetAddress as base