### PR TITLE
SPARKC-137 Added Table Creation to CassandraCatalog

### DIFF
--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraCatalog.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraCatalog.scala
@@ -299,7 +299,7 @@ private[cassandra] class CassandraCatalog(
   }
 
   /** Add table names to options */
-  private def optionsWithTableRef(
+  def optionsWithTableRef(
       tableRef: TableRef,
       options: Map[String, String]) : Map[String, String] = {
 

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/Commands.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/Commands.scala
@@ -1,10 +1,137 @@
 package org.apache.spark.sql.cassandra
 
+import org.apache.spark.sql.cassandra.DefaultSource._
+import org.apache.spark.sql.catalyst.analysis.EliminateSubQueries
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.execution.RunnableCommand
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.sources.{InsertableRelation, LogicalRelation, ResolvedDataSource}
+import org.apache.spark.sql.{DataFrame, SaveMode, AnalysisException, SQLContext}
 
 import Commands._
+import org.apache.spark.sql.types.StructType
+
+
+/** Create a datasource table metadata in metastore */
+private[cassandra] case class CreateMetastoreDataSource(
+    tableName: String,
+    userSpecifiedSchema: Option[StructType],
+    provider: String,
+    options: Map[String, String],
+    allowExisting: Boolean) extends RunnableCommand {
+
+  override def run(sqlContext: SQLContext): Seq[Row] = {
+    val cc = cassandraSQLContext(sqlContext)
+    val tableRef = cc.catalog.tableRefFrom(Seq(cc.getKeyspace, tableName))
+    if (cc.catalog.tableExistsInMetastore(tableRef)) {
+      if (allowExisting) {
+        return Seq.empty[Row]
+      } else {
+        throw new AnalysisException(s"Table $tableName already exists.")
+      }
+    }
+    cc.catalog.registerTable(
+      tableRef,
+      provider,
+      userSpecifiedSchema,
+      options)
+    Seq.empty[Row]
+  }
+}
+
+/** Create a datasource table metadata in metastore for a AS Select query */
+private[cassandra] case class CreateMetastoreDataSourceAsSelect(
+    tableName: String,
+    provider: String,
+    mode: SaveMode,
+    options: Map[String, String],
+    query: LogicalPlan) extends RunnableCommand {
+
+  override def run(sqlContext: SQLContext): Seq[Row] = {
+    val cc = sqlContext.asInstanceOf[CassandraSQLContext]
+    val tableRef = cc.catalog.tableRefFrom(Seq(cc.getKeyspace, tableName))
+    var existingSchema = None: Option[StructType]
+    var createMetastoreTable = false
+    if (cc.catalog.tableExistsInMetastore(tableRef)) {
+      // Check if we need to throw an exception or just return.
+      mode match {
+        case SaveMode.ErrorIfExists =>
+          throw new AnalysisException(s"Table $tableName already exists. " +
+            s"If you are using saveAsTable, you can set SaveMode to SaveMode.Append to " +
+            s"insert data into the table or set SaveMode to SaveMode.Overwrite to overwrite" +
+            s"the existing data. " +
+            s"Or, if you are using SQL CREATE TABLE, you need to drop $tableName first.")
+        case SaveMode.Ignore =>
+          // Since the table already exists and the save mode is Ignore, we will just return.
+          return Seq.empty[Row]
+        case SaveMode.Append =>
+          // Check if the specified data source match the data source of the existing table.
+          val resolved =
+            ResolvedDataSource(sqlContext, Some(query.schema), provider, options)
+          val createdRelation = LogicalRelation(resolved.relation)
+          EliminateSubQueries(sqlContext.table(tableName).logicalPlan) match {
+            case l @ LogicalRelation(i: InsertableRelation) =>
+              if (i != createdRelation.relation) {
+                val errorDescription =
+                  s"Cannot append to table $tableName because the resolved relation does not " +
+                    s"match the existing relation of $tableName. " +
+                    s"You can use insertInto($tableName, false) to append this DataFrame to the " +
+                    s"table $tableName and using its data source and options."
+                val errorMessage =
+                  s"""
+                |$errorDescription
+                |== Relations ==
+                |${sideBySide(
+                    s"== Expected Relation ==" ::
+                      l.toString :: Nil,
+                    s"== Actual Relation ==" ::
+                      createdRelation.toString :: Nil).mkString("\n")}
+              """.stripMargin
+                throw new AnalysisException(errorMessage)
+              }
+              existingSchema = Some(l.schema)
+            case o =>
+              throw new AnalysisException(s"Saving data in ${o.toString} is not supported.")
+          }
+        case SaveMode.Overwrite =>
+          cc.sql(s"DROP TABLE $tableName")
+          // Need to create the table again.
+          createMetastoreTable = true
+      }
+    } else {
+      // The table does not exist. We need to create it in metastore.
+      createMetastoreTable = true
+    }
+
+    val data = DataFrame(cc, query)
+    val df = existingSchema match {
+      // If we are inserting into an existing table, just use the existing schema.
+      case Some(schema) => sqlContext.createDataFrame(data.queryExecution.toRdd, schema)
+      case None => data
+    }
+
+    val optionsMayWithTableIdent =
+      if(cassandraSource(provider))
+        cc.catalog.optionsWithTableRef(tableRef, options)
+      else
+        options
+    // Create the relation based on the data of df.
+    val resolved = ResolvedDataSource(sqlContext, provider, mode, optionsMayWithTableIdent, df)
+    if (createMetastoreTable) {
+      // We will use the schema of resolved.relation as the schema of the table (instead of
+      // the schema of df). It is important since the nullability may be changed by the relation
+      // provider (for example, see org.apache.spark.sql.parquet.DefaultSource).
+      cc.catalog.registerTable(
+        tableRef,
+        provider,
+        Some(resolved.relation.schema),
+        options)
+    }
+
+    Seq.empty[Row]
+  }
+}
 
 /**
  * Drops a table from the metastore and removes it if it is cached.


### PR DESCRIPTION
Added CreateTableUsing and CreateTableUsingAsSelect
function to CassandraCatalog.

Table of any source can be created and its meta
data is saved to metastore Cassandra table.

Spark SQL constructs source relation based on
source provider. Query planner uses the source
relation to access the underline data source.

Now it can join tables from any sources as along
as there is a data source implementation in the
classpath.