### PR TITLE
SPARKC-177: Refactored ColumnSelector

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
@@ -148,21 +148,6 @@ case class TableDef(
        |  PRIMARY KEY ($primaryKeyClause)
        |)""".stripMargin
   }
-
-  /** Selects a subset of columns.
-    * Columns are returned in the order specified in the `ColumnSelector`. */
-  def select(selector: ColumnSelector): IndexedSeq[ColumnDef] = {
-    selector match {
-      case AllColumns => columns
-      case PartitionKeyColumns => partitionKey
-      case SomeColumns(names @ _*) => names.map {
-        case ColumnName(columnName, _) =>
-          columnByName(columnName)
-        case columnRef =>
-          throw new IllegalArgumentException(s"Invalid column reference $columnRef for table $keyspaceName.$tableName")
-      }
-    }
-  }.toIndexedSeq
 }
 
 object TableDef {

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/ColumnSelectorSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/ColumnSelectorSpec.scala
@@ -1,0 +1,42 @@
+package com.datastax.spark.connector
+
+import org.scalatest.{Matchers, WordSpec}
+
+import com.datastax.spark.connector.cql._
+import com.datastax.spark.connector.types.{TimestampType, VarCharType, IntType}
+
+class ColumnSelectorSpec extends WordSpec with Matchers {
+  "A ColumnSelector#selectFrom method" should {
+    val column1 = ColumnDef("c1", PartitionKeyColumn, IntType)
+    val column2 = ColumnDef("c2", PartitionKeyColumn, VarCharType)
+    val column3 = ColumnDef("c3", ClusteringColumn(0), VarCharType)
+    val column4 = ColumnDef("c4", ClusteringColumn(1), VarCharType)
+    val column5 = ColumnDef("c5", RegularColumn, VarCharType)
+    val column6 = ColumnDef("c6", RegularColumn, TimestampType)
+
+    val tableDef = TableDef("keyspace", "table", Seq(column1, column2), Seq(column3, column4), Seq(column5, column6))
+
+    "return all columns" in {
+      val columns = AllColumns.selectFrom(tableDef)
+      columns should equal(tableDef.columns.map(_.ref))
+    }
+
+    "return partition key columns" in {
+      val columns = PartitionKeyColumns.selectFrom(tableDef)
+      columns should equal(tableDef.partitionKey.map(_.ref))
+    }
+
+    "return some columns" in {
+      val columns = SomeColumns("c1", "c3", "c5").selectFrom(tableDef)
+      columns.map(_.columnName) should be equals Seq("c1", "c3", "c5")
+    }
+
+    "throw a NoSuchElementException when selected column name is invalid" in {
+      a[NoSuchElementException] should be thrownBy {
+        SomeColumns("c1", "c3", "unknown_column").selectFrom(tableDef)
+      }
+    }
+
+  }
+
+}

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/cql/TableDefSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/cql/TableDefSpec.scala
@@ -69,42 +69,4 @@ class TableDefSpec extends WordSpec with Matchers {
       }
     }
   }
-
-  "A TableDef#select method" should {
-    val column1 = ColumnDef("c1", PartitionKeyColumn, IntType)
-    val column2 = ColumnDef("c2", PartitionKeyColumn, VarCharType)
-    val column3 = ColumnDef("c3", ClusteringColumn(0), VarCharType)
-    val column4 = ColumnDef("c4", ClusteringColumn(1), VarCharType)
-    val column5 = ColumnDef("c5", RegularColumn, VarCharType)
-    val column6 = ColumnDef("c6", RegularColumn, TimestampType)
-
-    val tableDef = TableDef("keyspace", "table", Seq(column1, column2), Seq(column3, column4), Seq(column5, column6))
-
-    "return all columns" in {
-      val columns = tableDef.select(AllColumns)
-      columns should equal(tableDef.columns)
-    }
-
-    "return partition key columns" in {
-      val columns = tableDef.select(PartitionKeyColumns)
-      columns should equal(tableDef.partitionKey)
-    }
-
-    "return some columns" in {
-      val columns = tableDef.select(SomeColumns("c1", "c3", "c5"))
-      columns.map(_.columnName) should be equals Seq("c1", "c3", "c5")
-    }
-
-    "throw a NoSuchElementException when selected column name is invalid" in {
-      a[NoSuchElementException] should be thrownBy {
-        tableDef.select(SomeColumns("c1", "c3", "unknown_column"))
-      }
-    }
-
-    "throw an IllegalArgumentException when selected column with invalid selector, e.g. TTL" in {
-      an[IllegalArgumentException] should be thrownBy {
-        tableDef.select(SomeColumns("c1", TTL("c3")))
-      }
-    }
-  }
 }


### PR DESCRIPTION
This patch removes `select` method from `TableDef` because this method turned out to be redundant
and making a circular dependency to `ColumnSelector`. Instead of pattern matching in this method,
the proper column sequence is obtained directly in `ColumnSelector.selectFrom` method.

The exceptions have been aligned and the test cases have been moved to `ColumnSelectorSpec`.

 The case when `TableDef.select` method gets `SomeColumns` where never used but in the tests.