### PR TITLE
SPARKC-178 Fixed IT tests with external Cassandra nodes

### DIFF
--- a/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/SparkTemplate.scala
+++ b/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/SparkTemplate.scala
@@ -1,6 +1,7 @@
 package com.datastax.spark.connector.embedded
 
 import akka.actor.ActorSystem
+import com.datastax.spark.connector.embedded.EmbeddedCassandra._
 import org.apache.spark.{SparkConf, SparkContext, SparkEnv}
 
 trait SparkTemplate {
@@ -24,7 +25,9 @@ object SparkTemplate {
 
   /** Default configuration for [[org.apache.spark.SparkContext SparkContext]]. */
   val defaultConf = new SparkConf(true)
-    .set("spark.cassandra.connection.host", EmbeddedCassandra.getHost(0).getHostAddress)
+    .set("spark.cassandra.connection.host", getHost(0).getHostAddress)
+    .set("spark.cassandra.connection.native.port", getNativePort(0).toString)
+    .set("spark.cassandra.connection.rpc.port", getRpcPort(0).toString)
     .set("spark.cleaner.ttl", "3600")
     .setMaster(sys.env.getOrElse("IT_TEST_SPARK_MASTER", "local[*]"))
     .setAppName("Test")

--- a/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/CassandraJavaUtilSpec.scala
+++ b/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/CassandraJavaUtilSpec.scala
@@ -1,6 +1,7 @@
 package com.datastax.spark.connector
 
 import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.embedded.SparkTemplate._
 import com.datastax.spark.connector.embedded._
 import com.datastax.spark.connector.japi.CassandraJavaUtil
 import com.datastax.spark.connector.japi.CassandraJavaUtil._
@@ -14,7 +15,7 @@ class CassandraJavaUtilSpec extends SparkCassandraITFlatSpecBase with BeforeAndA
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultSparkConf)
 
-  val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
+  val conn = CassandraConnector(defaultConf)
 
   before {
     conn.withSessionDo { session =>

--- a/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaPairRDDSpec.scala
+++ b/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaPairRDDSpec.scala
@@ -4,6 +4,7 @@ import java.util
 
 import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
 import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.embedded.SparkTemplate._
 import com.datastax.spark.connector.embedded._
 import com.datastax.spark.connector.japi.CassandraJavaUtil._
 import org.apache.spark.api.java.function.{Function => JFunction, Function2}
@@ -18,7 +19,7 @@ class CassandraJavaPairRDDSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultSparkConf)
 
-  val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
+  val conn = CassandraConnector(defaultConf)
 
   conn.withSessionDo { session =>
     session.execute("DROP KEYSPACE IF EXISTS java_api_test")

--- a/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaRDDSpec.scala
+++ b/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaRDDSpec.scala
@@ -4,6 +4,7 @@ import java.io.IOException
 
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.embedded.SparkTemplate._
 import com.datastax.spark.connector.embedded._
 import com.datastax.spark.connector.japi.CassandraJavaUtil._
 import com.datastax.spark.connector.japi.CassandraRow
@@ -18,7 +19,7 @@ class CassandraJavaRDDSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultSparkConf)
 
-  val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
+  val conn = CassandraConnector(defaultConf)
 
   conn.withSessionDo { session =>
     session.execute("DROP KEYSPACE IF EXISTS java_api_test")

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraAuthenticatedConnectorSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraAuthenticatedConnectorSpec.scala
@@ -1,5 +1,6 @@
 package com.datastax.spark.connector.cql
 
+import com.datastax.spark.connector.embedded.SparkTemplate._
 import org.apache.spark.SparkConf
 
 import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
@@ -12,29 +13,30 @@ class CassandraAuthenticatedConnectorSpec extends SparkCassandraITFlatSpecBase {
   // Wait for the default user to be created in Cassandra.
   Thread.sleep(1000)
 
+  val conf = defaultConf
+  conf.set(DefaultAuthConfFactory.CassandraUserNameProperty, "cassandra")
+  conf.set(DefaultAuthConfFactory.CassandraPasswordProperty, "cassandra")
+
   "A CassandraConnector" should "authenticate with username and password when using native protocol" in {
-    val conn2 = CassandraConnector(
-      hosts = Set(EmbeddedCassandra.getHost(0)),
-      authConf = PasswordAuthConf("cassandra", "cassandra"))
+    val conn2 = CassandraConnector(conf)
     conn2.withSessionDo { session =>
       assert(session !== null)
       assert(session.isClosed === false)
-      assert(session.getCluster.getMetadata.getClusterName === "Test Cluster0")
+      assert(session.getCluster.getMetadata.getClusterName != null)
     }
   }
 
   it should "authenticate with username and password when using thrift" in {
-    val conn2 = CassandraConnector(
-      hosts = Set(EmbeddedCassandra.getHost(0)),
-      authConf = PasswordAuthConf("cassandra", "cassandra"))
+    val conn2 = CassandraConnector(conf)
     conn2.withCassandraClientDo { client =>
-      assert(client.describe_cluster_name() === "Test Cluster0")
+      assert(client.describe_partitioner() != null)
+      assert(client.describe_cluster_name() != null)
     }
   }
 
   it should "pick up user and password from SparkConf" in {
     val host = EmbeddedCassandra.getHost(0).getHostAddress
-    val conf = new SparkConf(loadDefaults = true)
+    val conf = defaultConf
       .set(CassandraConnectorConf.CassandraConnectionHostProperty, host)
       .set(DefaultAuthConfFactory.CassandraUserNameProperty, "cassandra")
       .set(DefaultAuthConfFactory.CassandraPasswordProperty, "cassandra")

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraConnectorSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraConnectorSpec.scala
@@ -1,6 +1,7 @@
 package com.datastax.spark.connector.cql
 
 import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
+import com.datastax.spark.connector.embedded.SparkTemplate._
 import org.apache.spark.SparkConf
 import com.datastax.spark.connector.embedded._
 
@@ -10,7 +11,7 @@ case class KeyValueWithConversion(key: String, group: Int, value: Long)
 class CassandraConnectorSpec extends SparkCassandraITFlatSpecBase {
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
-  val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
+  val conn = CassandraConnector(defaultConf)
 
   val createKeyspaceCql = "CREATE KEYSPACE IF NOT EXISTS test WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }"
 
@@ -23,13 +24,13 @@ class CassandraConnectorSpec extends SparkCassandraITFlatSpecBase {
 
   it should "connect to Cassandra with thrift" in {
     conn.withCassandraClientDo { client =>
-      assert(client.describe_cluster_name() === "Test Cluster0")
+      assert(client.describe_cluster_name() != null)
     }
   }
 
   it should "give access to cluster metadata" in {
     conn.withClusterDo { cluster =>
-      assert(cluster.getMetadata.getClusterName === "Test Cluster0")
+      assert(cluster.getMetadata.getClusterName != null)
       assert(cluster.getMetadata.getAllHosts.size > 0)
     }
   }
@@ -80,7 +81,7 @@ class CassandraConnectorSpec extends SparkCassandraITFlatSpecBase {
   }
 
   it should "share internal Cluster object between multiple logical sessions created by different connectors to the same cluster" in {
-    val conn2 = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
+    val conn2 = CassandraConnector(defaultConf)
     val session1 = conn.openSession()
     val threadCount1 = Thread.activeCount()
     val session2 = conn2.openSession()
@@ -96,8 +97,8 @@ class CassandraConnectorSpec extends SparkCassandraITFlatSpecBase {
 
   it should "be configurable from SparkConf" in {
     val host = EmbeddedCassandra.getHost(0).getHostAddress
-    val conf = new SparkConf(loadDefaults = true)
-      .set(CassandraConnectorConf.CassandraConnectionHostProperty, host)
+    val conf = defaultConf
+    conf.set(CassandraConnectorConf.CassandraConnectionHostProperty, host)
 
     // would throw exception if connection unsuccessful
     val conn2 = CassandraConnector(conf)
@@ -108,8 +109,8 @@ class CassandraConnectorSpec extends SparkCassandraITFlatSpecBase {
     val goodHost = EmbeddedCassandra.getHost(0).getHostAddress
     val invalidHost = "192.168.254.254"
     // let's connect to two addresses, of which the first one is deliberately invalid
-    val conf = new SparkConf(loadDefaults = true)
-      .set(CassandraConnectorConf.CassandraConnectionHostProperty, invalidHost + "," + goodHost)
+    val conf = defaultConf
+    conf.set(CassandraConnectorConf.CassandraConnectionHostProperty, invalidHost + "," + goodHost)
 
     // would throw exception if connection unsuccessful
     val conn2 = CassandraConnector(conf)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraPartitionKeyWhereSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraPartitionKeyWhereSpec.scala
@@ -1,6 +1,7 @@
 package com.datastax.spark.connector.cql
 
 import com.datastax.spark.connector._
+import com.datastax.spark.connector.embedded.SparkTemplate._
 import com.datastax.spark.connector.embedded._
 
 class CassandraPartitionKeyWhereSpec extends SparkCassandraITFlatSpecBase {
@@ -8,7 +9,7 @@ class CassandraPartitionKeyWhereSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultSparkConf)
 
-  val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
+  val conn = CassandraConnector(defaultConf)
 
   conn.withSessionDo { session =>
     session.execute("CREATE KEYSPACE IF NOT EXISTS where_test WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }")

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/SchemaSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/SchemaSpec.scala
@@ -3,6 +3,7 @@ package com.datastax.spark.connector.cql
 
 import com.datastax.spark.connector.SparkCassandraITWordSpecBase
 import com.datastax.spark.connector.embedded.EmbeddedCassandra
+import com.datastax.spark.connector.embedded.SparkTemplate._
 import com.datastax.spark.connector.types._
 import org.scalatest.Inspectors._
 
@@ -10,7 +11,7 @@ import org.scalatest.Inspectors._
 class SchemaSpec extends SparkCassandraITWordSpecBase {
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
-  val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
+  val conn = CassandraConnector(defaultConf)
 
   conn.withSessionDo { session =>
     session.execute(

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -3,6 +3,8 @@ package com.datastax.spark.connector.rdd
 import java.io.IOException
 import java.util.Date
 
+import com.datastax.spark.connector.embedded.SparkTemplate._
+
 import scala.reflect.runtime.universe.typeTag
 
 import org.joda.time.DateTime
@@ -49,7 +51,7 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultSparkConf)
 
-  val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
+  val conn = CassandraConnector(defaultConf)
   val bigTableRowCount = 100000
 
   private val ks = "CassandraRDDSpec"

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
@@ -2,6 +2,7 @@ package com.datastax.spark.connector.rdd
 
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.embedded.SparkTemplate._
 import com.datastax.spark.connector.embedded._
 import com.datastax.spark.connector.rdd.partitioner.EndpointPartition
 import com.datastax.spark.connector.testkit.SharedEmbeddedCassandra
@@ -27,7 +28,7 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultSparkConf)
 
-  val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
+  val conn = CassandraConnector(defaultConf)
   implicit val protocolVersion = conn.withClusterDo(_.getConfiguration.getProtocolOptions.getProtocolVersionEnum)
   private val ks = "RDDSpec"
   val tableName = "key_value"

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/repl/CassandraRDDReplSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/repl/CassandraRDDReplSpec.scala
@@ -2,13 +2,14 @@ package com.datastax.spark.connector.repl
 
 import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
 import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.embedded.SparkTemplate._
 import com.datastax.spark.connector.embedded._
 
 class CassandraRDDReplSpec extends SparkCassandraITFlatSpecBase with SparkRepl {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultSparkConf)
 
-  val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
+  val conn = CassandraConnector(defaultConf)
 
   conn.withSessionDo { session =>
     session.execute("CREATE KEYSPACE IF NOT EXISTS read_test WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }")

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
@@ -1,19 +1,21 @@
 package com.datastax.spark.connector.sql
 
+import org.apache.spark.Logging
 import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.sql.SaveMode._
 
-import org.apache.spark.sql.cassandra.{CassandraSourceOptions, TableRef, CassandraSourceRelation}
+import org.apache.spark.sql.cassandra.{TableRef, CassandraSourceRelation}
 
 import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
 import com.datastax.spark.connector.cql.CassandraConnector
-import com.datastax.spark.connector.embedded.EmbeddedCassandra
+import com.datastax.spark.connector.embedded.SparkTemplate._
+import com.datastax.spark.connector.embedded.EmbeddedCassandra._
 
-class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase {
+class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase with Logging {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultSparkConf)
 
-  val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
+  val conn = CassandraConnector(defaultConf)
   conn.withSessionDo { session =>
     session.execute("CREATE KEYSPACE IF NOT EXISTS sql_ds_test WITH REPLICATION = " +
       "{ 'class': 'SimpleStrategy', 'replication_factor': 1 }")
@@ -58,7 +60,7 @@ class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase {
         | spark_cassandra_input_page_row_size "10",
         | spark_cassandra_output_consistency_level "ONE",
         | spark_cassandra_connection_timeout_ms "1000",
-        | spark_cassandra_connection_host "127.0.0.1"
+        | spark_cassandra_connection_host "${getHost(0).getHostAddress}"
         | )
       """.stripMargin.replaceAll("\n", " "))
   }

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLClusterLevelSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLClusterLevelSpec.scala
@@ -5,14 +5,12 @@ import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.embedded.EmbeddedCassandra._
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.cassandra.CassandraSQLContext
-import org.scalatest._
 
 class CassandraSQLClusterLevelSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template", "cassandra-default.yaml.template"))
   useSparkConf(defaultSparkConf)
 
-  val conn = CassandraConnector(Set(getHost(0)))
-
+  val conn = CassandraConnector(defaultSparkConf)
   conn.withSessionDo { session =>
     session.execute("CREATE KEYSPACE IF NOT EXISTS sql_test1 WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }")
 
@@ -25,7 +23,11 @@ class CassandraSQLClusterLevelSpec extends SparkCassandraITFlatSpecBase {
     session.execute("INSERT INTO sql_test1.test1 (a, b, c) VALUES (5, 1, 5)")
   }
 
-  val conn2 = CassandraConnector(Set(getHost(1)), getNativePort(1))
+  val conf2 = new SparkConf(true)
+    .set("spark.cassandra.connection.host", getHost(1).getHostAddress)
+    .set("spark.cassandra.connection.native.port", getNativePort(1).toString)
+    .set("spark.cassandra.connection.rpc.port", getRpcPort(1).toString)
+  val conn2 = CassandraConnector(conf2)
   conn2.withSessionDo { session =>
     session.execute("CREATE KEYSPACE IF NOT EXISTS sql_test2 WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }")
 
@@ -43,15 +45,7 @@ class CassandraSQLClusterLevelSpec extends SparkCassandraITFlatSpecBase {
 
   override def beforeAll() {
     cc = new CassandraSQLContext(sc)
-    val conf1 = new SparkConf(true)
-      .set("spark.cassandra.connection.host", getHost(0).getHostAddress)
-      .set("spark.cassandra.connection.native.port", getNativePort(0).toString)
-      .set("spark.cassandra.connection.rpc.port", getRpcPort(0).toString)
-    val conf2 = new SparkConf(true)
-      .set("spark.cassandra.connection.host", getHost(1).getHostAddress)
-      .set("spark.cassandra.connection.native.port", getNativePort(1).toString)
-      .set("spark.cassandra.connection.rpc.port", getRpcPort(1).toString)
-    cc.addClusterLevelCassandraConnConf("cluster1", conf1)
+    cc.addClusterLevelCassandraConnConf("cluster1", defaultSparkConf)
       .addClusterLevelCassandraConnConf("cluster2", conf2)
       .addClusterLevelReadConf("cluster1", sc.getConf)
       .addClusterLevelWriteConf("cluster1", sc.getConf)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLSpec.scala
@@ -2,17 +2,15 @@ package com.datastax.spark.connector.sql
 
 import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
 import com.datastax.spark.connector.cql.CassandraConnector
-import com.datastax.spark.connector.embedded.{EmbeddedCassandra, SparkTemplate}
-import com.datastax.spark.connector.testkit.SharedEmbeddedCassandra
-import org.apache.spark.SparkContext
+import com.datastax.spark.connector.embedded.SparkTemplate._
+
 import org.apache.spark.sql.cassandra.CassandraSQLContext
-import org.scalatest.{ConfigMap, FlatSpec, Matchers}
 
 class CassandraSQLSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultSparkConf)
 
-  val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
+  val conn = CassandraConnector(defaultConf)
   var cc: CassandraSQLContext = null
 
   conn.withSessionDo { session =>

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/util/MultiThreadedSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/util/MultiThreadedSpec.scala
@@ -1,5 +1,6 @@
 package com.datastax.spark.connector.util
 
+import com.datastax.spark.connector.embedded.SparkTemplate._
 import com.datastax.spark.connector.{SparkCassandraITFlatSpecBase, _}
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.embedded.EmbeddedCassandra
@@ -11,7 +12,7 @@ class MultiThreadedSpec extends SparkCassandraITFlatSpecBase with AsyncAssertion
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultSparkConf)
 
-  val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
+  val conn = CassandraConnector(defaultConf)
   val count = 10000
 
   val ks = "multi_threaded"

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/GroupingBatchBuilderSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/GroupingBatchBuilderSpec.scala
@@ -1,5 +1,7 @@
 package com.datastax.spark.connector.writer
 
+import com.datastax.spark.connector.embedded.SparkTemplate._
+
 import scala.collection.JavaConversions._
 import scala.collection.immutable.Map
 import scala.util.Random
@@ -13,7 +15,7 @@ import com.datastax.spark.connector.{BatchSize, BytesInBatch, RowsInBatch, Spark
 class GroupingBatchBuilderSpec extends SparkCassandraITFlatSpecBase {
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
-  val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
+  val conn = CassandraConnector(defaultConf)
 
   private val ks = "GroupingBatchBuilder"
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/RoutingKeyGeneratorSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/RoutingKeyGeneratorSpec.scala
@@ -1,5 +1,7 @@
 package com.datastax.spark.connector.writer
 
+import com.datastax.spark.connector.embedded.SparkTemplate._
+
 import scala.collection.immutable.Map
 
 import org.apache.cassandra.dht.IPartitioner
@@ -11,7 +13,7 @@ import com.datastax.spark.connector.{CassandraRow, SparkCassandraITFlatSpecBase}
 class RoutingKeyGeneratorSpec extends SparkCassandraITFlatSpecBase {
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
-  val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
+  val conn = CassandraConnector(defaultConf)
 
   val ks = "RoutingKeyGeneratorSpec"
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterColumnNamesSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterColumnNamesSpec.scala
@@ -1,6 +1,7 @@
 package com.datastax.spark.connector.writer
 
 import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.embedded.SparkTemplate._
 import com.datastax.spark.connector.embedded._
 import com.datastax.spark.connector._
 
@@ -9,7 +10,7 @@ class TableWriterColumnNamesSpec extends SparkCassandraITAbstractSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultSparkConf)
 
-  val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
+  val conn = CassandraConnector(defaultConf)
 
   case class KeyValue(key: Int, group: Long)
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
@@ -2,6 +2,8 @@ package com.datastax.spark.connector.writer
 
 import java.io.IOException
 
+import com.datastax.spark.connector.embedded.SparkTemplate._
+
 import scala.reflect.ClassTag
 
 import com.datastax.spark.connector.mapper.{ColumnMapper, DefaultColumnMapper}
@@ -36,7 +38,7 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultSparkConf)
 
-  val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
+  val conn = CassandraConnector(defaultConf)
 
   val ks = "TableWriterSpec"
   


### PR DESCRIPTION
To test on external Cassandra nodes, export following
properties

export IT_TEST_CASSANDRA_HOSTS=192.168.123.10,127.0.0.1
export IT_TEST_CASSANDRA_RPC_PORTS=9160, 9161
export IT_TEST_CASSANDRA_NATIVE_PORTS=9042,9043