### PR TITLE
SPARKC-104 Add partitionKeyMapper to repartitionByCassandraReplica()

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,8 @@
    - spark.cassandra.connection.(rpc|native).port replaced with spark.cassandra.connection.port
  * Refactored ColumnSelector to avoid circular dependency on TableDef (SPARKC-177)
  * Support for modifying C* Collections using saveToCassandra (SPARKC-147)
+ * Add the abilty to use Custom Mappers with repartitionByCassandraReplica (SPARKC-104)
+
 
 
 1.3.0 M1

--- a/doc/2_loading.md
+++ b/doc/2_loading.md
@@ -228,6 +228,27 @@ scala> repartitioned
 //res2: com.datastax.spark.connector.rdd.partitioner.CassandraPartitionedRDD[CustomerID] = CassandraPartitionedRDD[5] at RDD at CassandraPartitionedRDD.scala:12
 ```
 
+Specifying the RDD Field mapping to Cassandra Partition Keys can be done using the partitionKeyMapper parameter.
+
+```scala
+//CREATE TABLE test.shopping_history ( cust_id INT, date TIMESTAMP,  product TEXT, quantity INT, PRIMARY KEY (cust_id, date, product));
+case class OtherId(aCol: Int, bCol: Int) // Defines partition key
+val idsOfInterest = sc.parallelize(1 to 1000).map(id => OtherId(id, id + 1))
+val repartitionedOnA = idsOfInterest.repartitionByCassandraReplica(
+  "test", 
+  "shopping_history", 
+  10, 
+  partitionKeyMapper = SomeColumns("cust_id" as "aCol") 
+)
+
+val repartitionedOnB = idsOfInterest.repartitionByCassandraReplica(
+  "test", 
+  "shopping_history", 
+  10, 
+  partitionKeyMapper = SomeColumns("cust_id" as "bCol") 
+)
+```
+
 
 ### Using joinWithCassandraTable
 The connector supports using any RDD as a source of a direct join with a Cassandra Table through `joinWithCassandraTable`.

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/RDDJavaFunctions.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/RDDJavaFunctions.java
@@ -133,6 +133,7 @@ public class RDDJavaFunctions<T> extends RDDAndDStreamCommonJavaFunctions<T> {
             String keyspaceName,
             String tableName,
             int partitionsPerHost,
+            ColumnSelector partitionKeyMapper,
             RowWriterFactory<T> rowWriterFactory
     ) {
         CassandraConnector connector = defaultConnector();
@@ -142,6 +143,7 @@ public class RDDJavaFunctions<T> extends RDDAndDStreamCommonJavaFunctions<T> {
                 keyspaceName,
                 tableName,
                 partitionsPerHost,
+                partitionKeyMapper,
                 connector,
                 ctT,
                 rowWriterFactory);

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
@@ -25,12 +25,14 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
    * Saves the data from [[org.apache.spark.rdd.RDD RDD]] to a Cassandra table. Uses the specified column names.
    * @see [[com.datastax.spark.connector.writer.WritableToCassandra]]
    */
-  def saveToCassandra(keyspaceName: String,
-                      tableName: String,
-                      columns: ColumnSelector = AllColumns,
-                      writeConf: WriteConf = WriteConf.fromSparkConf(sparkContext.getConf))
-                     (implicit connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
-                      rwf: RowWriterFactory[T]): Unit = {
+  def saveToCassandra(
+    keyspaceName: String,
+    tableName: String,
+    columns: ColumnSelector = AllColumns,
+    writeConf: WriteConf = WriteConf.fromSparkConf(sparkContext.getConf))(
+  implicit
+    connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+    rwf: RowWriterFactory[T]): Unit = {
 
     val writer = TableWriter(connector, keyspaceName, tableName, columns, writeConf)
     rdd.sparkContext.runJob(rdd, writer.write _)
@@ -53,11 +55,13 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
    * @param rwf factory for obtaining the row writer to be used to extract column values
    *            from items of the [[org.apache.spark.rdd.RDD RDD]]
    */
-  def saveAsCassandraTableEx(table: TableDef,
-                             columns: ColumnSelector = AllColumns,
-                             writeConf: WriteConf = WriteConf.fromSparkConf(sparkContext.getConf))
-                            (implicit connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
-                             rwf: RowWriterFactory[T]): Unit = {
+  def saveAsCassandraTableEx(
+    table: TableDef,
+    columns: ColumnSelector = AllColumns,
+    writeConf: WriteConf = WriteConf.fromSparkConf(sparkContext.getConf))(
+  implicit
+    connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+    rwf: RowWriterFactory[T]): Unit = {
 
     connector.withSessionDo(session => session.execute(table.cql))
     saveToCassandra(table.keyspaceName, table.tableName, columns, writeConf)
@@ -79,13 +83,15 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
    *            from items of the [[org.apache.spark.rdd.RDD RDD]]
    * @param columnMapper a column mapper determining the definition of the table
    */
-  def saveAsCassandraTable(keyspaceName: String,
-                           tableName: String,
-                           columns: ColumnSelector = AllColumns,
-                           writeConf: WriteConf = WriteConf.fromSparkConf(sparkContext.getConf))
-                          (implicit connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
-                           rwf: RowWriterFactory[T],
-                           columnMapper: ColumnMapper[T]): Unit = {
+  def saveAsCassandraTable(
+    keyspaceName: String,
+    tableName: String,
+    columns: ColumnSelector = AllColumns,
+    writeConf: WriteConf = WriteConf.fromSparkConf(sparkContext.getConf))(
+  implicit
+    connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+    rwf: RowWriterFactory[T],
+    columnMapper: ColumnMapper[T]): Unit = {
 
     val table = TableDef.fromType[T](keyspaceName, tableName)
     saveAsCassandraTableEx(table, columns, writeConf)
@@ -121,29 +127,40 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
    * val someCass = source.joinWithCassandraTable(keyspace, wideTable).on(SomeColumns("key", "group"))
    * }}}
    **/
-  def joinWithCassandraTable[R](keyspaceName: String, tableName: String,
-                                selectedColumns: ColumnSelector = AllColumns,
-                                joinColumns: ColumnSelector = PartitionKeyColumns)
-                               (implicit connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
-                                newType: ClassTag[R], rrf: RowReaderFactory[R], ev: ValidRDDType[R],
-                                currentType: ClassTag[T], rwf: RowWriterFactory[T]): CassandraJoinRDD[T, R] = {
+  def joinWithCassandraTable[R](
+    keyspaceName: String,
+    tableName: String,
+    selectedColumns: ColumnSelector = AllColumns,
+    joinColumns: ColumnSelector = PartitionKeyColumns)(
+  implicit
+    connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+    newType: ClassTag[R],
+    rrf: RowReaderFactory[R],
+    ev: ValidRDDType[R],
+    currentType: ClassTag[T],
+    rwf: RowWriterFactory[T]): CassandraJoinRDD[T, R] = {
+
     new CassandraJoinRDD[T, R](rdd, keyspaceName, tableName, connector, columnNames = selectedColumns, joinColumns = joinColumns)
   }
 
 
   /**
-   * Repartitions the data (via a shuffle) based upon the replication of the given `keyspaceName` and `tableName`. 
+   * Repartitions the data (via a shuffle) based upon the replication of the given `keyspaceName` and `tableName`.
    * Calling this method before using joinWithCassandraTable will ensure that requests will be coordinator
    * local. `partitionsPerHost` Controls the number of Spark Partitions that will be created in this repartitioning
    * event.
    * The calling RDD must have rows that can be converted into the partition key of the given Cassandra Table.
    **/
-  def repartitionByCassandraReplica(keyspaceName: String,
-                                    tableName: String,
-                                    partitionsPerHost: Int = 10,
-                                    partitionKeyMapper: ColumnSelector = PartitionKeyColumns)
-                                   (implicit connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
-                                    currentType: ClassTag[T], rwf: RowWriterFactory[T]) = {
+  def repartitionByCassandraReplica(
+    keyspaceName: String,
+    tableName: String,
+    partitionsPerHost: Int = 10,
+    partitionKeyMapper: ColumnSelector = PartitionKeyColumns)(
+  implicit
+    connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+    currentType: ClassTag[T],
+    rwf: RowWriterFactory[T]) = {
+
     val part = new ReplicaPartitioner(partitionsPerHost, connector)
     val repart = rdd.keyByCassandraReplica(keyspaceName, tableName, partitionKeyMapper).partitionBy(part)
     val output = repart.mapPartitions(_.map(_._2), preservesPartitioning = true)
@@ -155,11 +172,15 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
    * of the data specified by that row.
    * The calling RDD must have rows that can be converted into the partition key of the given Cassandra Table.
    */
-  def keyByCassandraReplica(keyspaceName: String,
-                            tableName: String,
-                            partitionKeyMapper: ColumnSelector = PartitionKeyColumns)
-                           (implicit connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
-                            currentType: ClassTag[T], rwf: RowWriterFactory[T]): RDD[(Set[InetAddress], T)] = {
+  def keyByCassandraReplica(
+    keyspaceName: String,
+    tableName: String,
+    partitionKeyMapper: ColumnSelector = PartitionKeyColumns)(
+  implicit
+    connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+    currentType: ClassTag[T],
+    rwf: RowWriterFactory[T]): RDD[(Set[InetAddress], T)] = {
+
     val converter = ReplicaMapper[T](connector, keyspaceName, tableName, partitionKeyMapper)
     rdd.mapPartitions(primaryKey =>
       converter.keyByReplicas(primaryKey)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/DStreamFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/DStreamFunctions.scala
@@ -40,14 +40,16 @@ class DStreamFunctions[T](dstream: DStream[T]) extends WritableToCassandra[T] wi
   def repartitionByCassandraReplica(
     keyspaceName: String,
     tableName: String,
-    partitionsPerHost: Int = 10)(
+    partitionsPerHost: Int = 10,
+    partitionKeyMapper: ColumnSelector = PartitionKeyColumns)
+    (
   implicit
     connector: CassandraConnector = CassandraConnector(conf),
     currentType: ClassTag[T],
     rwf: RowWriterFactory[T]): DStream[T] = {
 
     dstream.transform(rdd =>
-      rdd.repartitionByCassandraReplica(keyspaceName, tableName, partitionsPerHost))
+      rdd.repartitionByCassandraReplica(keyspaceName, tableName, partitionsPerHost, partitionKeyMapper))
   }
 
   /**


### PR DESCRIPTION
Previously we relied on the implicit mapping of rdd to CassandraRows to
determine a the Primary Key present in the RDD. This patch allows the
user to specify using a column mapper the mapping between the partition
key and the RDD. The interface is the same as if they were saving to
Cassandra.