### PR TITLE
Easier spark shell "how-to" guide

### DIFF
--- a/doc/13_1_setup_spark_shell.md
+++ b/doc/13_1_setup_spark_shell.md
@@ -1,0 +1,32 @@
+# Documentation
+
+## Setting up Cassandra
+
+The easiest way to get quickly started with Cassandra is to follow the instructions provided by 
+[Datastax](http://docs.datastax.com/en/cassandra/2.1/cassandra/install/install_cassandraTOC.html)
+
+## Setting up spark
+
+### Download Spark
+
+Download a pre-built Spark from  https://spark.apache.org/downloads.html
+Untar the tar.gz downloaded with 
+
+    tar -xvf spark-*-.tgz
+
+### Start Spark in Stand Alone Mode (Optional)
+
+[Official Spark Instructions](https://spark.apache.org/docs/latest/spark-standalone.html)
+
+If you would like to run against a separate executor JVM then you need a running Spark Master and Worker.
+By default the spark-shell will run in local mode (driver/master/executor share a jvm.)
+
+Go to the newly created directory and start up Spark in stand-alone mode bound to localhost
+
+    cd spark*
+    ./sbin/start-all.sh
+
+At this point you should be able to access the Spark UI at localhost:8080. In the display you
+should see a single worker. At the top of this website you should see a URL set for the spark master. Save
+the master address (the entire spark://something:7077) if you would like to connect the shell to 
+this stand alone spark master (use as sparkMasterAddress below).

--- a/doc/13_spark_shell.md
+++ b/doc/13_spark_shell.md
@@ -1,62 +1,45 @@
 # Documentation
 
-## The Spark Shell and Spark Cassandra Connector
+## Using the Spark Cassandra Connector with the Spark Shell 
 
-These instructions were last confirmed with C* 2.0.11, Spark 1.2.1 and Connector 1.2.0-rc3
+These instructions were last confirmed with C* 2.0.11, Spark 1.2.1 and Connector 1.2.0.
 
-### Setting up Cassandra
+For this guide, we assume an existing Cassandra deployment, running either locally or on a cluster, a local installation of Spark and an optional Spark cluster. For detail setup instructions see [setup spark-shell](13_1_setup_spark_shell.md)   
 
-The easiest way to get quickly started with Cassandra is to follow the instructions provided by 
-[Datastax](http://docs.datastax.com/en/cassandra/2.1/cassandra/install/install_cassandraTOC.html)
+To use the Spark Cassandra Connector from within the Spark Shell, we need to load the Connector and all its dependencies in the shell context. The easiest way to achieve that is to build an assembly (also known as _"fat jar"_) that packages all dependencies.
 
-### Setting up spark
+### Building the Spark Cassandra Connector assembly 
 
-#### Download Spark
+```bash
+git clone git@github.com:datastax/spark-cassandra-connector.git 
+cd spark-cassandra-connector
+git checkout b1.2 ## Replace this with the version of the connector you would like to use
+./sbt/sbt assembly
+```
 
-Download a pre-built Spark from  https://spark.apache.org/downloads.html
-Untar the tar.gz downloaded with 
+Sanity check: 
+```bash
+ls spark-cassandra-connector/target/scala-2.10/*  
+## Should have a spark-cassandra-connector-assembly-*.jar here, copy full path to use as yourAssemblyJar below)
+```
 
-    tar -xvf spark-*-.tgz
-
-#### Start Spark in Stand Alone Mode (Optional)
-
-[Offical Spark Instructions](https://spark.apache.org/docs/latest/spark-standalone.html)
-
-If you would like to run against a separate executor JVM then you need a running Spark Master and Worker.
-By default the spark-shell will run in local mode (driver/master/executor share a jvm.)
-
-Go to the newly created directory and start up Spark in stand-alone mode bound to localhost
-
-    cd spark*
-    ./sbin/start-all.sh
-    
-At this point you should be able to access the Spark UI at localhost:8080. In the display you
-should see a single worker. At the top of this website you should see a URL set for the spark master. Save
-the master address (the entire spark://something:7077) if you would like to connect the shell to 
-this stand alone spark master (use as sparkMasterAddress below).
-
-### Clone and assemble the Spark Cassandra Connector
-
-    git clone git@github.com:datastax/spark-cassandra-connector.git 
-    cd spark-cassandra-connector
-    git checkout b1.2 ## Replace this with the version of the connector you would like to use
-    ./sbt/sbt  assembly
-    ls spark-cassandra-connector/target/scala-2.10/*  
-    ## Should have a spark-cassandra-connector-assembly-*.jar here, copy full path to use as yourAssemblyJar below)
-    
-### Start the Spark Shell 
+### Starting the Spark Shell 
 If you don't include the master address below the spark shell will run in Local mode. 
+  
+```bash
+cd spark/install/dir
+#Include the --master if you want to run against a spark cluster and not local mode
+./bin/spark-shell [--master sparkMasterAddress] --jars yourAssemblyJar --conf spark.cassandra.connection.host=yourCassandraClusterIp
+```
 
-cd ~/spark-*    
-
-    #Include the --master if you want to run against a stand alone spark and not local mode
-    ./bin/spark-shell [--master sparkMasterAddress] --jars yourAssemblyJar --conf spark.cassandra.connection.host=yourCassandraClusterIp
-
-By default spark will log everything to the console and this may be a bit of an overload. To change this copy and modify the  log4j.properties template file
-
-   cp conf/log4j.properties.template conf/log4j.properties
+By default spark will log everything to the console and this may be a bit of an overload. To change this copy and modify the `log4j.properties` template file
+```bash
+cp conf/log4j.properties.template conf/log4j.properties
+```
 
 Changing the root logger at the top from INFO to WARN will significantly reduce the verbosity.
+
+## Example
 
 ### Import connector classes
 ```scala    
@@ -74,5 +57,3 @@ sc.cassandraTable("test","fun").take(3)
 // Your results may differ 
 //res1: Array[com.datastax.spark.connector.CassandraRow] = Array(CassandraRow{k: 60, v: 60}, CassandraRow{k: 67, v: 67}, CassandraRow{k: 10, v: 10})
 ```
-   
-

--- a/doc/13_spark_shell.md
+++ b/doc/13_spark_shell.md
@@ -2,7 +2,7 @@
 
 ## Using the Spark Cassandra Connector with the Spark Shell 
 
-These instructions were last confirmed with C* 2.0.11, Spark 1.2.1 and Connector 1.2.0.
+These instructions were last confirmed with C* 2.0.11, Spark 1.2.1 and Connector 1.2.1.
 
 For this guide, we assume an existing Cassandra deployment, running either locally or on a cluster, a local installation of Spark and an optional Spark cluster. For detail setup instructions see [setup spark-shell](13_1_setup_spark_shell.md)   
 
@@ -13,13 +13,13 @@ To use the Spark Cassandra Connector from within the Spark Shell, we need to loa
 ```bash
 git clone git@github.com:datastax/spark-cassandra-connector.git 
 cd spark-cassandra-connector
-git checkout b1.2 ## Replace this with the version of the connector you would like to use
+git checkout tags/v1.2.1 ## Replace this with the version of the connector you would like to use
 ./sbt/sbt assembly
 ```
 
 Sanity check: 
 ```bash
-ls spark-cassandra-connector/target/scala-2.10/*  
+ls spark-cassandra-connector/target/scala-2.10/
 ## Should have a spark-cassandra-connector-assembly-*.jar here, copy full path to use as yourAssemblyJar below)
 ```
 
@@ -52,8 +52,44 @@ import com.datastax.spark.connector.cql._ //(Optional) Imports java driver helpe
 val c = CassandraConnector(sc.getConf)
 c.withSessionDo ( session => session.execute("CREATE KEYSPACE test WITH replication={'class':'SimpleStrategy', 'replication_factor':1}"))
 c.withSessionDo ( session => session.execute("CREATE TABLE test.fun (k int PRIMARY KEY, v int)"))
-sc.parallelize(1 to 100).map( x => (x,x)).saveToCassandra("test","fun")
-sc.cassandraTable("test","fun").take(3)
+
+
 // Your results may differ 
 //res1: Array[com.datastax.spark.connector.CassandraRow] = Array(CassandraRow{k: 60, v: 60}, CassandraRow{k: 67, v: 67}, CassandraRow{k: 10, v: 10})
 ```
+
+## Creating a playground with Docker
+
+We can use Docker to quickly create a working setup without the need to install and configure Cassandra.
+
+For this guide we will use the Cassandra docker image maintained by [Al Tobert on GitHub](https://github.com/tobert/cassandra-docker/blob/master/README.md)
+
+First, let's pull the docker image:
+```bash
+docker pull tobert/cassandra
+```
+
+To instantiate a Cassandra container, we need to specify a host volume where the data will be stored. We store the resulting container id in the variable `CASSANDRA_CONTAINER_ID`. We will need that id afterwards to lookup the IP address of the running instance.
+```bash
+mkdir /srv/cassandra
+CASSANDRA_CONTAINER_ID=`docker run -d -v /srv/cassandra:/data tobert/cassandra`
+```
+
+Alternatively, if the data is disposable (e.g. tests), we can omit the volume, resulting in the following step:
+```bash
+CASSANDRA_CONTAINER_ID=$(docker run -d tobert/cassandra)
+```
+
+Now, we obtain the IP Address that docker assigned to the container:
+```bash
+CASSANDRA_CONTAINER_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' $CASSANDRA_CONTAINER_ID)
+```
+
+And we can start the spark shell using that running container:
+
+```bash
+cd spark/install/dir
+#Include the --master if you want to run against a spark cluster and not local mode
+./bin/spark-shell [--master sparkMasterAddress] --jars yourAssemblyJar --conf spark.cassandra.connection.host=$IP
+```
+


### PR DESCRIPTION
Attempts to make the how-to guide on using the Spark-Cassandra Connector with the Spark Shell more accessible by:
 - moving detail information out of the main path, 
 - adding a small paragraph on why this is needed
 - some style refactoring

@RussellSpitzer what do you think?  (btw, I didn't know if I needed to track this into JIRA, and there's an umbrella story for that as well. https://datastax-oss.atlassian.net/browse/SPARKC-41  Let me know if I need to take action there in case this proposal is deemed of some use)