### PR TITLE
SPARKC-169: Backport of SPARKC-8: Reading TTL and write time of regular columns

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 (1.1.x unreleased)
+ * Backport SPARKC-8, retrieval of TTL and write time
  * Synchronized ReflectionUtil findScalaObject and findSingletonClassInstance methods
    to avoid problems with Scala 2.10 lack thread safety in the reflection subsystem (SPARKC-107)
  * Fixed populating ReadConf with properties from SparkConf (SPARKC-121)

--- a/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaRDDSpec.scala
+++ b/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaRDDSpec.scala
@@ -105,7 +105,7 @@ with ShouldMatchers with SharedEmbeddedCassandra with SparkTemplate {
     val rdd = javaFunctions(sc).cassandraTable("java_api_test", "test_table")
       .select("key")
     assert(rdd.selectedColumnNames().size === 1)
-    assert(rdd.selectedColumnNames().contains("key"))
+    assert(rdd.selectedColumnNames().contains(new ColumnName("key")))
   }
 
   it should "allow to use where clause to filter records" in {

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/CassandraJavaUtil.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/CassandraJavaUtil.java
@@ -3,7 +3,8 @@ package com.datastax.spark.connector.japi;
 import akka.japi.JAPI;
 import com.datastax.spark.connector.*;
 import com.datastax.spark.connector.cql.CassandraConnector;
-import com.datastax.spark.connector.mapper.ColumnMapper;
+import com.datastax.spark.connector.mapper.*;
+import com.datastax.spark.connector.rdd.*;
 import com.datastax.spark.connector.rdd.reader.ClassBasedRowReaderFactory;
 import com.datastax.spark.connector.rdd.reader.RowReaderFactory;
 import com.datastax.spark.connector.rdd.reader.ValueRowReaderFactory;
@@ -438,9 +439,34 @@ public class CassandraJavaUtil {
      * Creates a column selector with a given columns projection.
      */
     public static ColumnSelector someColumns(String... columnNames) {
-        return SomeColumns$.MODULE$.apply(JAPI.seq(columnNames));
+        NamedColumnRef[] columnsSelection = new NamedColumnRef[columnNames.length];
+        for (int i = 0; i < columnNames.length; i++) {
+            columnsSelection[i] = ColumnName$.MODULE$.apply(columnNames[i]);
+        }
+
+        return SomeColumns$.MODULE$.apply(JAPI.seq(columnsSelection));
     }
 
+    public static NamedColumnRef[] convert(String... columnNames) {
+        NamedColumnRef[] columnsSelection = new NamedColumnRef[columnNames.length];
+        for (int i = 0; i < columnNames.length; i++) {
+            columnsSelection[i] = ColumnName$.MODULE$.apply(columnNames[i]);
+        }
+
+        return columnsSelection;
+    }
+
+    public static ColumnName plain(String columnName) {
+        return new ColumnName(columnName);
+    }
+
+    public static TTL ttl(String columnName) {
+        return new TTL(columnName);
+    }
+
+    public static WriteTime writeTime(String columnName) {
+        return new WriteTime(columnName);
+    }
 
     // -------------------------------------------------------------------------
     //              Utility methods 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterColumnNamesSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterColumnNamesSpec.scala
@@ -4,6 +4,7 @@ import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.{SomeColumns, AllColumns}
 import com.datastax.spark.connector.testkit._
 import com.datastax.spark.connector.embedded._
+import com.datastax.spark.connector._
 
 class TableWriterColumnNamesSpec extends AbstractSpec with SharedEmbeddedCassandra with SparkTemplate {
 
@@ -35,7 +36,7 @@ class TableWriterColumnNamesSpec extends AbstractSpec with SharedEmbeddedCassand
     }
 
     "distinguish and use only specified column names if provided" in {
-      val subset = Seq("key", "group")
+      val subset = Seq("key": NamedColumnRef, "group": NamedColumnRef)
 
       val writer = TableWriter(
         conn,

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ColumnRef.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ColumnRef.scala
@@ -1,0 +1,49 @@
+package com.datastax.spark.connector
+
+import scala.language.implicitConversions
+
+/** Unambiguous reference to a column in the query result set row. */
+sealed trait ColumnRef
+
+sealed trait NamedColumnRef extends ColumnRef {
+  /** Returns the column name which this selection bases on. In case of a function, such as `ttl` or
+    * `writetime`, it returns the column name passed to that function. */
+  def columnName: String
+
+  /** Returns a CQL phrase which has to be passed to the `SELECT` clause with appropriate quotation
+    * marks. */
+  def cql: String
+
+  /** Returns a name of the selection as it is seen in the result set. Most likely this is going to be
+    * used when providing custom column name to field name mapping. */
+  def selectedAs: String
+}
+
+object NamedColumnRef {
+  def unapply(columnRef: NamedColumnRef) = Some((columnRef.columnName, columnRef.selectedAs))
+}
+
+/** References a column by name. */
+case class ColumnName(columnName: String) extends NamedColumnRef {
+  val cql = s""""$columnName""""
+  val selectedAs = columnName
+
+  override def toString: String = selectedAs
+}
+
+case class TTL(columnName: String) extends NamedColumnRef {
+  val cql = s"""TTL("$columnName")"""
+  val selectedAs = s"ttl($columnName)"
+
+  override def toString: String = selectedAs
+}
+
+case class WriteTime(columnName: String) extends NamedColumnRef {
+  val cql = s"""WRITETIME("$columnName")"""
+  val selectedAs = s"writetime($columnName)"
+
+  override def toString: String = selectedAs
+}
+
+/** References a column by its index in the row. Useful for tuples. */
+case class ColumnIndex(columnIndex: Int) extends ColumnRef

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ColumnSelector.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ColumnSelector.scala
@@ -1,13 +1,15 @@
 package com.datastax.spark.connector
 
+import scala.language.implicitConversions
+
 sealed trait ColumnSelector
 case object AllColumns extends ColumnSelector
-case class SomeColumns(columns: String*) extends ColumnSelector
+case class SomeColumns(columns: NamedColumnRef*) extends ColumnSelector
 
 object SomeColumns {
   @deprecated("Use com.datastax.spark.connector.rdd.SomeColumns instead of Seq", "1.0")
   implicit def seqToSomeColumns(columns: Seq[String]): SomeColumns =
-    SomeColumns(columns: _*)
+    SomeColumns(columns.map(x => x: NamedColumnRef): _*)
 }
 
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/ColumnMap.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/ColumnMap.scala
@@ -1,25 +1,20 @@
 package com.datastax.spark.connector.mapper
 
-/** Unambiguous reference to a column in the query result set row. */
-sealed trait ColumnRef
-
-/** References a column by name. */
-case class NamedColumnRef(name: String) extends ColumnRef
-
-/** References a column by its index in the row. Useful for tuples. */
-case class IndexedColumnRef(index: Int) extends ColumnRef
+import com.datastax.spark.connector.ColumnRef
 
 /** Associates constructor parameters and property accessors with table columns */
 trait ColumnMap extends Serializable {
   def constructor: Seq[ColumnRef]
+
   def getters: Map[String, ColumnRef]
+
   def setters: Map[String, ColumnRef]
+
   def allowsNull: Boolean
 }
 
-case class SimpleColumnMap(
-  constructor: Seq[ColumnRef],
-  getters: Map[String, ColumnRef],
-  setters: Map[String, ColumnRef],
-  allowsNull: Boolean = false) extends ColumnMap
+case class SimpleColumnMap(constructor: Seq[ColumnRef],
+                           getters: Map[String, ColumnRef],
+                           setters: Map[String, ColumnRef],
+                           allowsNull: Boolean = false) extends ColumnMap
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/ReflectionColumnMapper.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/ReflectionColumnMapper.scala
@@ -2,6 +2,7 @@ package com.datastax.spark.connector.mapper
 
 import java.lang.reflect.{Constructor, Method}
 
+import com.datastax.spark.connector.{ColumnRef, ColumnName}
 import com.datastax.spark.connector.cql.TableDef
 import com.datastax.spark.connector.rdd.reader.AnyObjectFactory
 import org.apache.commons.lang.StringUtils
@@ -41,7 +42,7 @@ abstract class ReflectionColumnMapper[T : ClassTag] extends ColumnMapper[T] {
         val columnNames = paramNames
           .map(constructorParamToColumnName(_, tableDef))
           .filter(_ != "$_outer")
-        columnNames.map(NamedColumnRef)
+        columnNames.map(ColumnName)
       }
     }
 
@@ -51,7 +52,7 @@ abstract class ReflectionColumnMapper[T : ClassTag] extends ColumnMapper[T] {
       for (method <- cls.getMethods if isGetter(method)) yield {
         val methodName = method.getName
         val columnName = getterToColumnName(methodName, tableDef)
-        (methodName, NamedColumnRef(columnName))
+        (methodName, ColumnName(columnName))
       }
     }.toMap
 
@@ -59,7 +60,7 @@ abstract class ReflectionColumnMapper[T : ClassTag] extends ColumnMapper[T] {
       for (method <- cls.getMethods if isSetter(method)) yield {
         val methodName = method.getName
         val columnName = setterToColumnName(methodName, tableDef)
-        (methodName, NamedColumnRef(columnName))
+        (methodName, ColumnName(columnName))
       }
     }.toMap
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/TupleColumnMapper.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/TupleColumnMapper.scala
@@ -1,5 +1,6 @@
 package com.datastax.spark.connector.mapper
 
+import com.datastax.spark.connector.{ColumnRef, ColumnIndex}
 import com.datastax.spark.connector.cql.TableDef
 
 import scala.reflect.ClassTag
@@ -9,7 +10,7 @@ class TupleColumnMapper[T <: Product : ClassTag] extends ColumnMapper[T] {
   override def classTag: ClassTag[T] = implicitly[ClassTag[T]]
 
   private def indexedColumnRefs(n: Int) =
-    (0 until n).map(IndexedColumnRef)
+    (0 until n).map(ColumnIndex)
 
   override def columnMap(tableDef: TableDef): ColumnMap = {
 
@@ -21,7 +22,7 @@ class TupleColumnMapper[T <: Product : ClassTag] extends ColumnMapper[T] {
 
     val getters = {
       for (name@GetterRegex(id) <- cls.getMethods.map(_.getName))
-      yield (name, IndexedColumnRef(id.toInt - 1))
+      yield (name, ColumnIndex(id.toInt - 1))
     }.toMap
 
     val setters =

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/package.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/package.scala
@@ -3,6 +3,7 @@ package com.datastax.spark
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
+import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
 /**
@@ -55,4 +56,10 @@ package object connector {
   implicit def toRDDFunctions[T : ClassTag](rdd: RDD[T]): RDDFunctions[T] =
     new RDDFunctions[T](rdd)
 
+  implicit class ColumnNameFunctions(val columnName: String) extends AnyVal {
+    def writeTime: WriteTime = WriteTime(columnName)
+    def ttl: TTL = TTL(columnName)
+  }
+
+  implicit def toNamedColumnRef(columnName: String): NamedColumnRef = ColumnName(columnName)
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
@@ -17,6 +17,7 @@ import com.datastax.spark.connector.util.{Logging, CountingIterator}
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{Partition, SparkContext, TaskContext}
+import com.datastax.spark.connector._
 
 
 /** RDD representing a Cassandra table.
@@ -104,9 +105,15 @@ class CassandraRDD[R] private[connector] (
   }
 
   /** Throws IllegalArgumentException if columns sequence contains unavailable columns */
-  private def checkColumnsAvailable(columns: Seq[String], availableColumns: Seq[String]) {
-    val availableColumnsSet = availableColumns.toSet
-    val notFound = columns.find(c => !availableColumnsSet.contains(c))
+  private def checkColumnsAvailable(columns: Seq[NamedColumnRef], availableColumns: Seq[NamedColumnRef]) {
+    val availableColumnsSet = availableColumns.collect {
+      case ColumnName(columnName) => columnName
+    }.toSet
+
+    val notFound = columns.collectFirst {
+      case ColumnName(columnName) if !availableColumnsSet.contains(columnName) => columnName
+    }
+
     if (notFound.isDefined)
       throw new IllegalArgumentException(
         s"Column not found in selection: ${notFound.get}. " +
@@ -114,24 +121,30 @@ class CassandraRDD[R] private[connector] (
   }
 
   /** Filters currently selected set of columns with a new set of columns */
-  private def narrowColumnSelection(columns: Seq[String]): Seq[String] = {
+  private def narrowColumnSelection(columns: Seq[NamedColumnRef]): Seq[NamedColumnRef] = {
     columnNames match {
       case SomeColumns(cs @ _*) =>
         checkColumnsAvailable(columns, cs)
-        cs.filter(columns.toSet.contains)
       case AllColumns =>
         // we do not check for column existence yet as it would require fetching schema and a call to C*
         // columns existence will be checked by C* once the RDD gets computed.
-        columns
     }
+    columns
   }
 
   /** Narrows down the selected set of columns.
     * Use this for better performance, when you don't need all the columns in the result RDD.
     * When called multiple times, it selects the subset of the already selected columns, so
     * after a column was removed by the previous `select` call, it is not possible to
-    * add it back.  */
-  def select(columns: String*): CassandraRDD[R] = {
+    * add it back.
+    *
+    * The selected columns are [[NamedColumnRef]] instances. This type allows to specify columns for
+    * straightforward retrieval and to read TTL or write time of regular columns as well. Implicit
+    * conversions included in [[com.datastax.spark.connector]] package make it possible to provide
+    * just column names (which is also backward compatible) and optional add `.ttl` or `.writeTime`
+    * suffix in order to create an appropriate [[NamedColumnRef]] instance.
+    */
+  def select(columns: NamedColumnRef*): CassandraRDD[R] = {
     copy(columnNames = SomeColumns(narrowColumnSelection(columns): _*))
   }
 
@@ -237,26 +250,45 @@ class CassandraRDD[R] private[connector] (
 
   private lazy val rowTransformer = implicitly[RowReaderFactory[R]].rowReader(tableDef)
 
-  private def checkColumnsExistence(columnNames: Seq[String]): Seq[String] = {
+  private def checkColumnsExistence(columns: Seq[NamedColumnRef]): Seq[NamedColumnRef] = {
     val allColumnNames = tableDef.allColumns.map(_.columnName).toSet
-    def columnNotFound(c: String) = !allColumnNames.contains(c)
-    columnNames.find(columnNotFound) match {
-      case Some(c) => throw new IOException(s"Column $c not found in table $keyspaceName.$tableName")
-      case None => columnNames
+    val regularColumnNames = tableDef.regularColumns.map(_.columnName).toSet
+
+    def checkSingleColumn(column: NamedColumnRef) = {
+      if (!allColumnNames.contains(column.columnName))
+        throw new IOException(s"Column $column not found in table $keyspaceName.$tableName")
+
+      column match {
+        case ColumnName(_) =>
+
+        case TTL(columnName) =>
+          if (!regularColumnNames.contains(columnName))
+            throw new IOException(s"TTL can be obtained only for regular columns, " +
+              s"but column $columnName is not a regular column in table $keyspaceName.$tableName.")
+
+        case WriteTime(columnName) =>
+          if (!regularColumnNames.contains(columnName))
+            throw new IOException(s"TTL can be obtained only for regular columns, " +
+              s"but column $columnName is not a regular column in table $keyspaceName.$tableName.")
+      }
+
+      column
     }
+
+    columns.map(checkSingleColumn)
   }
 
 
   /** Returns the names of columns to be selected from the table.*/
-  lazy val selectedColumnNames: Seq[String] = {
+  lazy val selectedColumnNames: Seq[NamedColumnRef] = {
     val providedColumnNames =
       columnNames match {
-        case AllColumns => tableDef.allColumns.map(_.columnName).toSeq
+        case AllColumns => tableDef.allColumns.map(col => col.columnName: NamedColumnRef).toSeq
         case SomeColumns(cs @ _*) => checkColumnsExistence(cs)
       }
 
     (rowTransformer.columnNames, rowTransformer.requiredColumns) match {
-      case (Some(cs), None) => providedColumnNames.filter(cs.toSet)
+      case (Some(cs), None) => providedColumnNames.filter(columnName => cs.toSet(columnName.selectedAs))
       case (_, _) => providedColumnNames
     }
   }
@@ -272,7 +304,7 @@ class CassandraRDD[R] private[connector] (
 
     rowTransformer.columnNames match {
       case Some(names) =>
-        val missingColumns = names.toSet -- selectedColumnNames.toSet
+        val missingColumns = names.toSet -- selectedColumnNames.map(_.selectedAs).toSet
         assert(missingColumns.isEmpty, s"Missing columns needed by $targetType: ${missingColumns.mkString(", ")}")
       case None =>
     }
@@ -307,7 +339,7 @@ class CassandraRDD[R] private[connector] (
     .endpoints.flatMap(inet => Seq(inet.getHostName, inet.getHostAddress)).toSeq.distinct
 
   private def tokenRangeToCqlQuery(range: CqlTokenRange): (String, Seq[Any]) = {
-    val columns = selectedColumnNames.map(quote).mkString(", ")
+    val columns = selectedColumnNames.map(_.cql).mkString(", ")
     val filter = (range.cql +: where.predicates ).filter(_.nonEmpty).mkString(" AND ") + " ALLOW FILTERING"
     val quotedKeyspaceName = quote(keyspaceName)
     val quotedTableName = quote(tableName)
@@ -341,7 +373,7 @@ class CassandraRDD[R] private[connector] (
     val (cql, values) = tokenRangeToCqlQuery(range)
     logDebug(s"Fetching data for range ${range.cql} with $cql with params ${values.mkString("[", ",", "]")}")
     val stmt = createStatement(session, cql, values: _*)
-    val columnNamesArray = selectedColumnNames.toArray
+    val columnNamesArray = selectedColumnNames.map(_.selectedAs).toArray
     try {
       val rs = session.execute(stmt)
       val protocolVersion = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersionEnum

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/ValueRowReader.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/ValueRowReader.scala
@@ -1,33 +1,35 @@
 package com.datastax.spark.connector.rdd.reader
 
 import com.datastax.driver.core.{ProtocolVersion, Row}
-import com.datastax.spark.connector.{AbstractRow, CassandraRow}
+import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql.TableDef
-import com.datastax.spark.connector.mapper.{ColumnRef, IndexedColumnRef, NamedColumnRef}
 import com.datastax.spark.connector.types.TypeConverter
 import com.datastax.spark.connector.util.JavaApiHelper
 
 class ValueRowReader[T: TypeConverter](columnRef: ColumnRef) extends RowReader[T] {
+
+  private val converter = implicitly[TypeConverter[T]]
+
   /** Reads column values from low-level `Row` and turns them into higher level representation.
     * @param row row fetched from Cassandra
     * @param columnNames column names available in the `row` */
   override def read(row: Row, columnNames: Array[String], protocolVersion: ProtocolVersion): T = {
     columnRef match {
-      case IndexedColumnRef(idx) => implicitly[TypeConverter[T]].convert(AbstractRow.get(row, idx, protocolVersion))
-      case NamedColumnRef(name) => implicitly[TypeConverter[T]].convert(AbstractRow.get(row, name, protocolVersion))
+      case ColumnIndex(idx) => converter.convert(AbstractRow.get(row, idx, protocolVersion))
+      case NamedColumnRef(_, selectedAs) => converter.convert(AbstractRow.get(row, selectedAs, protocolVersion))
     }
   }
 
   /** List of columns this `RowReader` is going to read.
     * Useful to avoid fetching the columns that are not needed. */
   override def columnNames: Option[Seq[String]] = columnRef match {
-    case NamedColumnRef(name) => Some(Seq(name))
+    case NamedColumnRef(_, selectedAs) => Some(Seq(selectedAs))
     case _ => None
   }
 
   /** The number of columns that need to be fetched from C*. */
   override def requiredColumns: Option[Int] = columnRef match {
-    case IndexedColumnRef(idx) => Some(idx)
+    case ColumnIndex(idx) => Some(idx)
     case _ => None
   }
 
@@ -38,7 +40,7 @@ class ValueRowReaderFactory[T: TypeConverter]
   extends RowReaderFactory[T] {
 
   override def rowReader(table: TableDef, options: RowReaderOptions): RowReader[T] = {
-    new ValueRowReader[T](IndexedColumnRef(options.offset))
+    new ValueRowReader[T](ColumnIndex(options.offset))
   }
 
   override def targetClass: Class[T] = JavaApiHelper.getRuntimeClass(implicitly[TypeConverter[T]].targetTypeTag)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/DefaultRowWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/DefaultRowWriter.scala
@@ -1,8 +1,9 @@
 package com.datastax.spark.connector.writer
 
 import com.datastax.driver.core.{ProtocolVersion, PreparedStatement}
+import com.datastax.spark.connector.{ColumnIndex, ColumnName, ColumnRef}
 import com.datastax.spark.connector.cql.TableDef
-import com.datastax.spark.connector.mapper.{IndexedColumnRef, NamedColumnRef, ColumnRef, ColumnMapper}
+import com.datastax.spark.connector.mapper.ColumnMapper
 import com.datastax.spark.connector.types.TypeConverter
 
 import scala.collection.{Map, Seq}
@@ -47,8 +48,8 @@ class DefaultRowWriter[T : ColumnMapper](table: TableDef, selectedColumns: Seq[S
 
   private def columnNameByRef(columnRef: ColumnRef): Option[String] = {
     columnRef match {
-      case NamedColumnRef(name) if selectedColumnsSet.contains(name) => Some(name)
-      case IndexedColumnRef(index) if index < selectedColumns.size => Some(selectedColumnsIndexed(index))
+      case ColumnName(name) if selectedColumnsSet.contains(name) => Some(name)
+      case ColumnIndex(index) if index < selectedColumns.size => Some(selectedColumnsIndexed(index))
       case _ => None
     }
   }

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraTableScan.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraTableScan.scala
@@ -21,7 +21,7 @@ case class CassandraTableScan(
     //TODO: cluster level CassandraConnector, read configuration settings
     var rdd = context.sparkContext.cassandraTable[CassandraSQLRow](relation.keyspaceName, relation.tableName)
     if (attributes.map(_.name).size > 0)
-      rdd = rdd.select(attributes.map(a => relation.columnNameByLowercase(a.name)): _*)
+      rdd = rdd.select(attributes.map(a => relation.columnNameByLowercase(a.name): NamedColumnRef): _*)
     if (pushdownPred.nonEmpty) {
       val(cql, values) = whereClause(pushdownPred)
       rdd = rdd.where(cql, values: _*)

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/mapper/DefaultColumnMapperTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/mapper/DefaultColumnMapperTest.scala
@@ -1,5 +1,6 @@
 package com.datastax.spark.connector.mapper
 
+import com.datastax.spark.connector.ColumnName
 import com.datastax.spark.connector.cql.{RegularColumn, TableDef, ColumnDef}
 import com.datastax.spark.connector.types.IntType
 import org.apache.commons.lang3.SerializationUtils
@@ -22,18 +23,18 @@ class DefaultColumnMapperTest {
   def testGetters1() {
     val columnMap = new DefaultColumnMapper[DefaultColumnMapperTestClass1].columnMap(tableDef)
     val getters = columnMap.getters
-    assertEquals(NamedColumnRef(c1.columnName), getters("property1"))
-    assertEquals(NamedColumnRef(c2.columnName), getters("camelCaseProperty"))
-    assertEquals(NamedColumnRef(c3.columnName), getters("UpperCaseColumn"))
+    assertEquals(ColumnName(c1.columnName), getters("property1"))
+    assertEquals(ColumnName(c2.columnName), getters("camelCaseProperty"))
+    assertEquals(ColumnName(c3.columnName), getters("UpperCaseColumn"))
   }
 
   @Test
   def testGetters2() {
     val columnMap = new DefaultColumnMapper[DefaultColumnMapperTestClass2].columnMap(tableDef)
     val getters = columnMap.getters
-    assertEquals(NamedColumnRef(c1.columnName), getters("property1"))
-    assertEquals(NamedColumnRef(c2.columnName), getters("camelCaseProperty"))
-    assertEquals(NamedColumnRef(c3.columnName), getters("UpperCaseColumn"))
+    assertEquals(ColumnName(c1.columnName), getters("property1"))
+    assertEquals(ColumnName(c2.columnName), getters("camelCaseProperty"))
+    assertEquals(ColumnName(c3.columnName), getters("UpperCaseColumn"))
   }
 
   @Test
@@ -46,28 +47,28 @@ class DefaultColumnMapperTest {
   def testSetters2() {
     val columnMap = new DefaultColumnMapper[DefaultColumnMapperTestClass2].columnMap(tableDef)
     val setters = columnMap.setters
-    assertEquals(NamedColumnRef(c1.columnName), setters("property1_$eq"))
-    assertEquals(NamedColumnRef(c2.columnName), setters("camelCaseProperty_$eq"))
-    assertEquals(NamedColumnRef(c3.columnName), setters("UpperCaseColumn_$eq"))
+    assertEquals(ColumnName(c1.columnName), setters("property1_$eq"))
+    assertEquals(ColumnName(c2.columnName), setters("camelCaseProperty_$eq"))
+    assertEquals(ColumnName(c3.columnName), setters("UpperCaseColumn_$eq"))
   }
 
   @Test
   def testConstructorParams1() {
     val columnMap = new DefaultColumnMapper[DefaultColumnMapperTestClass1].columnMap(tableDef)
-    val expectedConstructor: Seq[NamedColumnRef] = Seq(
-      NamedColumnRef(c1.columnName),
-      NamedColumnRef(c2.columnName),
-      NamedColumnRef(c3.columnName))
+    val expectedConstructor: Seq[ColumnName] = Seq(
+      ColumnName(c1.columnName),
+      ColumnName(c2.columnName),
+      ColumnName(c3.columnName))
     assertEquals(expectedConstructor, columnMap.constructor)
   }
 
   @Test
   def testConstructorParams2() {
     val columnMap = new DefaultColumnMapper[DefaultColumnMapperTestClass2].columnMap(tableDef)
-    val expectedConstructor: Seq[NamedColumnRef] = Seq(
-      NamedColumnRef(c1.columnName),
-      NamedColumnRef(c2.columnName),
-      NamedColumnRef(c3.columnName))
+    val expectedConstructor: Seq[ColumnName] = Seq(
+      ColumnName(c1.columnName),
+      ColumnName(c2.columnName),
+      ColumnName(c3.columnName))
     assertEquals(expectedConstructor, columnMap.constructor)
   }
 
@@ -76,9 +77,9 @@ class DefaultColumnMapperTest {
     val nameOverride: Map[String, String] = Map("property1" -> c4.columnName)
     val columnMap = new DefaultColumnMapper[DefaultColumnMapperTestClass1](nameOverride).columnMap(tableDef)
     val getters = columnMap.getters
-    assertEquals(NamedColumnRef(c4.columnName), getters("property1"))
-    assertEquals(NamedColumnRef(c2.columnName), getters("camelCaseProperty"))
-    assertEquals(NamedColumnRef(c3.columnName), getters("UpperCaseColumn"))
+    assertEquals(ColumnName(c4.columnName), getters("property1"))
+    assertEquals(ColumnName(c2.columnName), getters("camelCaseProperty"))
+    assertEquals(ColumnName(c3.columnName), getters("UpperCaseColumn"))
   }
 
   @Test
@@ -86,19 +87,19 @@ class DefaultColumnMapperTest {
     val nameOverride: Map[String, String] = Map("property1" -> c4.columnName)
     val columnMap = new DefaultColumnMapper[DefaultColumnMapperTestClass2](nameOverride).columnMap(tableDef)
     val setters = columnMap.setters
-    assertEquals(NamedColumnRef(c4.columnName), setters("property1_$eq"))
-    assertEquals(NamedColumnRef(c2.columnName), setters("camelCaseProperty_$eq"))
-    assertEquals(NamedColumnRef(c3.columnName), setters("UpperCaseColumn_$eq"))
+    assertEquals(ColumnName(c4.columnName), setters("property1_$eq"))
+    assertEquals(ColumnName(c2.columnName), setters("camelCaseProperty_$eq"))
+    assertEquals(ColumnName(c3.columnName), setters("UpperCaseColumn_$eq"))
   }
 
   @Test
   def columnNameOverrideConstructor() {
     val nameOverride: Map[String, String] = Map("property1" -> "column")
     val mapper = new DefaultColumnMapper[DefaultColumnMapperTestClass1](nameOverride).columnMap(tableDef)
-    val expectedConstructor: Seq[NamedColumnRef] = Seq(
-      NamedColumnRef(c4.columnName),
-      NamedColumnRef(c2.columnName),
-      NamedColumnRef(c3.columnName))
+    val expectedConstructor: Seq[ColumnName] = Seq(
+      ColumnName(c4.columnName),
+      ColumnName(c2.columnName),
+      ColumnName(c3.columnName))
     assertEquals(expectedConstructor, mapper.constructor)
   }
 

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/mapper/JavaBeanColumnMapperTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/mapper/JavaBeanColumnMapperTest.scala
@@ -1,5 +1,6 @@
 package com.datastax.spark.connector.mapper
 
+import com.datastax.spark.connector.ColumnName
 import com.datastax.spark.connector.cql.{TableDef, RegularColumn, ColumnDef}
 import com.datastax.spark.connector.types.IntType
 import org.apache.commons.lang3.SerializationUtils
@@ -35,18 +36,18 @@ class JavaBeanColumnMapperTest {
   def testGetters() {
     val columnMap = new JavaBeanColumnMapper[JavaBeanColumnMapperTestClass].columnMap(tableDef)
     val getters = columnMap.getters
-    assertEquals(NamedColumnRef(c1.columnName), getters("getProperty1"))
-    assertEquals(NamedColumnRef(c2.columnName), getters("getCamelCaseProperty"))
-    assertEquals(NamedColumnRef(c3.columnName), getters("isFlagged"))
+    assertEquals(ColumnName(c1.columnName), getters("getProperty1"))
+    assertEquals(ColumnName(c2.columnName), getters("getCamelCaseProperty"))
+    assertEquals(ColumnName(c3.columnName), getters("isFlagged"))
   }
 
   @Test
   def testSetters() {
     val columnMap = new JavaBeanColumnMapper[JavaBeanColumnMapperTestClass].columnMap(tableDef)
     val setters = columnMap.setters
-    assertEquals(NamedColumnRef(c1.columnName), setters("setProperty1"))
-    assertEquals(NamedColumnRef(c2.columnName), setters("setCamelCaseProperty"))
-    assertEquals(NamedColumnRef(c3.columnName), setters("setFlagged"))
+    assertEquals(ColumnName(c1.columnName), setters("setProperty1"))
+    assertEquals(ColumnName(c2.columnName), setters("setCamelCaseProperty"))
+    assertEquals(ColumnName(c3.columnName), setters("setFlagged"))
   }
 
   @Test
@@ -54,9 +55,9 @@ class JavaBeanColumnMapperTest {
     val columnNameOverrides: Map[String, String] = Map("property1" -> c5.columnName, "flagged" -> c4.columnName)
     val columnMap = new JavaBeanColumnMapper[JavaBeanColumnMapperTestClass](columnNameOverrides).columnMap(tableDef)
     val getters = columnMap.getters
-    assertEquals(NamedColumnRef(c5.columnName), getters("getProperty1"))
-    assertEquals(NamedColumnRef(c2.columnName), getters("getCamelCaseProperty"))
-    assertEquals(NamedColumnRef(c4.columnName), getters("isFlagged"))
+    assertEquals(ColumnName(c5.columnName), getters("getProperty1"))
+    assertEquals(ColumnName(c2.columnName), getters("getCamelCaseProperty"))
+    assertEquals(ColumnName(c4.columnName), getters("isFlagged"))
   }
 
   @Test
@@ -64,9 +65,9 @@ class JavaBeanColumnMapperTest {
     val columnNameOverrides: Map[String, String] = Map("property1" -> c5.columnName, "flagged" -> c4.columnName)
     val columnMap = new JavaBeanColumnMapper[JavaBeanColumnMapperTestClass](columnNameOverrides).columnMap(tableDef)
     val setters = columnMap.setters
-    assertEquals(NamedColumnRef(c5.columnName), setters("setProperty1"))
-    assertEquals(NamedColumnRef(c2.columnName), setters("setCamelCaseProperty"))
-    assertEquals(NamedColumnRef(c4.columnName), setters("setFlagged"))
+    assertEquals(ColumnName(c5.columnName), setters("setProperty1"))
+    assertEquals(ColumnName(c2.columnName), setters("setCamelCaseProperty"))
+    assertEquals(ColumnName(c4.columnName), setters("setFlagged"))
   }
 
   @Test

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/mapper/TupleColumnMapperTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/mapper/TupleColumnMapperTest.scala
@@ -1,5 +1,6 @@
 package com.datastax.spark.connector.mapper
 
+import com.datastax.spark.connector.ColumnIndex
 import com.datastax.spark.connector.cql.{TableDef, RegularColumn, ColumnDef}
 import com.datastax.spark.connector.types.IntType
 import org.apache.commons.lang3.SerializationUtils
@@ -17,15 +18,15 @@ class TupleColumnMapperTest {
   def testGetters() {
     val columnMap = new TupleColumnMapper[(Int, String, Boolean)].columnMap(tableDef)
     val getters = columnMap.getters
-    assertEquals(IndexedColumnRef(0), getters("_1"))
-    assertEquals(IndexedColumnRef(1), getters("_2"))
-    assertEquals(IndexedColumnRef(2), getters("_3"))
+    assertEquals(ColumnIndex(0), getters("_1"))
+    assertEquals(ColumnIndex(1), getters("_2"))
+    assertEquals(ColumnIndex(2), getters("_3"))
   }
 
   @Test
   def testConstructor() {
     val columnMap = new TupleColumnMapper[(Int, String, Boolean)].columnMap(tableDef)
-    assertEquals(Seq(IndexedColumnRef(0), IndexedColumnRef(1), IndexedColumnRef(2)), columnMap.constructor)
+    assertEquals(Seq(ColumnIndex(0), ColumnIndex(1), ColumnIndex(2)), columnMap.constructor)
   }
 
   @Test
@@ -38,9 +39,9 @@ class TupleColumnMapperTest {
   def testImplicit() {
     val columnMap = implicitly[ColumnMapper[(Int, String, Boolean)]].columnMap(tableDef)
     val getters = columnMap.getters
-    assertEquals(IndexedColumnRef(0), getters("_1"))
-    assertEquals(IndexedColumnRef(1), getters("_2"))
-    assertEquals(IndexedColumnRef(2), getters("_3"))
+    assertEquals(ColumnIndex(0), getters("_1"))
+    assertEquals(ColumnIndex(1), getters("_2"))
+    assertEquals(ColumnIndex(2), getters("_3"))
   }
 
 }


### PR DESCRIPTION
- Created case classes for different kinds of columns
- Changed the way the columns can be selected - select method now accepts SelectionColumn instead of String arguments
- Updated JavaAPI for TTL and write time retrieval support
- Updated and added test cases for TTL and write time retrieval support
- Updated API docs
- Applied reviewer's comments - merged ColumnSelection hierarchy into ColumnRef
- Add extractor to NamedColumnRef and use it.
