### PR TITLE
SPARKC-135 Added metastore to CassandraCatalog

### DIFF
--- a/spark-cassandra-connector/src/it/scala/org/apache/spark/sql/cassandra/CassandraDataSourceSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/org/apache/spark/sql/cassandra/CassandraDataSourceSpec.scala
@@ -1,13 +1,10 @@
-package com.datastax.spark.connector.sql
-
-import org.apache.spark.sql.{DataFrame, SQLContext}
-import org.apache.spark.sql.SaveMode._
-
-import org.apache.spark.sql.cassandra.{CassandraSourceOptions, TableRef, CassandraSourceRelation}
+package org.apache.spark.sql.cassandra
 
 import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.embedded.EmbeddedCassandra
+import org.apache.spark.sql.SaveMode._
+import org.apache.spark.sql.{DataFrame, SQLContext}
 
 class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))

--- a/spark-cassandra-connector/src/it/scala/org/apache/spark/sql/cassandra/CassandraPrunedScanSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/org/apache/spark/sql/cassandra/CassandraPrunedScanSpec.scala
@@ -1,4 +1,4 @@
-package com.datastax.spark.connector.sql
+package org.apache.spark.sql.cassandra
 
 class CassandraPrunedScanSpec extends CassandraDataSourceSpec {
   override def pushDown = false

--- a/spark-cassandra-connector/src/it/scala/org/apache/spark/sql/cassandra/CassandraSQLClusterLevelSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/org/apache/spark/sql/cassandra/CassandraSQLClusterLevelSpec.scala
@@ -1,9 +1,8 @@
-package com.datastax.spark.connector.sql
+package org.apache.spark.sql.cassandra
 
 import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.embedded.EmbeddedCassandra._
-import org.apache.spark.sql.cassandra.CassandraSQLContext
 
 class CassandraSQLClusterLevelSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template", "cassandra-default.yaml.template"))

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraCatalog.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraCatalog.scala
@@ -1,45 +1,56 @@
 package org.apache.spark.sql.cassandra
 
-import scala.collection.mutable
+import java.util.concurrent.ExecutionException
+
+import org.apache.spark.sql.cassandra.DefaultSource._
+import org.apache.spark.sql.types.StructType
+
 import java.io.IOException
 
-import com.datastax.spark.connector.cql.{CassandraConnectorConf, CassandraConnector, Schema}
 import com.google.common.cache.{LoadingCache, CacheBuilder, CacheLoader}
 import org.apache.spark.Logging
 import org.apache.spark.sql.catalyst.analysis.Catalog
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Subquery}
-import org.apache.spark.sql.sources.LogicalRelation
 
-private[cassandra] class CassandraCatalog(cc: CassandraSQLContext) extends Catalog with Logging {
+private[cassandra] class CassandraCatalog(
+      cc: CassandraSQLContext)
+      extends Catalog
+      with Logging {
 
   val caseSensitive: Boolean = true
+  val metaStore: MetaStore = new DataSourceMetaStore(cc)
 
-  /** A cache of Spark SQL data source tables that have been accessed. Cache is thread safe.*/
-  private[cassandra] val cachedDataSourceTables: LoadingCache[Seq[String], LogicalPlan] = {
+  // Create metastore keyspace and table if they don't exist
+  metaStore.init()
+
+  /**
+   * A cache of Spark SQL data source tables that have been accessed.
+   * Cache is thread safe.
+   */
+  private[cassandra] val cachedDataSourceTables:
+    LoadingCache[Seq[String], LogicalPlan] = {
     val cacheLoader = new CacheLoader[Seq[String], LogicalPlan]() {
       override def load(tableIdent: Seq[String]): LogicalPlan = {
         logDebug(s"Creating new cached data source for ${tableIdent.mkString(".")}")
-        buildRelation(tableIdent)
+        synchronized {
+          metaStore.getTable(tableRefFrom(tableIdent))
+        }
       }
     }
     CacheBuilder.newBuilder().maximumSize(1000).build(cacheLoader)
   }
 
-  override def lookupRelation(tableIdentifier: Seq[String], alias: Option[String]): LogicalPlan = {
+  override def lookupRelation(
+      tableIdentifier: Seq[String],
+      alias: Option[String]): LogicalPlan = {
     val tableIdent = fullTableIdent(tableIdentifier)
     val tableLogicPlan = cachedDataSourceTables.get(tableIdent)
     alias.map(a => Subquery(a, tableLogicPlan)).getOrElse(tableLogicPlan)
   }
 
-  /** Build logic plan from a CassandraSourceRelation */
-  private def buildRelation(tableIdentifier: Seq[String]): LogicalPlan = {
-    val (cluster, database, table) = getClusterDBTableNames(tableIdentifier)
-    val tableRef = TableRef(table, database, Option(cluster))
-    val sourceRelation = CassandraSourceRelation(tableRef, cc, CassandraSourceOptions())
-    Subquery(table, LogicalRelation(sourceRelation))
-  }
-
-  private def getClusterDBTableNames(tableIdentifier: Seq[String]): (String, String, String) = {
+  /** Return cluster, database and table names from a table identifier*/
+  private def getClusterDBTableNames(
+      tableIdentifier: Seq[String]): (String, String, String) = {
     val id = processTableIdentifier(tableIdentifier).reverse.lift
     val cluster = id(2).getOrElse(cc.getCluster)
     val database = id(1).getOrElse(cc.getKeyspace)
@@ -48,63 +59,255 @@ private[cassandra] class CassandraCatalog(cc: CassandraSQLContext) extends Catal
   }
 
   /** Return a table identifier with table name, keyspace name and cluster name */
-  private def fullTableIdent(tableIdentifier: Seq[String]) : Seq[String] = {
+  private def fullTableIdent(
+      tableIdentifier: Seq[String]) : Seq[String] = {
     val (cluster, database, table) = getClusterDBTableNames(tableIdentifier)
     Seq(cluster, database, table)
   }
 
-  override def registerTable(tableIdentifier: Seq[String], plan: LogicalPlan): Unit = {
-    cachedDataSourceTables.put(tableIdentifier, plan)
+  /**
+   * Only register table to local cache. To register table
+   * in metastore, use registerTable(tableRef, source, schema, options) method
+   */
+  override def registerTable(
+      tableIdentifier: Seq[String], plan: LogicalPlan): Unit = {
+    val tableIdent = fullTableIdent(tableIdentifier)
+    cachedDataSourceTables.put(tableIdent, plan)
+  }
+
+  /** Register a table metadata to metastore */
+  def registerTable(
+      tableRef: TableRef,
+      source: String,
+      schema: Option[StructType],
+      options: Map[String, String]): Unit = {
+    val fullOptions =
+      if (DefaultSource.cassandraSource(source)) {
+        optionsWithTableRef(tableRef, options)
+      } else {
+        options
+      }
+    synchronized {
+      metaStore.saveTable(tableRef, source, schema, fullOptions)
+    }
   }
 
   override def unregisterTable(tableIdentifier: Seq[String]): Unit = {
-    cachedDataSourceTables.invalidate(tableIdentifier)
+    val tableIdent = fullTableIdent(tableIdentifier)
+    cachedDataSourceTables.invalidate(tableIdent)
+    synchronized {
+      metaStore.removeTable(tableRefFrom(tableIdent))
+    }
+  }
+
+  /** Remove table from local cache and metastore. */
+  def unregisterTable(tableRef: TableRef): Unit = {
+    val tableIdent = Seq(
+      tableRef.cluster.getOrElse(cc.getCluster),
+      tableRef.keyspace,
+      tableRef.table)
+    cachedDataSourceTables.invalidate(tableIdent)
+    synchronized {
+      metaStore.removeTable(tableRef)
+    }
+  }
+
+  /** Unregister a database from local cache and metastore. */
+  def unregisterDatabase(
+      database: String,
+      cluster: Option[String]): Unit = {
+    unregisterDatabaseFromCache(database, cluster)
+    synchronized {
+      metaStore.removeDatabase(database, cluster)
+    }
+  }
+
+  /** Remove tables of given database from the local cache */
+  private def unregisterDatabaseFromCache(
+      database: String,
+      cluster: Option[String]): Unit = {
+    val tables = getTables(Option(database), cluster)
+    val dbAndCluster = {
+      if (cluster.nonEmpty)
+        Seq(cluster.get, database)
+      else
+        Seq(database)
+    }
+    for (table <- tables) {
+      val tableIdentifier = dbAndCluster ++ Seq(table)
+      cachedDataSourceTables.invalidate(tableIdentifier)
+    }
+  }
+
+  /** Unregister a cluster from local cache and metastore. */
+  def unregisterCluster(cluster: String): Unit = {
+    val databases = getDatabases(Option(cluster))
+    for (database <- databases) {
+      unregisterDatabaseFromCache(database, Option(cluster))
+    }
+    synchronized {
+      metaStore.removeCluster(cluster)
+    }
   }
 
   override def unregisterAllTables(): Unit = {
     cachedDataSourceTables.invalidateAll()
-  }
-
-  override def tableExists(tableIdentifier: Seq[String]): Boolean = {
-    val (cluster, database, table) = getClusterDBTableNames(tableIdentifier)
-    val schema = Schema.fromCassandra(getCassandraConnector(cluster))
-    val tabDef =
-      for (ksDef <- schema.keyspaceByName.get(database);
-           tabDef <- ksDef.tableByName.get(table)) yield tabDef
-    tabDef.nonEmpty
-  }
-
-  override def getTables(databaseName: Option[String]): Seq[(String, Boolean)] = {
-    val cluster = cc.getCluster
-    val schema = Schema.fromCassandra(getCassandraConnector(cluster))
-    if (databaseName.nonEmpty) {
-      val ksDef = schema.keyspaceByName.get(databaseName.get)
-      if (ksDef.nonEmpty) {
-        ksDef.get.tables.map(tableDef => (tableDef.tableName, false)).toSeq
-      } else {
-        Seq.empty
-      }
-    } else {
-      val tables = mutable.Set[(String, Boolean)]()
-      for (ksDef <- schema.keyspaces) {
-        tables ++= ksDef.tables.map(table => (table.tableName, false))
-      }
-      tables.toSeq
+    synchronized {
+      metaStore.removeAllTables()
     }
   }
 
-  private def getCassandraConnector(cluster: String) : CassandraConnector = {
-    val conf = cc.sparkContext.getConf.clone()
-    val sqlConf = cc.getAllConfs
-    for (prop <- CassandraConnectorConf.Properties) {
-      val clusterLevelValue = sqlConf.get(s"$cluster/$prop")
-      if (clusterLevelValue.nonEmpty)
-        conf.set(prop, clusterLevelValue.get)
+  /** Check whether table exists */
+  override def tableExists(
+      tableIdentifier: Seq[String]): Boolean = synchronized {
+    val fullTableIdentifier = fullTableIdentFrom(tableIdentifier)
+    try {
+      return cachedDataSourceTables.get(fullTableIdentifier) != null
+    } catch {
+      case e: ExecutionException =>
     }
-    new CassandraConnector(CassandraConnectorConf(conf))
+    false
   }
 
-  def refreshTable(databaseName: String, tableName: String): Unit = {
-    cachedDataSourceTables.refresh(Seq(cc.getCluster, databaseName, tableName))
+  /** Check whether table exists */
+  def tableExists(tableRef: TableRef): Boolean = synchronized {
+    tableExists(catalystTableIdentFrom(tableRef))
+  }
+
+  /** Check whether table is stored in metastore table */
+  def tableExistsInMetastore(tableRef: TableRef): Boolean = synchronized {
+    metaStore.getRegisteredTable(tableRef).nonEmpty
+  }
+
+  /** List all tables */
+  // TODO: May return DataFrame
+  override def getTables(
+      databaseName: Option[String]): Seq[(String, Boolean)] = {
+    getTables(databaseName, None)
+  }
+
+  /** List all tables for a given database name and cluster */
+  // TODO: May return DataFrame
+  def getTables(
+     databaseName: Option[String],
+     cluster: Option[String] = None): Seq[(String, Boolean)] = synchronized {
+    metaStore.getTables(databaseName, cluster)
+  }
+
+  /** List all databases for a given cluster */
+  // TODO: May return DataFrame
+  def getDatabases(
+      cluster: Option[String] = None): Seq[String] = synchronized {
+    metaStore.getDatabases(cluster)
+  }
+
+  /** List all clusters */
+  // TODO: May return DataFrame
+  def getClusters(): Seq[String] = synchronized {
+    metaStore.getClusters()
+  }
+
+  /** Create a database in metastore */
+  def createDatabase(
+      database: String,
+      cluster: Option[String]): Unit = synchronized {
+    metaStore.createDatabase(database, cluster)
+  }
+
+  /** Create a cluster in metastore */
+  def createCluster(cluster: String): Unit = synchronized {
+    metaStore.createCluster(cluster)
+  }
+
+  /**
+   * Refresh CassandraContext schema cache,
+   * then refresh table in local cache
+   */
+  def refreshTable(tableRef: TableRef): Unit = {
+    cachedDataSourceTables.refresh(catalystTableIdentFrom(tableRef))
+  }
+
+  /** Refresh table in local cache */
+  override def refreshTable(
+      databaseName: String,
+      tableName: String): Unit = {
+    refreshTable(TableRef(tableName, databaseName, Option(cc.getCluster)))
+  }
+
+  /** Return table metadata */
+  def getTableMetadata(
+      tableRef : TableRef) : Option[TableMetaData] = synchronized {
+    metaStore.getRegisteredTableMetaData(tableRef)
+  }
+
+  /** Set table schema */
+  def setTableSchema(
+      tableRef : TableRef,
+      schemaJsonString: String) : Unit = {
+    synchronized {
+      metaStore.setTableSchema(tableRef, schemaJsonString)
+    }
+    cachedDataSourceTables.refresh(catalystTableIdentFrom(tableRef))
+  }
+
+  /** Set an option of table options*/
+  def setTableOption(
+      tableRef : TableRef,
+      key: String,
+      value: String) : Unit = {
+    synchronized {
+      metaStore.setTableOption(tableRef, key, value)
+    }
+    cachedDataSourceTables.refresh(catalystTableIdentFrom(tableRef))
+  }
+
+  /** Remove an option from table options */
+  def removeTableOption(tableRef : TableRef, key: String) : Unit = {
+    synchronized {
+      metaStore.removeTableOption(tableRef, key)
+    }
+    cachedDataSourceTables.refresh(catalystTableIdentFrom(tableRef))
+  }
+
+  /** Remove table schema */
+  def removeTableSchema(tableRef : TableRef) : Unit = {
+    synchronized {
+      metaStore.removeTableSchema(tableRef)
+    }
+    cachedDataSourceTables.refresh(catalystTableIdentFrom(tableRef))
+  }
+
+  /** Convert Catalyst tableIdentifier to TableRef */
+  def tableRefFrom(tableIdentifier: Seq[String]) : TableRef = {
+    val id = processTableIdentifier(tableIdentifier).reverse.lift
+    val clusterName = id(2).getOrElse(cc.getCluster).trim
+    val keyspaceName = id(1).getOrElse(cc.getKeyspace).trim
+    val tableName = id(0).getOrElse(throw new IOException(s"Missing table name"))
+    TableRef(tableName.trim, keyspaceName, Option(clusterName))
+  }
+
+  /** Convert TableRef to Catalyst tableIdentifier */
+  def catalystTableIdentFrom(tableRef: TableRef) : Seq[String] =
+    Seq(
+      tableRef.cluster.getOrElse(cc.getCluster),
+      tableRef.keyspace,
+      tableRef.table)
+
+  private[this] def fullTableIdentFrom(
+      tableIdentifier: Seq[String]) : Seq[String] = {
+    catalystTableIdentFrom(tableRefFrom(tableIdentifier))
+  }
+
+  /** Add table names to options */
+  private def optionsWithTableRef(
+      tableRef: TableRef,
+      options: Map[String, String]) : Map[String, String] = {
+
+    Map[String, String](
+      CassandraDataSourceClusterNameProperty ->
+        tableRef.cluster.getOrElse(cc.getCluster),
+      CassandraDataSourceKeyspaceNameProperty -> tableRef.keyspace,
+      CassandraDataSourceTableNameProperty -> tableRef.table
+    ) ++ options
   }
 }

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSQLContext.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSQLContext.scala
@@ -2,14 +2,12 @@ package org.apache.spark.sql.cassandra
 
 import java.util.NoSuchElementException
 
-import org.apache.commons.lang.StringUtils
 import org.apache.spark.sql.sources.DataSourceStrategy
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.SparkContext
 import org.apache.spark.sql.catalyst.analysis.OverrideCatalog
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.{DataFrame, Strategy, SQLContext}
 
-import CassandraSQLContext._
 import CassandraSourceRelation._
 
 /** Allows to execute SQL queries against Cassandra and access results as
@@ -47,10 +45,10 @@ class CassandraSQLContext(sc: SparkContext) extends SQLContext(sc) {
   }
 
   /** Set current used database name. Database is equivalent to keyspace */
-  def setDatabase(db: String) = setKeyspace(db)
+  def useDatabase(db: String) = setKeyspace(db)
 
   /** Set current used cluster name */
-  def setCluster(cluster: String) = {
+  def useCluster(cluster: String) = {
     this.setConf(CassandraSqlClusterNameProperty, cluster)
   }
 

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/Commands.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/Commands.scala
@@ -4,12 +4,29 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.RunnableCommand
 import org.apache.spark.sql.SQLContext
 
+import Commands._
+
 /**
  * Drops a table from the metastore and removes it if it is cached.
  */
-private[cassandra] case class DropTable(tableIdentifier: Seq[String]) extends RunnableCommand {
+private[cassandra] case class DropTable(
+    tableIdentifier: Seq[String]) extends RunnableCommand {
+
   override def run(sqlContext: SQLContext) = {
-    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    val cc = cassandraSQLContext(sqlContext)
+    val tableRef = cc.catalog.tableRefFrom(tableIdentifier)
+    try {
+      //TODO OSS SPARK should be updated to use tableIdentifier
+      cc.cacheManager.tryUncacheQuery(cc.table(tableRef.table))
+    } catch {
+      // This table's metadata is not in
+      case _: org.apache.hadoop.hive.ql.metadata.InvalidTableException =>
+      // Other Throwables can be caused by users providing wrong parameters in OPTIONS
+      // (e.g. invalid paths). We catch it and log a warning message.
+      // Users should be able to drop such kinds of tables regardless if there is an error.
+      case e: Throwable => log.warn(s"${e.getMessage}")
+    }
+    cc.catalog.unregisterTable(tableRef)
     Seq.empty[Row]
   }
 }
@@ -17,17 +34,49 @@ private[cassandra] case class DropTable(tableIdentifier: Seq[String]) extends Ru
 /**
  * Rename a table from the metastore.
  */
-private[cassandra] case class RenameTable(tableIdentifier: Seq[String], newName: String) extends RunnableCommand {
+private[cassandra] case class RenameTable(
+       tableIdentifier: Seq[String],
+       newName: String) extends RunnableCommand {
+
   override def run(sqlContext: SQLContext) = {
-    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    val cc = cassandraSQLContext(sqlContext)
+    val tableRef = cc.catalog.tableRefFrom(tableIdentifier)
+    try {
+      //TODO OSS SPARK should be updated to use tableIdentifier
+      cc.cacheManager.tryUncacheQuery(cc.table(tableRef.table))
+    } catch {
+      // This table's metadata is not in
+      case _: org.apache.hadoop.hive.ql.metadata.InvalidTableException =>
+      // Other Throwables can be caused by users providing wrong parameters in OPTIONS
+      // (e.g. invalid paths). We catch it and log a warning message.
+      // Users should be able to drop such kinds of tables regardless if there is an error.
+      case e: Throwable => log.warn(s"${e.getMessage}")
+    }
+    val metadata = cc.catalog.getTableMetadata(tableRef)
+    if (metadata.nonEmpty) {
+      cc.catalog.unregisterTable(tableRef)
+      val newTableIdent =
+        TableRef(newName, tableRef.keyspace, tableRef.cluster)
+      val data = metadata.get
+      cc.catalog.registerTable(
+        newTableIdent,
+        data.source,
+        data.schema,
+        data.options)
+    }
     Seq.empty[Row]
   }
 }
 
 /** Set table schema */
-private[cassandra] case class SetTableSchema(tableIdentifier: Seq[String], schemaJsonString: String) extends RunnableCommand {
+private[cassandra] case class SetTableSchema(
+    tableIdentifier: Seq[String],
+    schemaJsonString: String) extends RunnableCommand {
+
   override def run(sqlContext: SQLContext) = {
-    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    val cc = cassandraSQLContext(sqlContext)
+    val tableRef = cc.catalog.tableRefFrom(tableIdentifier)
+    cc.catalog.setTableSchema(tableRef, schemaJsonString)
     Seq.empty[Row]
   }
 }
@@ -37,100 +86,161 @@ private[cassandra] case class SetTableOption(
     tableIdentifier: Seq[String],
     key: String,
     value: String) extends RunnableCommand {
+
   override def run(sqlContext: SQLContext) = {
-    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    val cc = cassandraSQLContext(sqlContext)
+    val tableRef = cc.catalog.tableRefFrom(tableIdentifier)
+    cc.catalog.setTableOption(tableRef, key, value)
     Seq.empty[Row]
   }
 }
 
 /** Remove an option of table options */
-private[cassandra] case class RemoveTableOption(tableIdentifier: Seq[String], key: String) extends RunnableCommand {
+private[cassandra] case class RemoveTableOption(
+    tableIdentifier: Seq[String], key: String) extends RunnableCommand {
+
   override def run(sqlContext: SQLContext) = {
-    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    val cc = cassandraSQLContext(sqlContext)
+    val tableRef = cc.catalog.tableRefFrom(tableIdentifier)
+    cc.catalog.removeTableOption(tableRef, key)
     Seq.empty[Row]
   }
 }
 
 /** Remove table schema */
-private[cassandra] case class RemoveTableSchema(tableIdentifier: Seq[String]) extends RunnableCommand {
+private[cassandra] case class RemoveTableSchema(
+    tableIdentifier: Seq[String]) extends RunnableCommand {
   override def run(sqlContext: SQLContext) = {
-    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    val cc = cassandraSQLContext(sqlContext)
+    val tableRef = cc.catalog.tableRefFrom(tableIdentifier)
+    cc.catalog.removeTableSchema(tableRef)
     Seq.empty[Row]
   }
 }
 
 /** Change the current used cluster */
-private[cassandra] case class UseCluster(cluster: String) extends RunnableCommand {
+private[cassandra] case class UseCluster(
+    cluster: String) extends RunnableCommand {
+
   override def run(sqlContext: SQLContext) = {
-    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    val cc = cassandraSQLContext(sqlContext)
+    cc.useCluster(cluster)
     Seq.empty[Row]
   }
 }
 
 /** Change the current used database */
-private[cassandra] case class UseDatabase(databaseIdentifier: Seq[String]) extends RunnableCommand {
+private[cassandra] case class UseDatabase(
+    databaseIdentifier: Seq[String]) extends RunnableCommand {
+
   override def run(sqlContext: SQLContext) = {
-    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    val cc = cassandraSQLContext(sqlContext)
+    val (clusterName, databaseName) =
+      clusterDBFrom(databaseIdentifier, cc)
+    cc.useCluster(clusterName)
+    cc.useDatabase(databaseName)
     Seq.empty[Row]
   }
 }
 
-/** Show table names for a database of a cluster */
-private[cassandra] case class ShowTables(databaseIdentifier: Seq[String]) extends RunnableCommand {
+/** List table names for a database of a cluster */
+private[cassandra] case class ShowTables(
+    databaseIdentifier: Seq[String]) extends RunnableCommand {
+
   override def run(sqlContext: SQLContext) = {
-    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
-    Seq.empty[Row]
+    val cc = cassandraSQLContext(sqlContext)
+    val (clusterName, databaseName) =
+      clusterDBFrom(databaseIdentifier, cc)
+    val tables =
+      cc.catalog.getTables(Option(databaseName), Option(clusterName))
+    tables.map(_._1).map(name => Row(name))
   }
 }
 
-/** Show database names for a cluster */
-private[cassandra] case class ShowDatabases(clusterIdentifier: Seq[String]) extends RunnableCommand {
+/** List database names for a cluster */
+private[cassandra] case class ShowDatabases(
+    clusterIdentifier: Seq[String]) extends RunnableCommand {
+
   override def run(sqlContext: SQLContext) = {
-    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
-    Seq.empty[Row]
+    val cc = cassandraSQLContext(sqlContext)
+    val id = clusterIdentifier.reverse.lift
+    val clusterName = id(0).getOrElse(cc.getCluster)
+    val databases = cc.catalog.getDatabases(Option(clusterName))
+    databases.map(name => Row(name))
   }
 }
 
-/** Show cluster names */
+/** List cluster names */
 private[cassandra] case class ShowClusters() extends RunnableCommand {
   override def run(sqlContext: SQLContext) = {
-    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
-    Seq.empty[Row]
+    val cc = cassandraSQLContext(sqlContext)
+    val clusters = cc.catalog.getClusters()
+    clusters.map(name => Row(name))
   }
 }
 
 /** Create a database in metastore */
-private[cassandra] case class CreateDatabase(databaseIdentifier: Seq[String]) extends RunnableCommand {
+private[cassandra] case class CreateDatabase(
+    databaseIdentifier: Seq[String]) extends RunnableCommand {
+
   override def run(sqlContext: SQLContext) = {
-    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
-    //cc.createDatabase(databaseName, Option(clusterName))
+    val cc = cassandraSQLContext(sqlContext)
+    val (clusterName, databaseName) =
+      clusterDBFrom(databaseIdentifier, cc)
+    cc.catalog.createDatabase(databaseName, Option(clusterName))
     Seq.empty[Row]
   }
 }
 
 /** Create a cluster in metastore */
-private[cassandra] case class CreateCluster(cluster: String) extends RunnableCommand {
+private[cassandra] case class CreateCluster(
+    cluster: String) extends RunnableCommand {
+
   override def run(sqlContext: SQLContext) = {
-    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
-    //cc.createCluster(cluster)
+    val cc = cassandraSQLContext(sqlContext)
+    cc.catalog.createCluster(cluster)
     Seq.empty[Row]
   }
 }
 
 /** Drop a database from metastore */
-private[cassandra] case class DropDatabase(databaseIdentifier: Seq[String]) extends RunnableCommand {
+private[cassandra] case class DropDatabase(
+    databaseIdentifier: Seq[String]) extends RunnableCommand {
+
   override def run(sqlContext: SQLContext) = {
-    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
-    //cc.unregisterDatabase(databaseName, Option(clusterName))
+    val cc = cassandraSQLContext(sqlContext)
+    val (clusterName, databaseName) =
+      clusterDBFrom(databaseIdentifier, cc)
+    cc.catalog.unregisterDatabase(databaseName, Option(clusterName))
     Seq.empty[Row]
   }
 }
 
 /** Drop a cluster from metastore */
-private[cassandra] case class DropCluster(cluster: String) extends RunnableCommand {
+private[cassandra] case class DropCluster(
+    cluster: String) extends RunnableCommand {
+
   override def run(sqlContext: SQLContext) = {
-    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
-    //cc.unregisterCluster(cluster)
+    val cc = cassandraSQLContext(sqlContext)
+    cc.catalog.unregisterCluster(cluster)
     Seq.empty[Row]
+  }
+}
+
+
+object Commands {
+  /** Get cluster name and database name from database identifier */
+  def clusterDBFrom(
+    databaseIdentifier: Seq[String],
+    cc: CassandraSQLContext) : (String, String) = {
+    val id = databaseIdentifier.reverse.lift
+    val clusterName = id(1).getOrElse(cc.getCluster)
+    val databaseName = id(0).getOrElse(cc.getKeyspace)
+    (clusterName, databaseName)
+  }
+
+  def cassandraSQLContext(
+      sqlContext: SQLContext) : CassandraSQLContext = {
+    sqlContext.asInstanceOf[CassandraSQLContext]
   }
 }

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/MetaStore.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/MetaStore.scala
@@ -1,0 +1,732 @@
+package org.apache.spark.sql.cassandra
+
+import org.apache.spark.Logging
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
+
+import scala.collection.mutable.ListBuffer
+
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.sources.{ResolvedDataSource, LogicalRelation}
+import org.apache.spark.sql.types.{StructType, DataType}
+
+import com.datastax.driver.core.{ResultSet, Row}
+import com.datastax.spark.connector.cql.{CassandraConnectorConf, Schema, CassandraConnector}
+
+/**
+ * Only registered table's metadata is stored in metastore's Cassandra table.
+ * Unregistered Cassandra table's logical plan is constructed directly from
+ * Cassandra table's schema.
+ *
+ * A cluster has databases/keyspaces. Keyspace is equivalent to database.
+ * A database has tables.
+ */
+trait MetaStore {
+
+  /**
+   * Get a table's logical plan. If it's not found in metastore's Cassandra
+   * table, then construct it directly from Cassandra table's schema.
+   */
+  def getTable(tableRef: TableRef) : LogicalPlan
+
+  /** Get a registered table's metadata. Return None if the table is not found 
+   * in metastore's Cassandra table.
+   */
+  def getRegisteredTableMetaData(tableRef: TableRef) : Option[TableMetaData]
+
+  /** 
+   * Get a registered table's logical plan from metastore's Cassandra table.
+   * Return None if it's not found.
+   */
+  def getRegisteredTable(tableRef: TableRef) : Option[LogicalPlan]
+
+  /**
+   * Get all table names for a keyspace. If keyspace is None,
+   * get all tables from all keyspaces.
+   */
+  def getTables(
+      keyspace: Option[String],
+      cluster: Option[String] = None) : Seq[(String, Boolean)]
+
+
+  /** Return all database names */
+  def getDatabases(cluster: Option[String] = None) : Seq[String]
+
+  /** Return all cluster names */
+  def getClusters() : Seq[String]
+
+  /** Store a registered table's metadata in metastore's Cassandra table */
+  def saveTable(
+      tableRef: TableRef,
+      source: String,
+      schema: Option[StructType],
+      options: Map[String, String]) : Unit
+
+  /** Update table Schema */
+  def setTableSchema(tableRef: TableRef, schemaJsonString: String) : Unit
+
+  /** Update table options */
+  def setTableOption(tableRef: TableRef, key: String, value: String) : Unit
+
+  /** Remove an option from table options */
+  def removeTableOption(tableRef: TableRef, key: String) : Unit
+
+  /** Remove table schema from metadata */
+  def removeTableSchema(tableRef: TableRef) : Unit
+
+  /** create a database in metastore */
+  def createDatabase(database: String, cluster: Option[String]) : Unit
+
+  /** create a cluster in metastore */
+  def createCluster(cluster: String) : Unit
+
+  /** Remove table from metastore */
+  def removeTable(tableRef: TableRef) : Unit
+
+  /** Remove a database from metastore */
+  def removeDatabase(database: String, cluster: Option[String]) : Unit
+
+  /** Remove a cluster from metastore */
+  def removeCluster(cluster: String) : Unit
+
+  /** Remove all tables from metastore */
+  def removeAllTables() : Unit
+
+  /** Create metastore keyspace and table in Cassandra */
+  def init() : Unit
+
+}
+
+class DataSourceMetaStore(sqlContext: SQLContext) extends MetaStore with Logging {
+
+  import DataSourceMetaStore._
+  import CassandraSourceRelation._
+  import CassandraSQLContext._
+  import DefaultSource._
+
+  /** Connector to Metastore's Cassandra table */
+  private val metaStoreConn = getCassandraConnector(metaStoreCluster)
+
+  private val createMetaStoreKeyspaceQuery =
+    s"""
+      |CREATE KEYSPACE IF NOT EXISTS ${metaStoreKeyspace}
+      | WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}
+    """.stripMargin.replaceAll("\n", " ")
+
+  private val createMetaStoreTableQuery =
+    s"""
+      |CREATE TABLE IF NOT EXISTS ${metaStoreTableFullName}
+      | (cluster_name text,
+      |  keyspace_name text,
+      |  table_name text,
+      |  source_provider text,
+      |  schema_json text,
+      |  options map<text, text>,
+      |  PRIMARY KEY (cluster_name, keyspace_name, table_name))
+    """.stripMargin.replaceAll("\n", " ")
+
+  private val insertTableQuery =
+    s"""
+      |INSERT INTO ${metaStoreTableFullName}
+      | (schema_json, source_provider, options,
+      |  cluster_name, keyspace_name, table_name)
+      | values (?, ?, ?, ?, ?, ?)
+    """.stripMargin.replaceAll("\n", " ")
+
+  private val insertTableWithoutSchemaQuery =
+    s"""
+      |INSERT INTO ${metaStoreTableFullName}
+      | (source_provider, options, cluster_name, keyspace_name, table_name)
+      | values (?, ?, ?, ?, ?)
+    """.stripMargin.replaceAll("\n", " ")
+
+  private val insertTableNamesOnlyQuery =
+    s"""
+      |INSERT INTO ${metaStoreTableFullName}
+      | (cluster_name, keyspace_name, table_name)
+      | values (?, ?, ?)
+    """.stripMargin.replaceAll("\n", " ")
+
+  private val deleteTableSchemaQuery =
+    s"""
+      |DELETE schema_json
+      |FROM ${metaStoreTableFullName}
+      |WHERE cluster_name = ?
+      | AND keyspace_name = ?
+      | AND table_name = ?
+    """.stripMargin.replaceAll("\n", " ")
+
+  private val deleteTableQuery =
+    s"""
+      |DELETE FROM ${metaStoreTableFullName}
+      |WHERE cluster_name = ?
+      | AND keyspace_name = ?
+      | AND table_name = ?
+    """.stripMargin.replaceAll("\n", " ")
+
+  private val updateTableOptionQuery =
+    s"""
+      |UPDATE ${metaStoreTableFullName}
+      |SET options[?] = ?
+      |WHERE cluster_name = ?
+      | AND keyspace_name = ?
+      | AND table_name = ?
+    """.stripMargin.replaceAll("\n", " ")
+
+  private val updateSchemaQuery =
+    s"""
+      |UPDATE ${metaStoreTableFullName}
+      |SET schema_json = ?
+      |WHERE cluster_name = ?
+      | AND keyspace_name = ?
+      | AND table_name = ?
+    """.stripMargin.replaceAll("\n", " ")
+
+  private val deleteTableOptionQuery =
+    s"""
+      |DELETE options[?]
+      |FROM ${metaStoreTableFullName}
+      |WHERE cluster_name = ?
+      | AND keyspace_name = ?
+      | AND table_name = ?
+    """.stripMargin.replaceAll("\n", " ")
+
+  private val selectTableMetaDataQuery =
+    s"""
+      |SELECT source_provider, schema_json, options
+      |FROM ${metaStoreTableFullName}
+      |WHERE cluster_name = ?
+      |  AND keyspace_name = ?
+      |  AND table_name = ?
+    """.stripMargin.replaceAll("\n", " ")
+
+  private val deleteClusterQuery =
+    s"""
+      |DELETE FROM ${metaStoreTableFullName}
+      |WHERE cluster_name = ?
+    """.stripMargin.replaceAll("\n", " ")
+
+  private val selectTableKeyspaceQuery =
+    s"""
+      |SELECT table_name, keyspace_name
+      |From ${metaStoreTableFullName}
+      |WHERE cluster_name = ?
+    """.stripMargin.replaceAll("\n", " ")
+
+  private val selectClusterNamesQuery =
+    s"""
+      |SELECT cluster_name
+      |From ${metaStoreTableFullName}
+    """.stripMargin.replaceAll("\n", " ")
+
+  private val selectKeyspaceNamesQuery =
+    s"""
+      |SELECT keyspace_name
+      |From ${metaStoreTableFullName}
+      |WHERE cluster_name = ?
+    """.stripMargin.replaceAll("\n", " ")
+
+  override def getTable(tableRef: TableRef): LogicalPlan = {
+      getRegisteredTable(tableRef).getOrElse(
+        getTableFromCassandraSchema(tableRef))
+  }
+
+  override def getTables(
+      keyspace: Option[String],
+      cluster: Option[String] = None): Seq[(String, Boolean)] = {
+    val clusterName = cluster.getOrElse(getCluster)
+    val names = ListBuffer[String]()
+    // Add source tables from metastore
+    val result = execute(selectTableKeyspaceQuery, clusterName).iterator()
+    while (result.hasNext) {
+      val row: Row = result.next()
+      val tableName = row.getString(0)
+      val ks = row.getString(1)
+      if (tableName != TempDBOrTableName) {
+        if (keyspace.nonEmpty && ks == keyspace.get ||
+          keyspace.isEmpty) {
+          names += tableName
+        }
+      }
+    }
+
+    // Add source tables from Cassandra tables
+    val conn = getCassandraConnector(clusterName)
+    if (keyspace.nonEmpty) {
+      val schema = Schema.fromCassandra(conn)
+      val ksDef = schema.keyspaceByName.get(keyspace.get)
+      names ++= ksDef.map(_.tableByName.keySet).getOrElse(Set.empty)
+    }
+    names.distinct.toList.map(name => (name, false))
+  }
+
+  override def getDatabases(
+      cluster: Option[String] = None): Seq[String] = {
+    val registeredDatabaseNames =
+      getRegisteredDatabases(cluster).toSet
+    val clusterName = cluster.getOrElse(getCluster)
+    // Add source tables from Cassandra tables
+    val conn = getCassandraConnector(clusterName)
+    val keyspacesFromCassandra =
+      Schema.fromCassandra(conn).keyspaceByName.keySet
+
+    (registeredDatabaseNames ++
+      keyspacesFromCassandra --
+      SystemKeyspaces).toSeq
+  }
+
+  def getRegisteredDatabases(
+      cluster: Option[String] = None): Seq[String] = {
+    val clusterName = cluster.getOrElse(getCluster)
+    val names = ListBuffer[String]()
+    // Add source tables from metastore
+    val result =
+      execute(selectKeyspaceNamesQuery, clusterName).iterator()
+    while (result.hasNext) {
+      val row: Row = result.next()
+      val keyspaceName = row.getString(0)
+      if (keyspaceName != TempDBOrTableName) {
+        names += keyspaceName
+      }
+    }
+    names.toList
+  }
+
+  override def getClusters(): Seq[String] = {
+    (getRegisteredClusters ++ Seq(getCluster)).distinct
+  }
+
+  /** Get cluster names for registered tables from metastore's Cassandra table */
+  private def getRegisteredClusters: Seq[String] = {
+    val names = ListBuffer[String]()
+    // Add source tables from metastore
+    val result = execute(selectClusterNamesQuery).iterator()
+    while (result.hasNext) {
+      val row: Row = result.next()
+      val clusterName = row.getString(0)
+      names += clusterName
+    }
+
+    names.toList
+  }
+
+  /** Save a registered tale's metadata */
+  override def saveTable(
+      tableRef: TableRef,
+      source: String,
+      schema: Option[StructType],
+      options: Map[String, String]): Unit = {
+    import collection.JavaConversions._
+
+    val cluster = tableRef.cluster.getOrElse(getCluster)
+    val keyspace = tableRef.keyspace
+    val table = tableRef.table
+    if (schema.nonEmpty) {
+      execute(
+        insertTableQuery,
+        schema.get.json,
+        source,
+        mapAsJavaMap(options),
+        cluster,
+        keyspace,
+        table)
+    } else {
+      execute(
+        insertTableWithoutSchemaQuery,
+        source,
+        mapAsJavaMap(options),
+        cluster,
+        keyspace,
+        table)
+    }
+
+    // Remove temporary database or table
+    val tempTableIdent = TableRef(
+      TempDBOrTableName,
+      TempDBOrTableName,
+      Option(cluster))
+    removeTable(tempTableIdent)
+  }
+
+  override def setTableOption(
+      tableRef: TableRef,
+      key: String,
+      value: String) : Unit = {
+    val cluster = tableRef.cluster.get
+    val keyspace = tableRef.keyspace
+    val table = tableRef.table
+    execute(
+      updateTableOptionQuery,
+      key,
+      value,
+      cluster,
+      keyspace,
+      table)
+  }
+
+  override def removeTableOption(
+      tableRef: TableRef,
+      key: String) : Unit = {
+    val cluster = tableRef.cluster.get
+    val keyspace = tableRef.keyspace
+    val table = tableRef.table
+    execute(
+      deleteTableOptionQuery,
+      key,
+      cluster,
+      keyspace,
+      table)
+  }
+
+  /** Set table schema */
+  override def setTableSchema(
+      tableRef: TableRef,
+      schemaJsonString: String) : Unit = {
+    try {
+      DataType.fromJson(schemaJsonString)
+    } catch {
+      case _: Exception =>
+        throw new RuntimeException(
+          s"$schemaJsonString is in wrong schema json string format")
+    }
+    val cluster = tableRef.cluster.get
+    val keyspace = tableRef.keyspace
+    val table = tableRef.table
+    execute(
+      updateSchemaQuery,
+      schemaJsonString,
+      cluster,
+      keyspace,
+      table)
+  }
+
+  /** Remove table schema */
+  override def removeTableSchema(tableRef: TableRef) : Unit = {
+    val cluster = tableRef.cluster.get
+    val keyspace = tableRef.keyspace
+    val table = tableRef.table
+    execute(deleteTableSchemaQuery, cluster, keyspace, table)
+  }
+
+  override def createDatabase(
+      database: String,
+      cluster: Option[String]) : Unit = {
+    val databaseNames = getRegisteredDatabases(cluster).toSet
+    if (!databaseNames.contains(database)) {
+      val clusterName = cluster.getOrElse(getCluster)
+      execute(
+        insertTableNamesOnlyQuery,
+        clusterName,
+        database,
+        TempDBOrTableName)
+    }
+  }
+
+  override def createCluster(cluster: String) : Unit = {
+    val clusterNames = getRegisteredClusters.toSet
+    if (!clusterNames.contains(cluster)) {
+      execute(
+        insertTableNamesOnlyQuery,
+        cluster,
+        TempDBOrTableName,
+        TempDBOrTableName)
+    }
+  }
+
+  override def removeTable(tableRef: TableRef) : Unit = {
+    val clusterName = tableRef.cluster.getOrElse(getCluster)
+    execute(
+      deleteTableQuery,
+      clusterName,
+      tableRef.keyspace,
+      tableRef.table)
+  }
+
+  override def removeDatabase(
+      database: String,
+      cluster: Option[String]) : Unit = {
+    val clusterName = cluster.getOrElse(getCluster)
+    val result = execute(selectTableKeyspaceQuery, clusterName).iterator()
+    while (result.hasNext) {
+      val row: Row = result.next()
+      val keyspaceName = row.getString(1)
+      if (keyspaceName == database) {
+        val tableName = row.getString(0)
+        removeTable(TableRef(tableName, keyspaceName, Option(clusterName)))
+      }
+    }
+  }
+
+  override def removeCluster(cluster: String) : Unit = {
+    execute(deleteClusterQuery, cluster)
+  }
+
+  override def removeAllTables() : Unit = {
+    metaStoreConn.withSessionDo {
+      session => session.execute(s"TRUNCATE ${metaStoreTableFullName}")
+    }
+  }
+
+  override def init() : Unit = {
+    metaStoreConn.withSessionDo {
+      session =>
+        session.execute(createMetaStoreKeyspaceQuery)
+        session.execute(createMetaStoreTableQuery)
+    }
+  }
+
+  /**
+   * Construct a logical plan for a registered table.
+   * Return None if it's not found.
+   */
+  def getRegisteredTable(tableRef: TableRef): Option[LogicalPlan] = {
+    val metadata = getRegisteredTableMetaData(tableRef)
+    if (metadata.nonEmpty) {
+      val data = metadata.get
+      val relation = ResolvedDataSource(
+        sqlContext,
+        data.schema,
+        data.source,
+        data.options)
+      Option(LogicalRelation(relation.relation))
+    } else {
+      None
+    }
+  }
+
+  override def getRegisteredTableMetaData(
+    tableRef: TableRef) : Option[TableMetaData] = {
+    val clusterName = tableRef.cluster.getOrElse(getCluster)
+    val keyspace = tableRef.keyspace
+    val table = tableRef.table
+    val result =
+      execute(selectTableMetaDataQuery, clusterName, keyspace, table)
+    if (result.isExhausted()) {
+      None
+    } else {
+      val row: Row = result.one()
+      val options : java.util.Map[String, String] =
+        row.getMap("options", classOf[String], classOf[String])
+      val schemaColumnValue = row.getString("schema_json")
+      val schemaJsonString =
+        Option(schemaColumnValue).getOrElse(
+          options.get(CassandraDataSourceUserDefinedSchemaNameProperty))
+      val schema : Option[StructType] =
+        Option(schemaJsonString)
+          .map(DataType.fromJson)
+          .map(_.asInstanceOf[StructType])
+      val source = row.getString("source_provider")
+
+      // convert to scala Map
+      import scala.collection.JavaConversions._
+      Option(TableMetaData(tableRef, source, options.toMap, schema))
+    }
+  }
+
+  /**
+   * Construct a relation directly from Cassandra table's schema.
+   * It may throw NoSuchTableException if it's not found.
+   */
+  private def getTableFromCassandraSchema(
+      tableRef: TableRef) : LogicalPlan = {
+    existInCassandra(tableRef)
+    val sourceRelation = CassandraSourceRelation(tableRef, sqlContext)
+    LogicalRelation(sourceRelation)
+  }
+
+  /** Check whether table is in Cassandra */
+  private def existInCassandra(tableRef: TableRef) : Unit = {
+    val clusterName = tableRef.cluster.getOrElse(getCluster)
+    val conn = getCassandraConnector(clusterName)
+    //Throw NoSuchTableException if table is not found in C*
+    try {
+      val schema = Schema.fromCassandra(conn)
+      val keyspace = schema.keyspaceByName(tableRef.keyspace)
+      keyspace.tableByName(tableRef.table)
+    } catch {
+      case _:NoSuchElementException => throw new NoSuchTableException
+    }
+  }
+
+  /** Create a Cassandra connector for a cluster */
+  private def getCassandraConnector(cluster: String) : CassandraConnector = {
+    val sparkConf = sqlContext.sparkContext.getConf
+    val sqlConf = sqlContext.getAllConfs
+    val conf = sparkConf.clone()
+    for (prop <- CassandraConnectorConf.Properties) {
+      val clusterLevelValue = sqlConf.get(s"$cluster/$prop")
+      if (clusterLevelValue.nonEmpty)
+        conf.set(prop, clusterLevelValue.get)
+    }
+    new CassandraConnector(CassandraConnectorConf(conf))
+  }
+
+  /** Get current used metastore's cluster name */
+  private def getCluster : String = {
+    sqlContext.conf.getConf(
+      CassandraSqlClusterNameProperty,
+      defaultClusterName)
+  }
+  /** Get metastore Cassandra table's keyspace name */
+  private def metaStoreKeyspace : String = {
+    sqlContext.conf.getConf(
+      CassandraDataSourceMetaStoreKeyspaceNameProperty,
+      DefaultCassandraDataSourceMetaStoreKeyspaceName)
+  }
+
+  /** Get metastore's Cassandra table name */
+  private def metaStoreTable : String = {
+    sqlContext.conf.getConf(
+      CassandraDataSourceMetaStoreTableNameProperty,
+      DefaultCassandraDataSourceMetaStoreTableName)
+  }
+
+  /** Get metastore Cassandra table name with keyspace name */
+  private def metaStoreTableFullName : String = {
+    s"${metaStoreKeyspace}.${metaStoreTable}"
+  }
+
+  /** Get cluster name where metastore's Cassandra table resides */
+  private def metaStoreCluster : String = {
+    sqlContext.conf.getConf(
+      CassandraDataSourceMetaStoreClusterNameProperty,
+      defaultClusterName)
+  }
+
+  private def execute(query: String) : ResultSet = {
+    metaStoreConn.withSessionDo {
+      session => session.execute(query)
+    }
+  }
+
+  private def execute(query: String, cluster: String) : ResultSet = {
+    metaStoreConn.withSessionDo {
+      session => session.execute(query, cluster)
+    }
+  }
+
+  private def execute(
+    query: String,
+    cluster: String,
+    keyspace: String,
+    table: String) : ResultSet = {
+    metaStoreConn.withSessionDo {
+      session => session.execute(query, cluster, keyspace, table)
+    }
+  }
+
+  private def execute(
+      query: String,
+      key: String,
+      value: String,
+      cluster: String,
+      keyspace: String,
+      table: String) : ResultSet = {
+    metaStoreConn.withSessionDo {
+      session =>
+        session.execute(query, key, value, cluster, keyspace, table)
+    }
+  }
+
+  private def execute(
+      query: String,
+      value: String,
+      cluster: String,
+      keyspace: String,
+      table: String) : ResultSet = {
+    metaStoreConn.withSessionDo {
+      session => session.execute(query, value, cluster, keyspace, table)
+    }
+  }
+
+  private def execute(
+      query: String,
+      source: String,
+      options: java.util.Map[String, String],
+      cluster: String,
+      keyspace: String,
+      table: String) : ResultSet = {
+    metaStoreConn.withSessionDo {
+      session =>
+        session.execute(
+          query,
+          source,
+          options,
+          cluster,
+          keyspace,
+          table)
+    }
+  }
+
+  private def execute(
+      query: String,
+      schemaJson: String,
+      source: String,
+      options: java.util.Map[String, String],
+      cluster: String,
+      keyspace: String,
+      table: String) : ResultSet = {
+    metaStoreConn.withSessionDo {
+      session =>
+        session.execute(
+          query,
+          schemaJson,
+          source,
+          options,
+          cluster,
+          keyspace,
+          table)
+    }
+  }
+}
+
+object DataSourceMetaStore {
+  val DefaultCassandraDataSourceMetaStoreKeyspaceName = "data_source_meta_store"
+  val DefaultCassandraDataSourceMetaStoreTableName = "data_source_meta_store"
+
+  val CassandraDataSourceMetaStoreClusterNameProperty =
+    "spark.cassandra.datasource.metastore.cluster";
+  val CassandraDataSourceMetaStoreKeyspaceNameProperty =
+    "spark.cassandra.datasource.metastore.keyspace";
+  val CassandraDataSourceMetaStoreTableNameProperty =
+    "spark.cassandra.datasource.metastore.table";
+
+  val Properties = Seq(
+    CassandraDataSourceMetaStoreClusterNameProperty,
+    CassandraDataSourceMetaStoreKeyspaceNameProperty,
+    CassandraDataSourceMetaStoreTableNameProperty
+  )
+
+  private val DSESystemKeyspace = "dse_system"
+  private val DSESecurityKeyspace = "dse_security"
+  private val HiveMetastoreKeyspace = "HiveMetaStore"
+  private val CFSKeyspace = "cfs"
+  private val CFSArchiveKeyspace = "cfs_archive"
+  private val CassandraSystemKeyspace = "system"
+  private val CassandraSystemTraceKeyspace = "system_traces"
+  private val CassandraSystemAuthKeyspace = "system_auth"
+
+  val SystemKeyspaces =
+    Set(
+      CassandraSystemKeyspace,
+      CassandraSystemTraceKeyspace,
+      CassandraSystemAuthKeyspace,
+      DefaultCassandraDataSourceMetaStoreKeyspaceName,
+      DSESystemKeyspace,
+      DSESecurityKeyspace,
+      HiveMetastoreKeyspace,
+      CFSKeyspace,
+      CFSArchiveKeyspace)
+
+  // This temporary entry in metastore's Cassandra table should be deleted once
+  // there are real table for the cluster is saved into metastore. It shouldn't
+  // return to client when list tables or databases.
+  val TempDBOrTableName = "TO_BE_DELETED"
+}
+
+/** Table metadata */
+case class TableMetaData(
+      tableRef: TableRef,
+      source : String,
+      options: Map[String, String],
+      schema: Option[StructType] = None)


### PR DESCRIPTION
Added a Cassandra table based metastore to
CassandraCatalog.

Metastore table schema is as following

   CREATE TABLE IF NOT EXISTS metastore_table
   (cluster_name text,
    keyspace_name text,
    table_name text,
    source_provider text,
    schema_json text,
    options map<text, text>,
    PRIMARY KEY (cluster_name, keyspace_name, table_name))

 where source_provider is the full name/short name of source
 implementation class, schema_json is the json string of
 schema, options is a map to store any table's option

 Only registered table's metadata is stored in metastore's
 Cassandra table. Unregistered Cassandra table's logical
 plan is constructed directly from Cassandra table's
 schema.

 A cluster has databases/keyspaces. Keyspace is equivalent to database.
 A database has tables.