### PR TITLE
SPARKC-183: ClosestLiveHost should ignore localhost if down

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
@@ -122,8 +122,9 @@ class CassandraConnector(conf: CassandraConnectorConf)
     withClusterDo { cluster =>
       LocalNodeFirstLoadBalancingPolicy
         .sortNodesByProximityAndStatus(_config.hosts, cluster.getMetadata.getAllHosts.toSet)
+        .filter(_.isUp) //Remove localhost if it is down (SPARKC-183)
         .headOption
-        .getOrElse(throw new IOException("Cannot connect to Cassandra: No hosts found"))
+        .getOrElse(throw new IOException("Cannot connect to Cassandra: No live hosts found"))
     }
   }
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
@@ -121,8 +121,8 @@ class CassandraConnector(conf: CassandraConnectorConf)
   def closestLiveHost: Host = {
     withClusterDo { cluster =>
       LocalNodeFirstLoadBalancingPolicy
-        .sortNodesByProximityAndStatus(_config.hosts, cluster.getMetadata.getAllHosts.toSet)
-        .filter(_.isUp) //Remove localhost if it is down (SPARKC-183)
+        .sortNodesByStatusAndProximity(_config.hosts, cluster.getMetadata.getAllHosts.toSet)
+        .filter(_.isUp)
         .headOption
         .getOrElse(throw new IOException("Cannot connect to Cassandra: No live hosts found"))
     }


### PR DESCRIPTION
Previously we could run into a situation where the node the driver was
running on could be down and the application would not run even if a
different node was specified as the intial contact point for the
cluster. This was caused because closestLiveHost was not actually
checking liveness since it relied on sortNodesByProximityAndStatus which
would always place localhost first. This means a dead localhost would be
used before a live neighbor on the driver. This code filters out dead
nodes from the nodes returned by SortNodesByProximityAndStatus
effectively removing the chance of selecting a node which is not
actually up.