### PR TITLE
SPARKC-169: Backport of SPARKC-8: Reading TTL and write time of regular columns

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
-(1.1.x unreleased)
+1.1.x (unreleased)
+ * Backport SPARKC-8, retrieval of TTL and write time
  * Upgraded to Spark 1.1.1
  * Synchronized ReflectionUtil findScalaObject and findSingletonClassInstance methods
    to avoid problems with Scala 2.10 lack thread safety in the reflection subsystem (SPARKC-107)

--- a/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaRDDSpec.scala
+++ b/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaRDDSpec.scala
@@ -6,6 +6,7 @@ import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.embedded._
 import com.datastax.spark.connector.japi.CassandraJavaUtil
+import com.datastax.spark.connector.mapper.NamedColumnRef
 import com.datastax.spark.connector.testkit._
 import com.datastax.spark.connector.types.TypeConverter
 import org.apache.commons.lang3.tuple
@@ -104,8 +105,8 @@ with ShouldMatchers with SharedEmbeddedCassandra with SparkTemplate {
   it should "return selected columns" in {
     val rdd = javaFunctions(sc).cassandraTable("java_api_test", "test_table")
       .select("key")
-    assert(rdd.selectedColumnNames().size === 1)
-    assert(rdd.selectedColumnNames().contains("key"))
+    assert(rdd.selectedColumnRefs().size === 1)
+    assert(rdd.selectedColumnRefs().contains(new NamedColumnRef("key")))
   }
 
   it should "allow to use where clause to filter records" in {

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/CassandraJavaUtil.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/CassandraJavaUtil.java
@@ -3,7 +3,7 @@ package com.datastax.spark.connector.japi;
 import akka.japi.JAPI;
 import com.datastax.spark.connector.*;
 import com.datastax.spark.connector.cql.CassandraConnector;
-import com.datastax.spark.connector.mapper.ColumnMapper;
+import com.datastax.spark.connector.mapper.*;
 import com.datastax.spark.connector.rdd.reader.ClassBasedRowReaderFactory;
 import com.datastax.spark.connector.rdd.reader.RowReaderFactory;
 import com.datastax.spark.connector.rdd.reader.ValueRowReaderFactory;
@@ -438,9 +438,34 @@ public class CassandraJavaUtil {
      * Creates a column selector with a given columns projection.
      */
     public static ColumnSelector someColumns(String... columnNames) {
-        return SomeColumns$.MODULE$.apply(JAPI.seq(columnNames));
+        IndexedByNameColumnRef[] columnsSelection = new IndexedByNameColumnRef[columnNames.length];
+        for (int i = 0; i < columnNames.length; i++) {
+            columnsSelection[i] = NamedColumnRef$.MODULE$.apply(columnNames[i]);
+        }
+
+        return SomeColumns$.MODULE$.apply(JAPI.seq(columnsSelection));
     }
 
+    public static IndexedByNameColumnRef[] convert(String... columnNames) {
+        IndexedByNameColumnRef[] columnsSelection = new IndexedByNameColumnRef[columnNames.length];
+        for (int i = 0; i < columnNames.length; i++) {
+            columnsSelection[i] = NamedColumnRef$.MODULE$.apply(columnNames[i]);
+        }
+
+        return columnsSelection;
+    }
+
+    public static NamedColumnRef plain(String columnName) {
+        return new NamedColumnRef(columnName);
+    }
+
+    public static TTL ttl(String columnName) {
+        return new TTL(columnName);
+    }
+
+    public static WriteTime writeTime(String columnName) {
+        return new WriteTime(columnName);
+    }
 
     // -------------------------------------------------------------------------
     //              Utility methods 

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraJavaPairRDD.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraJavaPairRDD.java
@@ -1,6 +1,8 @@
 package com.datastax.spark.connector.japi.rdd;
 
 import com.datastax.spark.connector.cql.CassandraConnector;
+import com.datastax.spark.connector.japi.CassandraJavaUtil;
+import com.datastax.spark.connector.mapper.IndexedByNameColumnRef;
 import com.datastax.spark.connector.rdd.CassandraRDD;
 import com.datastax.spark.connector.rdd.ReadConf;
 import com.datastax.spark.connector.util.JavaApiHelper;
@@ -42,7 +44,21 @@ public class CassandraJavaPairRDD<K, V> extends JavaPairRDD<K, V> {
     public CassandraJavaPairRDD<K, V> select(String... columnNames) {
         // explicit type argument is intentional and required here
         //noinspection RedundantTypeArguments
-        CassandraRDD<Tuple2<K, V>> newRDD = rdd().select(JavaApiHelper.<String>toScalaSeq(columnNames));
+        CassandraRDD<Tuple2<K, V>> newRDD = rdd().select(JavaApiHelper.<IndexedByNameColumnRef>toScalaSeq(CassandraJavaUtil.convert(columnNames)));
+        return new CassandraJavaPairRDD<>(newRDD, kClassTag(), vClassTag());
+    }
+
+    /**
+     * Narrows down the selected set of columns.
+     *
+     * <p>Use this for better performance, when you don't need all the columns in the result RDD. When called multiple
+     * times, it selects the subset of the already selected columns, so after a column was removed by the previous
+     * {@code select} call, it is not possible to add it back.</p>
+     */
+    public CassandraJavaPairRDD<K, V> select(IndexedByNameColumnRef... selectionColumns) {
+        // explicit type argument is intentional and required here
+        //noinspection RedundantTypeArguments
+        CassandraRDD<Tuple2<K, V>> newRDD = rdd().select(JavaApiHelper.<IndexedByNameColumnRef>toScalaSeq(selectionColumns));
         return new CassandraJavaPairRDD<>(newRDD, kClassTag(), vClassTag());
     }
 
@@ -64,7 +80,7 @@ public class CassandraJavaPairRDD<K, V> extends JavaPairRDD<K, V> {
     public String[] selectedColumnNames() {
         // explicit type cast is intentional and required here
         //noinspection RedundantCast
-        return (String[]) rdd().selectedColumnNames().<String>toArray(getClassTag(String.class));
+        return (String[]) rdd().selectedColumnRefs().<String>toArray(getClassTag(String.class));
     }
 
     /**

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraJavaRDD.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraJavaRDD.java
@@ -1,6 +1,8 @@
 package com.datastax.spark.connector.japi.rdd;
 
 import com.datastax.spark.connector.cql.CassandraConnector;
+import com.datastax.spark.connector.japi.CassandraJavaUtil;
+import com.datastax.spark.connector.mapper.IndexedByNameColumnRef;
 import com.datastax.spark.connector.rdd.CassandraRDD;
 import com.datastax.spark.connector.rdd.ReadConf;
 import com.datastax.spark.connector.util.JavaApiHelper;
@@ -42,7 +44,21 @@ public class CassandraJavaRDD<R> extends JavaRDD<R> {
     public CassandraJavaRDD<R> select(String... columnNames) {
         // explicit type argument is intentional and required here
         //noinspection RedundantTypeArguments
-        CassandraRDD<R> newRDD = rdd().select(JavaApiHelper.<String>toScalaSeq(columnNames));
+        CassandraRDD<R> newRDD = rdd().select(JavaApiHelper.<IndexedByNameColumnRef>toScalaSeq(CassandraJavaUtil.convert(columnNames)));
+        return new CassandraJavaRDD<>(newRDD, classTag());
+    }
+
+    /**
+     * Narrows down the selected set of columns.
+     *
+     * <p>Use this for better performance, when you don't need all the columns in the result RDD. When called multiple
+     * times, it selects the subset of the already selected columns, so after a column was removed by the previous
+     * {@code select} call, it is not possible to add it back.</p>
+     */
+    public CassandraJavaRDD<R> select(IndexedByNameColumnRef... selectionColumns) {
+        // explicit type argument is intentional and required here
+        //noinspection RedundantTypeArguments
+        CassandraRDD<R> newRDD = rdd().select(JavaApiHelper.<IndexedByNameColumnRef>toScalaSeq(selectionColumns));
         return new CassandraJavaRDD<>(newRDD, classTag());
     }
 
@@ -56,6 +72,15 @@ public class CassandraJavaRDD<R> extends JavaRDD<R> {
     public CassandraJavaRDD<R> where(String cqlWhereClause, Object... args) {
         CassandraRDD<R> newRDD = rdd().where(cqlWhereClause, toScalaSeq(args));
         return new CassandraJavaRDD<>(newRDD, classTag());
+    }
+
+    /**
+     * Returns the columns to be selected from the table.
+     */
+    public IndexedByNameColumnRef[] selectedColumnRefs() {
+        // explicit type cast is intentional and required here
+        //noinspection RedundantCast
+        return (IndexedByNameColumnRef[]) rdd().selectedColumnRefs().<IndexedByNameColumnRef>toArray(getClassTag(IndexedByNameColumnRef.class));
     }
 
     /**

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterColumnNamesSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterColumnNamesSpec.scala
@@ -1,9 +1,11 @@
 package com.datastax.spark.connector.writer
 
 import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.mapper.IndexedByNameColumnRef
 import com.datastax.spark.connector.{SomeColumns, AllColumns}
 import com.datastax.spark.connector.testkit._
 import com.datastax.spark.connector.embedded._
+import com.datastax.spark.connector._
 
 class TableWriterColumnNamesSpec extends AbstractSpec with SharedEmbeddedCassandra with SparkTemplate {
 
@@ -35,7 +37,7 @@ class TableWriterColumnNamesSpec extends AbstractSpec with SharedEmbeddedCassand
     }
 
     "distinguish and use only specified column names if provided" in {
-      val subset = Seq("key", "group")
+      val subset = Seq("key": IndexedByNameColumnRef, "group": IndexedByNameColumnRef)
 
       val writer = TableWriter(
         conn,

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ColumnSelector.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ColumnSelector.scala
@@ -1,13 +1,34 @@
 package com.datastax.spark.connector
 
+import scala.language.implicitConversions
+
+import com.datastax.spark.connector.mapper.IndexedByNameColumnRef
+
 sealed trait ColumnSelector
 case object AllColumns extends ColumnSelector
-case class SomeColumns(columns: String*) extends ColumnSelector
+case class SomeColumns(@transient _columns: IndexedByNameColumnRef*) extends ColumnSelector {
+  // In previous minor releases this method accepts a vararg of Strings. Varargs in scala are
+  // resolved as Seq and the type parameter is erased. Therefore we can change the type parameter
+  // while keeping the backward binary compatibility - that is, the applications which were
+  // compiled against the previous minor release, which pass vararg of Strings are still able
+  // to work.
+  // In order to make it work, we need to explicitly cast _columns to Seq[AnyRef] before invoking
+  // any command on this sequence. Then we check what is the real type of each entry in the sequence,
+  // and convert it to IndexedByNameColumnRef if necessary.
+  val columns = _columns.asInstanceOf[Seq[AnyRef]].map {
+    case ref: IndexedByNameColumnRef ⇒ ref
+    case str ⇒ str.toString: IndexedByNameColumnRef
+  }
+}
 
 object SomeColumns {
   @deprecated("Use com.datastax.spark.connector.rdd.SomeColumns instead of Seq", "1.0")
   implicit def seqToSomeColumns(columns: Seq[String]): SomeColumns =
-    SomeColumns(columns: _*)
+    SomeColumns(columns.map(x => x: IndexedByNameColumnRef): _*)
+
+  def unapply(sc: SomeColumns): Option[Seq[IndexedByNameColumnRef]] = {
+    Some(sc.columns)
+  }
 }
 
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/ColumnMap.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/ColumnMap.scala
@@ -3,8 +3,45 @@ package com.datastax.spark.connector.mapper
 /** Unambiguous reference to a column in the query result set row. */
 sealed trait ColumnRef
 
+sealed trait IndexedByNameColumnRef extends ColumnRef {
+  /** Returns the column name which this selection bases on. In case of a function, such as `ttl` or
+    * `writetime`, it returns the column name passed to that function. */
+  def name: String
+
+  /** Returns a CQL phrase which has to be passed to the `SELECT` clause with appropriate quotation
+    * marks. */
+  def cql: String
+
+  /** Returns a name of the selection as it is seen in the result set. Most likely this is going to be
+    * used when providing custom column name to field name mapping. */
+  def selectedAs: String
+}
+
+object IndexedByNameColumnRef {
+  def unapply(columnRef: IndexedByNameColumnRef) = Some((columnRef.name, columnRef.selectedAs))
+}
+
 /** References a column by name. */
-case class NamedColumnRef(name: String) extends ColumnRef
+case class NamedColumnRef(name: String) extends IndexedByNameColumnRef {
+  val cql = s""""$name""""
+  val selectedAs = name
+
+  override def toString: String = selectedAs
+}
+
+case class TTL(name: String) extends IndexedByNameColumnRef {
+  val cql = s"""TTL("$name")"""
+  val selectedAs = s"ttl($name)"
+
+  override def toString: String = selectedAs
+}
+
+case class WriteTime(name: String) extends IndexedByNameColumnRef {
+  val cql = s"""WRITETIME("$name")"""
+  val selectedAs = s"writetime($name)"
+
+  override def toString: String = selectedAs
+}
 
 /** References a column by its index in the row. Useful for tuples. */
 case class IndexedColumnRef(index: Int) extends ColumnRef

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/package.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/package.scala
@@ -3,7 +3,10 @@ package com.datastax.spark
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
+import scala.language.implicitConversions
 import scala.reflect.ClassTag
+
+import com.datastax.spark.connector.mapper.{NamedColumnRef, IndexedByNameColumnRef, TTL, WriteTime}
 
 /**
  * The root package of Cassandra connector for Apache Spark.
@@ -55,4 +58,10 @@ package object connector {
   implicit def toRDDFunctions[T : ClassTag](rdd: RDD[T]): RDDFunctions[T] =
     new RDDFunctions[T](rdd)
 
+  implicit class ColumnNameFunctions(val columnName: String) extends AnyVal {
+    def writeTime: WriteTime = WriteTime(columnName)
+    def ttl: TTL = TTL(columnName)
+  }
+
+  implicit def toNamedColumnRef(columnName: String): IndexedByNameColumnRef = NamedColumnRef(columnName)
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/ClassBasedRowReader.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/ClassBasedRowReader.scala
@@ -3,7 +3,7 @@ package com.datastax.spark.connector.rdd.reader
 import java.lang.reflect.Method
 
 import com.datastax.driver.core.{ProtocolVersion, Row}
-import com.datastax.spark.connector.{AbstractRow, CassandraRow}
+import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql.TableDef
 import com.datastax.spark.connector.mapper._
 import com.datastax.spark.connector.types.{TypeConversionException, TypeConverter}
@@ -59,8 +59,8 @@ class ClassBasedRowReader[R : TypeTag : ColumnMapper](table: TableDef, skipColum
 
   private def getColumnValue(row: Row, columnRef: ColumnRef, protocolVersion: ProtocolVersion) = {
     columnRef match {
-      case NamedColumnRef(name) =>
-        AbstractRow.get(row, name, protocolVersion)
+      case IndexedByNameColumnRef(_, selectedAs) =>
+        AbstractRow.get(row, selectedAs, protocolVersion)
       case IndexedColumnRef(index) =>
         AbstractRow.get(row, index + skipColumns, protocolVersion)
     }
@@ -68,7 +68,7 @@ class ClassBasedRowReader[R : TypeTag : ColumnMapper](table: TableDef, skipColum
 
   private def getColumnName(row: Row, columnRef: ColumnRef) = {
     columnRef match {
-      case NamedColumnRef(name) => name        
+      case IndexedByNameColumnRef(_, selectedAs) => selectedAs
       case IndexedColumnRef(index) => row.getColumnDefinitions.getName(index + skipColumns)
     }
   }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/DefaultRowWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/DefaultRowWriter.scala
@@ -6,7 +6,6 @@ import com.datastax.spark.connector.mapper.{IndexedColumnRef, NamedColumnRef, Co
 import com.datastax.spark.connector.types.TypeConverter
 
 import scala.collection.{Map, Seq}
-import scala.reflect.ClassTag
 
 import scala.collection.JavaConversions._
 

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraTableScan.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraTableScan.scala
@@ -8,6 +8,8 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.types.DataType
 import org.apache.spark.sql.execution.LeafNode
 
+import com.datastax.spark.connector.mapper.IndexedByNameColumnRef
+
 @DeveloperApi
 case class CassandraTableScan(
   attributes: Seq[Attribute],
@@ -21,7 +23,7 @@ case class CassandraTableScan(
     //TODO: cluster level CassandraConnector, read configuration settings
     var rdd = context.sparkContext.cassandraTable[CassandraSQLRow](relation.keyspaceName, relation.tableName)
     if (attributes.map(_.name).size > 0)
-      rdd = rdd.select(attributes.map(a => relation.columnNameByLowercase(a.name)): _*)
+      rdd = rdd.select(attributes.map(a => relation.columnNameByLowercase(a.name): IndexedByNameColumnRef): _*)
     if (pushdownPred.nonEmpty) {
       val(cql, values) = whereClause(pushdownPred)
       rdd = rdd.where(cql, values: _*)


### PR DESCRIPTION
Cleanly cherry-picked the commit which fixed SPARKC-8

- Created case classes for different kinds of columns
- Changed the way the columns can be selected - select method now accepts SelectionColumn instead of String arguments
- Updated JavaAPI for TTL and write time retrieval support
- Updated and added test cases for TTL and write time retrieval support
- Updated API docs
- Applied reviewer's comments - merged ColumnSelection hierarchy into ColumnRef
- Add extractor to NamedColumnRef and use it.
