### PR TITLE
SPARKC-172: Support for Cassandra tuples

### DIFF
--- a/doc/2_loading.md
+++ b/doc/2_loading.md
@@ -187,6 +187,7 @@ The following table shows recommended Scala types corresponding to Cassandra col
 | `timeuuid`        | `java.util.UUID` 
 | `varchar`         | `String` 
 | `varint`          | `BigInt`, `java.math.BigInteger`
+| `frozen<tuple<>>` | `TupleValue`, `scala.Product`, `org.apache.commons.lang3.tuple.Pair`, `org.apache.commons.lang3.tuple.Triple`  
 | user defined      | `UDTValue`
 
 Other conversions might work, but may cause loss of precision or may not work for all values. 

--- a/spark-cassandra-connector-java/src/main/scala/com/datastax/spark/connector/japi/JavaGettableByIndexData.scala
+++ b/spark-cassandra-connector-java/src/main/scala/com/datastax/spark/connector/japi/JavaGettableByIndexData.scala
@@ -1,76 +1,80 @@
-package com.datastax.spark.connector
+package com.datastax.spark.connector.japi
 
+import java.lang.{Boolean => JBoolean, Byte => JByte, Double => JDouble, Float => JFloat, Long => JLong, Short => JShort}
+import java.math.{BigInteger, BigDecimal => JBigDecimal}
 import java.net.InetAddress
 import java.nio.ByteBuffer
-import java.util.{UUID, Date}
+import java.util.{Date, UUID, List => JList, Map => JMap, Set => JSet}
 
-import com.datastax.spark.connector.types.TypeConverter
-import com.datastax.spark.connector.types.TypeConverter.StringConverter
 import org.joda.time.DateTime
 
-trait ScalaGettableData extends ScalaGettableByIndexData with GettableData {
+import com.datastax.spark.connector.GettableByIndexData
+import com.datastax.spark.connector.types.TypeConverter
 
-  /** Converts this row to a Map */
-  def toMap: Map[String, Any] =
-    columnNames.zip(columnValues).toMap
+trait JavaGettableByIndexData extends GettableByIndexData {
 
   /** Generic getter for getting columns of any type.
-    * Looks the column up by column name. Column names are case-sensitive.*/
-  def get[T](name: String)(implicit c: TypeConverter[T]): T =
-    get[T](_indexOfOrThrow(name))
+    * Looks the column up by its index. First column starts at index 0. */
+  def get[T <: AnyRef](index: Int, tc: TypeConverter[T]): T =
+    _get(index)(tc)
+
+
+  /** Generic getter for getting columns of any type.
+    * Looks the column up by its index. First column starts at index 0. */
+  private def _get[T <: AnyRef](index: Int)(implicit tc: TypeConverter[T]): T =
+    tc.convert(columnValues(index))
+
+  /** Equivalent to `getAny` */
+  def apply(index: Int): AnyRef = getObject(index)
+
+  /** Returns a column value by index without applying any conversion.
+    * The underlying type is the same as the type returned by the low-level Cassandra driver. */
+  def getObject(index: Int) = _get[Object](index)
 
   /** Returns a `bool` column value. Besides working with `bool` Cassandra type, it can also read
     * numbers and strings. Non-zero numbers are converted to `true`, zero is converted to `false`.
     * Strings are converted using `String#toBoolean` method.*/
-  def getBoolean(name: String) = get[Boolean](name)
-  def getBooleanOption(name: String) = get[Option[Boolean]](name)
+  def getBoolean(index: Int) = _get[JBoolean](index)
 
-  def getByte(name: String) = get[Byte](name)
-  def getByteOption(name: String) = get[Option[Byte]](name)
+  def getByte(index: Int) = _get[JByte](index)
 
-  def getShort(name: String) = get[Short](name)
-  def getShortOption(name: String) = get[Option[Short]](name)
+  def getShort(index: Int) = _get[JShort](index)
 
   /** Returns a column value as a 32-bit integer number.
     * Besides working with `int` Cassandra type, it can also read
     * other integer numbers as `bigint` or `varint` and strings.
     * The string must represent a valid integer number.
     * The number must be within 32-bit integer range or the `TypeConversionException` will be thrown.*/
-  def getInt(name: String) = get[Int](name)
-  def getIntOption(name: String) = get[Option[Int]](name)
+  def getInt(index: Int) = _get[Integer](index)
 
   /** Returns a column value as a 64-bit integer number.
     * Recommended to use with `bigint` and `counter` CQL types
     * It can also read other column types as `int`, `varint`, `timestamp` and `string`.
     * The string must represent a valid integer number.
-    * The number must be within 64-bit integer range or [[com.datastax.spark.connector.types.TypeConversionException]]
+    * The number must be within 64-bit integer range or
+    * `com.datastax.spark.connector.types.TypeConversionException`
     * will be thrown. When used with timestamps, returns a number of milliseconds since epoch.*/
-  def getLong(name: String) = get[Long](name)
-  def getLongOption(name: String) = get[Option[Long]](name)
+  def getLong(index: Int) = _get[JLong](index)
 
   /** Returns a column value as Float.
     * Recommended to use with `float` CQL type.
     * This method can be also used to read a `double` or `decimal` column, with some loss of precision.*/
-  def getFloat(name: String) = get[Float](name)
-  def getFloatOption(name: String) = get[Option[Float]](name)
+  def getFloat(index: Int) = _get[JFloat](index)
 
   /** Returns a column value as Double.
     * Recommended to use with `float` and `double` CQL types.
     * This method can be also used to read a `decimal` column, with some loss of precision.*/
-  def getDouble(name: String) = get[Double](name)
-  def getDoubleOption(name: String) = get[Option[Double]](name)
+  def getDouble(index: Int) = _get[JDouble](index)
 
   /** Returns the column value converted to a `String` acceptable by CQL.
     * All data types that have human readable text representations can be converted.
     * Note, this is not the same as calling `getAny(index).toString` which works differently e.g. for dates.*/
-  def getString(name: String) = get[String](name)
-  def getStringOption(name: String) = get[Option[String]](name)
+  def getString(index: Int) = _get[String](index)
 
   /** Returns a `blob` column value as ByteBuffer.
     * This method is not suitable for reading other types of columns.
     * Columns of type `blob` can be also read as Array[Byte] with the generic `get` method. */
-  def getBytes(name: String) = get[ByteBuffer](name)
-  def getBytesOption(name: String) = get[Option[ByteBuffer]](name)
+  def getBytes(index: Int) = _get[ByteBuffer](index)
 
   /** Returns a `timestamp` or `timeuuid` column value as `java.util.Date`.
     * To convert a timestamp to one of other supported date types, use the generic `get` method,
@@ -78,69 +82,64 @@ trait ScalaGettableData extends ScalaGettableByIndexData with GettableData {
     * {{{
     *   row.get[java.sql.Date](0)
     * }}}*/
-  def getDate(name: String) = get[Date](name)
-  def getDateOption(name: String) = get[Option[Date]](name)
+  def getDate(index: Int) = _get[Date](index)
 
   /** Returns a `timestamp` or `timeuuid` column value as `org.joda.time.DateTime`. */
-  def getDateTime(name: String) = get[DateTime](name)
-  def getDateTimeOption(name: String) = get[Option[DateTime]](name)
+  def getDateTime(index: Int) = _get[DateTime](index)
 
   /** Returns a `varint` column value.
     * Can be used with all other integer types as well as
     * with strings containing a valid integer number of arbitrary size. */
-  def getVarInt(name: String) = get[BigInt](name)
-  def getVarIntOption(name: String) = get[Option[BigInt]](name)
+  def getVarInt(index: Int) = _get[BigInteger](index)
 
   /** Returns a `decimal` column value.
     * Can be used with all other floating point types as well as
     * with strings containing a valid floating point number of arbitrary precision. */
-  def getDecimal(name: String) = get[BigDecimal](name)
-  def getDecimalOption(name: String) = get[Option[BigDecimal]](name)
+  def getDecimal(index: Int) = _get[JBigDecimal](index)
 
   /** Returns an `uuid` column value.
     * Can be used to read a string containing a valid UUID.*/
-  def getUUID(name: String) = get[UUID](name)
-  def getUUIDOption(name: String) = get[Option[UUID]](name)
+  def getUUID(index: Int) = _get[UUID](index)
 
   /** Returns an `inet` column value.
     * Can be used to read a string containing a valid
     * Internet address, given either as a host name or IP address.*/
-  def getInet(name: String) = get[InetAddress](name)
-  def getInetOption(name: String) = get[Option[InetAddress]](name)
+  def getInet(index: Int) = _get[InetAddress](index)
 
   /** Returns a column value of User Defined Type */
-  def getUDTValue(name: String) = get[UDTValue](name)
-  def getUDTValueOption(name: String) = get[Option[UDTValue]](name)
+  def getUDTValue(index: Int) = _get[UDTValue](index)
 
-  /** Returns a column value of cassandra tuple type */
-  def getTupleValue(name: String) = get[TupleValue](name)
-  def getTupleValueOption(name: String) = get[Option[TupleValue]](name)
+  /** Returns a column value of tuple type */
+  def getTupleValue(index: Int) = _get[TupleValue](index)
 
   /** Reads a `list` column value and returns it as Scala `Vector`.
     * A null list is converted to an empty collection.
     * Items of the list are converted to the given type.
     * This method can be also used to read `set` and `map` column types.
-    * For `map`, the list items are converted to key-value pairs.
-    * @tparam T type of the list item, must be given explicitly. */
-  def getList[T : TypeConverter](name: String) =
-    get[Vector[T]](name)
+    * For `map`, the list items are converted to key-value pairs.*/
+  def getList(index: Int) = _get[JList[AnyRef]](index)
+
+  def getList[T](index: Int)(implicit converter: TypeConverter[T]) = _get[JList[T]](index)
 
   /** Reads a `set` column value.
     * A null set is converted to an empty collection.
     * Items of the set are converted to the given type.
     * This method can be also used to read `list` and `map` column types.
-    * For `map`, the set items are converted to key-value pairs.
-    * @tparam T type of the set item, must be given explicitly. */
-  def getSet[T : TypeConverter](name: String) =
-    get[Set[T]](name)
+    * For `map`, the set items are converted to key-value pairs. */
+  def getSet(index: Int) = _get[JSet[AnyRef]](index)
+
+  def getSet[T](index: Int)(implicit converter: TypeConverter[T]) = _get[JSet[T]](index)
+
+  /** Reads a `map` column value.
+    * A null map is converted to an empty collection.
+    * Keys and values of the map are converted to the given types. */
+  def getMap(index: Int) = _get[JMap[AnyRef, AnyRef]](index)
 
   /** Reads a `map` column value.
     * A null map is converted to an empty collection.
     * Keys and values of the map are converted to the given types.
     * @tparam K type of keys, must be given explicitly.
     * @tparam V type of values, must be given explicitly.*/
-  def getMap[K : TypeConverter, V : TypeConverter](name: String) =
-    get[Map[K, V]](name)
-
-  override def copy: ScalaGettableData = this  // this class is immutable
+  def getMap[K, V](index: Int)(implicit keyConverter: TypeConverter[K], valueConverter: TypeConverter[V]) =
+    _get[JMap[K, V]](index)
 }

--- a/spark-cassandra-connector-java/src/main/scala/com/datastax/spark/connector/japi/JavaGettableData.scala
+++ b/spark-cassandra-connector-java/src/main/scala/com/datastax/spark/connector/japi/JavaGettableData.scala
@@ -12,7 +12,7 @@ import com.datastax.spark.connector.types.TypeConverter
 import com.datastax.spark.connector.types.TypeConverter.StringConverter
 import org.joda.time.DateTime
 
-trait JavaGettableData extends GettableData {
+trait JavaGettableData extends JavaGettableByIndexData with GettableData {
 
   /** Converts this row to a Map */
   def toMap: JMap[String, AnyRef] = {
@@ -22,19 +22,9 @@ trait JavaGettableData extends GettableData {
   }
 
   /** Generic getter for getting columns of any type.
-    * Looks the column up by its index. First column starts at index 0. */
-  def get[T <: AnyRef](index: Int, tc: TypeConverter[T]): T =
-    _get(index)(tc)
-
-  /** Generic getter for getting columns of any type.
     * Looks the column up by column name. Column names are case-sensitive.*/
   def get[T <: AnyRef](name: String, tc: TypeConverter[T]): T =
     _get(name)(tc)
-
-  /** Generic getter for getting columns of any type.
-    * Looks the column up by its index. First column starts at index 0. */
-  private def _get[T <: AnyRef](index: Int)(implicit tc: TypeConverter[T]): T =
-    tc.convert(columnValues(index))
 
   /** Generic getter for getting columns of any type.
     * Looks the column up by column name. Column names are case-sensitive.*/
@@ -42,24 +32,19 @@ trait JavaGettableData extends GettableData {
     tc.convert(columnValues(_indexOfOrThrow(name)))
 
   /** Equivalent to `getAny` */
-  def apply(index: Int): AnyRef = getObject(index)
   def apply(name: String): AnyRef = getObject(name)
 
   /** Returns a column value by index without applying any conversion.
     * The underlying type is the same as the type returned by the low-level Cassandra driver. */
-  def getObject(index: Int) = _get[Object](index)
   def getObject(name: String) = _get[Object](name)
 
   /** Returns a `bool` column value. Besides working with `bool` Cassandra type, it can also read
     * numbers and strings. Non-zero numbers are converted to `true`, zero is converted to `false`.
     * Strings are converted using `String#toBoolean` method.*/
-  def getBoolean(index: Int) = _get[JBoolean](index)
   def getBoolean(name: String) = _get[JBoolean](name)
 
-  def getByte(index: Int) = _get[JByte](index)
   def getByte(name: String) = _get[JByte](name)
 
-  def getShort(index: Int) = _get[JShort](index)
   def getShort(name: String) = _get[JShort](name)
 
   /** Returns a column value as a 32-bit integer number.
@@ -67,7 +52,6 @@ trait JavaGettableData extends GettableData {
     * other integer numbers as `bigint` or `varint` and strings.
     * The string must represent a valid integer number.
     * The number must be within 32-bit integer range or the `TypeConversionException` will be thrown.*/
-  def getInt(index: Int) = _get[Integer](index)
   def getInt(name: String) = _get[Integer](name)
 
   /** Returns a column value as a 64-bit integer number.
@@ -77,31 +61,26 @@ trait JavaGettableData extends GettableData {
     * The number must be within 64-bit integer range or
     * `com.datastax.spark.connector.types.TypeConversionException`
     * will be thrown. When used with timestamps, returns a number of milliseconds since epoch.*/
-  def getLong(index: Int) = _get[JLong](index)
   def getLong(name: String) = _get[JLong](name)
 
   /** Returns a column value as Float.
     * Recommended to use with `float` CQL type.
     * This method can be also used to read a `double` or `decimal` column, with some loss of precision.*/
-  def getFloat(index: Int) = _get[JFloat](index)
   def getFloat(name: String) = _get[JFloat](name)
 
   /** Returns a column value as Double.
     * Recommended to use with `float` and `double` CQL types.
     * This method can be also used to read a `decimal` column, with some loss of precision.*/
-  def getDouble(index: Int) = _get[JDouble](index)
   def getDouble(name: String) = _get[JDouble](name)
 
   /** Returns the column value converted to a `String` acceptable by CQL.
     * All data types that have human readable text representations can be converted.
     * Note, this is not the same as calling `getAny(index).toString` which works differently e.g. for dates.*/
-  def getString(index: Int) = _get[String](index)
   def getString(name: String) = _get[String](name)
 
   /** Returns a `blob` column value as ByteBuffer.
     * This method is not suitable for reading other types of columns.
     * Columns of type `blob` can be also read as Array[Byte] with the generic `get` method. */
-  def getBytes(index: Int) = _get[ByteBuffer](index)
   def getBytes(name: String) = _get[ByteBuffer](name)
 
   /** Returns a `timestamp` or `timeuuid` column value as `java.util.Date`.
@@ -110,49 +89,42 @@ trait JavaGettableData extends GettableData {
     * {{{
     *   row.get[java.sql.Date](0)
     * }}}*/
-  def getDate(index: Int) = _get[Date](index)
   def getDate(name: String) = _get[Date](name)
 
   /** Returns a `timestamp` or `timeuuid` column value as `org.joda.time.DateTime`. */
-  def getDateTime(index: Int) = _get[DateTime](index)
   def getDateTime(name: String) = _get[DateTime](name)
 
   /** Returns a `varint` column value.
     * Can be used with all other integer types as well as
     * with strings containing a valid integer number of arbitrary size. */
-  def getVarInt(index: Int) = _get[BigInteger](index)
   def getVarInt(name: String) = _get[BigInteger](name)
 
   /** Returns a `decimal` column value.
     * Can be used with all other floating point types as well as
     * with strings containing a valid floating point number of arbitrary precision. */
-  def getDecimal(index: Int) = _get[JBigDecimal](index)
   def getDecimal(name: String) = _get[JBigDecimal](name)
 
   /** Returns an `uuid` column value.
     * Can be used to read a string containing a valid UUID.*/
-  def getUUID(index: Int) = _get[UUID](index)
   def getUUID(name: String) = _get[UUID](name)
 
   /** Returns an `inet` column value.
     * Can be used to read a string containing a valid
     * Internet address, given either as a host name or IP address.*/
-  def getInet(index: Int) = _get[InetAddress](index)
   def getInet(name: String) = _get[InetAddress](name)
 
   /** Returns a column value of User Defined Type */
-  def getUDTValue(index: Int) = _get[UDTValue](index)
   def getUDTValue(name: String) = _get[UDTValue](name)
+
+  /** Returns a column value of tuple type */
+  def getTupleValue(name: String) = _get[TupleValue](name)
 
   /** Reads a `list` column value and returns it as Scala `Vector`.
     * A null list is converted to an empty collection.
     * Items of the list are converted to the given type.
     * This method can be also used to read `set` and `map` column types.
     * For `map`, the list items are converted to key-value pairs.*/
-  def getList(index: Int) = _get[JList[AnyRef]](index)
   def getList(name: String) = _get[JList[AnyRef]](name)
-
-  def getList[T](index: Int)(implicit converter: TypeConverter[T]) = _get[JList[T]](index)
   def getList[T](name: String)(implicit converter: TypeConverter[T]) = _get[JList[T]](name)
 
   /** Reads a `set` column value.
@@ -160,16 +132,12 @@ trait JavaGettableData extends GettableData {
     * Items of the set are converted to the given type.
     * This method can be also used to read `list` and `map` column types.
     * For `map`, the set items are converted to key-value pairs. */
-  def getSet(index: Int) = _get[JSet[AnyRef]](index)
   def getSet(name: String) = _get[JSet[AnyRef]](name)
-
-  def getSet[T](index: Int)(implicit converter: TypeConverter[T]) = _get[JSet[T]](index)
   def getSet[T](name: String)(implicit converter: TypeConverter[T]) = _get[JSet[T]](name)
 
   /** Reads a `map` column value.
     * A null map is converted to an empty collection.
     * Keys and values of the map are converted to the given types. */
-  def getMap(index: Int) = _get[JMap[AnyRef, AnyRef]](index)
   def getMap(name: String) = _get[JMap[AnyRef, AnyRef]](name)
 
   /** Reads a `map` column value.
@@ -177,8 +145,6 @@ trait JavaGettableData extends GettableData {
     * Keys and values of the map are converted to the given types.
     * @tparam K type of keys, must be given explicitly.
     * @tparam V type of values, must be given explicitly.*/
-  def getMap[K, V](index: Int)(implicit keyConverter: TypeConverter[K], valueConverter: TypeConverter[V]) =
-    _get[JMap[K, V]](index)
   def getMap[K, V](name: String)(implicit keyConverter: TypeConverter[K], valueConverter: TypeConverter[V]) =
     _get[JMap[K, V]](name)
 

--- a/spark-cassandra-connector-java/src/main/scala/com/datastax/spark/connector/japi/TupleValue.scala
+++ b/spark-cassandra-connector-java/src/main/scala/com/datastax/spark/connector/japi/TupleValue.scala
@@ -1,0 +1,33 @@
+package com.datastax.spark.connector.japi
+
+import scala.annotation.varargs
+import scala.reflect.runtime.universe._
+
+import com.datastax.spark.connector.{TupleValue => ConnectorTupleValue}
+import com.datastax.spark.connector.types.{TypeConverter, NullableTypeConverter}
+
+final class TupleValue private (val columnValues: IndexedSeq[AnyRef])
+  extends JavaGettableByIndexData with Serializable
+
+
+object TupleValue {
+
+  val TupleValueTypeTag = typeTag[TupleValue]
+
+  implicit object UDTValueConverter extends NullableTypeConverter[TupleValue] {
+    def targetTypeTag = TupleValueTypeTag
+
+    def convertPF = {
+      case x: TupleValue => x
+      case x: ConnectorTupleValue =>
+        new TupleValue(x.columnValues)
+    }
+  }
+
+  TypeConverter.registerConverter(UDTValueConverter)
+
+  @varargs
+  def newTuple(values: Object*): TupleValue =
+    new TupleValue(values.toIndexedSeq)
+}
+

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/GettableByIndexData.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/GettableByIndexData.scala
@@ -1,0 +1,41 @@
+package com.datastax.spark.connector
+
+import com.datastax.spark.connector.types.TypeConverter.StringConverter
+
+trait GettableByIndexData extends Serializable {
+
+  def columnValues: IndexedSeq[AnyRef]
+
+  /** Returns a column value by index without applying any conversion.
+    * The underlying type is the same as the type returned by the low-level Cassandra driver,
+    * is implementation defined and may change in the future.
+    * Cassandra nulls are returned as Scala nulls. */
+  def getRaw(index: Int): AnyRef = columnValues(index)
+
+  /** Total number of columns in this row. Includes columns with null values. */
+  def length = columnValues.size
+
+  /** Total number of columns in this row. Includes columns with null values. */
+  def size = columnValues.size
+
+  /** Returns true if column value is Cassandra null */
+  def isNullAt(index: Int): Boolean =
+    columnValues(index) == null
+  
+  /** Displays the content in human readable form, including the names and values of the columns */
+  def dataAsString: String =
+    columnValues
+      .map(StringConverter.convert)
+      .mkString("(", ", ", ")")
+
+  override def toString =
+    dataAsString
+
+  override def equals(o: Any): Boolean = o match {
+    case that: GettableByIndexData if this.columnValues == that.columnValues => true
+    case _ => false
+  }
+
+  override def hashCode: Int =
+    columnValues.hashCode()
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ScalaGettableByIndexData.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ScalaGettableByIndexData.scala
@@ -4,40 +4,40 @@ import java.net.InetAddress
 import java.nio.ByteBuffer
 import java.util.{UUID, Date}
 
-import com.datastax.spark.connector.types.TypeConverter
-import com.datastax.spark.connector.types.TypeConverter.StringConverter
 import org.joda.time.DateTime
 
-trait ScalaGettableData extends ScalaGettableByIndexData with GettableData {
+import com.datastax.spark.connector.types.TypeConverter
 
-  /** Converts this row to a Map */
-  def toMap: Map[String, Any] =
-    columnNames.zip(columnValues).toMap
+trait ScalaGettableByIndexData extends GettableByIndexData {
 
   /** Generic getter for getting columns of any type.
-    * Looks the column up by column name. Column names are case-sensitive.*/
-  def get[T](name: String)(implicit c: TypeConverter[T]): T =
-    get[T](_indexOfOrThrow(name))
+    * Looks the column up by its index. First column starts at index 0. */
+  def get[T](index: Int)(implicit c: TypeConverter[T]): T =
+    c.convert(columnValues(index)) match {
+      case null => throw new NullPointerException(
+        "Unexpected null value of column " + index + ". Use get[Option[...]] to receive null values.")
+      case notNull => notNull
+    }
 
   /** Returns a `bool` column value. Besides working with `bool` Cassandra type, it can also read
     * numbers and strings. Non-zero numbers are converted to `true`, zero is converted to `false`.
     * Strings are converted using `String#toBoolean` method.*/
-  def getBoolean(name: String) = get[Boolean](name)
-  def getBooleanOption(name: String) = get[Option[Boolean]](name)
+  def getBoolean(index: Int) = get[Boolean](index)
+  def getBooleanOption(index: Int) = get[Option[Boolean]](index)
 
-  def getByte(name: String) = get[Byte](name)
-  def getByteOption(name: String) = get[Option[Byte]](name)
+  def getByte(index: Int) = get[Byte](index)
+  def getByteOption(index: Int) = get[Option[Byte]](index)
 
-  def getShort(name: String) = get[Short](name)
-  def getShortOption(name: String) = get[Option[Short]](name)
+  def getShort(index: Int) = get[Short](index)
+  def getShortOption(index: Int) = get[Option[Short]](index)
 
   /** Returns a column value as a 32-bit integer number.
     * Besides working with `int` Cassandra type, it can also read
     * other integer numbers as `bigint` or `varint` and strings.
     * The string must represent a valid integer number.
     * The number must be within 32-bit integer range or the `TypeConversionException` will be thrown.*/
-  def getInt(name: String) = get[Int](name)
-  def getIntOption(name: String) = get[Option[Int]](name)
+  def getInt(index: Int) = get[Int](index)
+  def getIntOption(index: Int) = get[Option[Int]](index)
 
   /** Returns a column value as a 64-bit integer number.
     * Recommended to use with `bigint` and `counter` CQL types
@@ -45,32 +45,32 @@ trait ScalaGettableData extends ScalaGettableByIndexData with GettableData {
     * The string must represent a valid integer number.
     * The number must be within 64-bit integer range or [[com.datastax.spark.connector.types.TypeConversionException]]
     * will be thrown. When used with timestamps, returns a number of milliseconds since epoch.*/
-  def getLong(name: String) = get[Long](name)
-  def getLongOption(name: String) = get[Option[Long]](name)
+  def getLong(index: Int) = get[Long](index)
+  def getLongOption(index: Int) = get[Option[Long]](index)
 
   /** Returns a column value as Float.
     * Recommended to use with `float` CQL type.
     * This method can be also used to read a `double` or `decimal` column, with some loss of precision.*/
-  def getFloat(name: String) = get[Float](name)
-  def getFloatOption(name: String) = get[Option[Float]](name)
+  def getFloat(index: Int) = get[Float](index)
+  def getFloatOption(index: Int) = get[Option[Float]](index)
 
   /** Returns a column value as Double.
     * Recommended to use with `float` and `double` CQL types.
     * This method can be also used to read a `decimal` column, with some loss of precision.*/
-  def getDouble(name: String) = get[Double](name)
-  def getDoubleOption(name: String) = get[Option[Double]](name)
+  def getDouble(index: Int) = get[Double](index)
+  def getDoubleOption(index: Int) = get[Option[Double]](index)
 
   /** Returns the column value converted to a `String` acceptable by CQL.
     * All data types that have human readable text representations can be converted.
     * Note, this is not the same as calling `getAny(index).toString` which works differently e.g. for dates.*/
-  def getString(name: String) = get[String](name)
-  def getStringOption(name: String) = get[Option[String]](name)
+  def getString(index: Int) = get[String](index)
+  def getStringOption(index: Int) = get[Option[String]](index)
 
   /** Returns a `blob` column value as ByteBuffer.
     * This method is not suitable for reading other types of columns.
     * Columns of type `blob` can be also read as Array[Byte] with the generic `get` method. */
-  def getBytes(name: String) = get[ByteBuffer](name)
-  def getBytesOption(name: String) = get[Option[ByteBuffer]](name)
+  def getBytes(index: Int) = get[ByteBuffer](index)
+  def getBytesOption(index: Int) = get[Option[ByteBuffer]](index)
 
   /** Returns a `timestamp` or `timeuuid` column value as `java.util.Date`.
     * To convert a timestamp to one of other supported date types, use the generic `get` method,
@@ -78,43 +78,43 @@ trait ScalaGettableData extends ScalaGettableByIndexData with GettableData {
     * {{{
     *   row.get[java.sql.Date](0)
     * }}}*/
-  def getDate(name: String) = get[Date](name)
-  def getDateOption(name: String) = get[Option[Date]](name)
+  def getDate(index: Int) = get[Date](index)
+  def getDateOption(index: Int) = get[Option[Date]](index)
 
   /** Returns a `timestamp` or `timeuuid` column value as `org.joda.time.DateTime`. */
-  def getDateTime(name: String) = get[DateTime](name)
-  def getDateTimeOption(name: String) = get[Option[DateTime]](name)
+  def getDateTime(index: Int) = get[DateTime](index)
+  def getDateTimeOption(index: Int) = get[Option[DateTime]](index)
 
   /** Returns a `varint` column value.
     * Can be used with all other integer types as well as
     * with strings containing a valid integer number of arbitrary size. */
-  def getVarInt(name: String) = get[BigInt](name)
-  def getVarIntOption(name: String) = get[Option[BigInt]](name)
+  def getVarInt(index: Int) = get[BigInt](index)
+  def getVarIntOption(index: Int) = get[Option[BigInt]](index)
 
   /** Returns a `decimal` column value.
     * Can be used with all other floating point types as well as
     * with strings containing a valid floating point number of arbitrary precision. */
-  def getDecimal(name: String) = get[BigDecimal](name)
-  def getDecimalOption(name: String) = get[Option[BigDecimal]](name)
+  def getDecimal(index: Int) = get[BigDecimal](index)
+  def getDecimalOption(index: Int) = get[Option[BigDecimal]](index)
 
   /** Returns an `uuid` column value.
     * Can be used to read a string containing a valid UUID.*/
-  def getUUID(name: String) = get[UUID](name)
-  def getUUIDOption(name: String) = get[Option[UUID]](name)
+  def getUUID(index: Int) = get[UUID](index)
+  def getUUIDOption(index: Int) = get[Option[UUID]](index)
 
   /** Returns an `inet` column value.
     * Can be used to read a string containing a valid
     * Internet address, given either as a host name or IP address.*/
-  def getInet(name: String) = get[InetAddress](name)
-  def getInetOption(name: String) = get[Option[InetAddress]](name)
+  def getInet(index: Int) = get[InetAddress](index)
+  def getInetOption(index: Int) = get[Option[InetAddress]](index)
 
   /** Returns a column value of User Defined Type */
-  def getUDTValue(name: String) = get[UDTValue](name)
-  def getUDTValueOption(name: String) = get[Option[UDTValue]](name)
+  def getUDTValue(index: Int) = get[UDTValue](index)
+  def getUDTValueOption(index: Int) = get[Option[UDTValue]](index)
 
   /** Returns a column value of cassandra tuple type */
-  def getTupleValue(name: String) = get[TupleValue](name)
-  def getTupleValueOption(name: String) = get[Option[TupleValue]](name)
+  def getTupleValue(index: Int) = get[TupleValue](index)
+  def getTupleValueOption(index: Int) = get[Option[TupleValue]](index)
 
   /** Reads a `list` column value and returns it as Scala `Vector`.
     * A null list is converted to an empty collection.
@@ -122,8 +122,8 @@ trait ScalaGettableData extends ScalaGettableByIndexData with GettableData {
     * This method can be also used to read `set` and `map` column types.
     * For `map`, the list items are converted to key-value pairs.
     * @tparam T type of the list item, must be given explicitly. */
-  def getList[T : TypeConverter](name: String) =
-    get[Vector[T]](name)
+  def getList[T : TypeConverter](index: Int) =
+    get[Vector[T]](index)
 
   /** Reads a `set` column value.
     * A null set is converted to an empty collection.
@@ -131,16 +131,18 @@ trait ScalaGettableData extends ScalaGettableByIndexData with GettableData {
     * This method can be also used to read `list` and `map` column types.
     * For `map`, the set items are converted to key-value pairs.
     * @tparam T type of the set item, must be given explicitly. */
-  def getSet[T : TypeConverter](name: String) =
-    get[Set[T]](name)
+  def getSet[T : TypeConverter](index: Int) =
+    get[Set[T]](index)
 
   /** Reads a `map` column value.
     * A null map is converted to an empty collection.
     * Keys and values of the map are converted to the given types.
     * @tparam K type of keys, must be given explicitly.
     * @tparam V type of values, must be given explicitly.*/
-  def getMap[K : TypeConverter, V : TypeConverter](name: String) =
-    get[Map[K, V]](name)
+  def getMap[K : TypeConverter, V : TypeConverter](index: Int) =
+    get[Map[K, V]](index)
 
-  override def copy: ScalaGettableData = this  // this class is immutable
+  def copy: ScalaGettableByIndexData = this  // this class is immutable
+
+  def iterator = columnValues.iterator
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/TupleValue.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/TupleValue.scala
@@ -1,0 +1,31 @@
+package com.datastax.spark.connector
+
+import scala.reflect.runtime.universe._
+
+import com.datastax.driver.core.{ProtocolVersion, TupleValue => DriverTupleValue}
+import com.datastax.spark.connector.types.NullableTypeConverter
+
+final case class TupleValue(values: Any*) extends ScalaGettableByIndexData {
+  override def columnValues = values.toIndexedSeq.map(_.asInstanceOf[AnyRef])
+}
+
+object TupleValue {
+
+  def fromJavaDriverTupleValue
+      (value: DriverTupleValue)
+      (implicit protocolVersion: ProtocolVersion): TupleValue = {
+    val values =
+      for (i <- 0 until value.getType.getComponentTypes.size()) yield
+        GettableData.get(value, i)
+    new TupleValue(values: _*)
+  }
+
+  val TupleValueTypeTag = typeTag[TupleValue]
+
+  implicit object TupleValueConverter extends NullableTypeConverter[TupleValue] {
+    def targetTypeTag = TupleValueTypeTag
+    def convertPF = {
+      case x: TupleValue => x
+    }
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/UDTValue.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/UDTValue.scala
@@ -6,10 +6,8 @@ import scala.reflect.runtime.universe._
 import com.datastax.driver.core.{ProtocolVersion, UDTValue => DriverUDTValue}
 import com.datastax.spark.connector.types.NullableTypeConverter
 
-final class UDTValue(val columnNames: IndexedSeq[String], val columnValues: IndexedSeq[AnyRef])
-  extends ScalaGettableData with Serializable {
-
-}
+final case class UDTValue(columnNames: IndexedSeq[String], columnValues: IndexedSeq[AnyRef])
+  extends ScalaGettableData
 
 object UDTValue {
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TupleType.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TupleType.scala
@@ -1,0 +1,124 @@
+package com.datastax.spark.connector.types
+
+
+import java.io.ObjectOutputStream
+
+import scala.collection.JavaConversions._
+import scala.reflect.runtime.universe._
+
+import org.apache.commons.lang3.tuple.{Triple, Pair}
+
+import com.datastax.driver.core.{TupleValue => DriverTupleValue, TupleType => DriverTupleType, ProtocolVersion, DataType}
+
+import com.datastax.spark.connector.{TupleValue, ColumnName}
+import com.datastax.spark.connector.cql.{FieldDef, StructDef}
+
+case class TupleFieldDef(index: Int, columnType: ColumnType[_]) extends FieldDef {
+  override def columnName = index.toString
+  override lazy val ref = ColumnName(columnName)
+}
+
+/** A type representing typed tuples.
+  * A tuple consists of a sequence of values.
+  * Every value is identified by its 0-based position.
+  * Every value can be of a different type. */
+case class TupleType(componentTypes: TupleFieldDef*)
+    extends StructDef with ColumnType[TupleValue] {
+
+  override type Column = TupleFieldDef
+
+  for ((c, i) <- componentTypes.zipWithIndex) {
+    if (c.index != i)
+      throw new IllegalArgumentException(s"Invalid tuple component index: ${c.index}. Expected: $i")
+  }
+
+  override def columns = componentTypes.toIndexedSeq
+
+  override def scalaTypeTag = TupleValue.TupleValueTypeTag
+
+  override def isCollection = false
+
+  /** Creates new tuple from components converted each to the
+    * type determined by an appropriate componentType.
+    * Throws IllegalArgumentException if the number of components does
+    * not match the number of components in the tuple type. */
+  def newTuple(componentValues: Any*): TupleValue = {
+    require(
+      componentValues.length == columns.length,
+      s"Expected ${columns.length} components, instead of ${componentValues.length}")
+    val values =
+      for (i <- columns.indices) yield
+        columnTypes(i).converterToCassandra.convert(componentValues(i))
+    new TupleValue(values: _*)
+  }
+
+  override def converterToCassandra =  new TypeConverter[TupleValue] {
+    override def targetTypeTag = TupleValue.TupleValueTypeTag
+    override def convertPF = {
+      case x: TupleValue =>
+        newTuple(x.columnValues: _*)
+      case x: Product =>                                // converts from Scala tuples
+        newTuple(x.productIterator.toIndexedSeq: _*)
+      case x: Pair[_, _] =>                             // Java programmers may like this
+        newTuple(x.getLeft, x.getRight)
+      case x: Triple[_, _, _] =>                        // Java programmers may like this
+        newTuple(x.getLeft, x.getMiddle, x.getRight)
+    }
+  }
+
+  override def cqlTypeName = {
+    val types = columnTypes.map(_.cqlTypeName)
+    s"frozen<tuple<${types.mkString(", ")}>>"
+  }
+
+  override def name = cqlTypeName
+
+}
+
+object TupleType {
+
+  /** Converts connector's UDTValue to Cassandra Java Driver UDTValue.
+    * Used when saving data to Cassandra.  */
+  class DriverTupleValueConverter(dataType: DriverTupleType)(implicit protocolVersion: ProtocolVersion)
+    extends TypeConverter[DriverTupleValue] {
+
+    val fieldTypes = dataType.getComponentTypes
+    val fieldConverters = fieldTypes.map(ColumnType.converterToCassandra)
+
+    override def targetTypeTag =
+      TypeTag.synchronized { typeTag[DriverTupleValue] }
+
+    override def convertPF = {
+      case tupleValue: TupleValue =>
+        val toSave = dataType.newValue()
+        for (i <- 0 until fieldTypes.size) {
+          val fieldConverter = fieldConverters(i)
+          val fieldValue = fieldConverter.convert(tupleValue.getRaw(i))
+          val fieldType = fieldTypes(i)
+          val serialized =
+            if (fieldValue != null) fieldType.serialize(fieldValue, protocolVersion)
+            else null
+          toSave.setBytesUnsafe(i, serialized)
+        }
+        toSave
+    }
+
+    // Fortunately we ain't gonna need serialization, because this TypeConverter is used only on the
+    // write side and instantiated separately on each executor node.
+    private def writeObject(oos: ObjectOutputStream): Unit =
+      throw new UnsupportedOperationException(
+        this.getClass.getName + " does not support serialization, because the " +
+          "required underlying " + classOf[DataType].getName + " is not Serializable.")
+
+  }
+
+  def driverTupleValueConverter(dataType: DataType)(implicit protocolVersion: ProtocolVersion): TypeConverter[_] = {
+    dataType match {
+      case dt: DriverTupleType => new DriverTupleValueConverter(dt)
+      case _ => throw new IllegalArgumentException(s"${classOf[DriverTupleType]} expected.")
+    }
+  }
+}
+
+
+

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/Symbols.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/Symbols.scala
@@ -3,6 +3,8 @@ package com.datastax.spark.connector.util
 import scala.collection.immutable.{TreeMap, TreeSet}
 import scala.reflect.runtime.universe._
 
+import org.apache.commons.lang3.tuple
+
 object Symbols {
   val OptionSymbol = typeOf[Option[Any]].asInstanceOf[TypeRef].sym
   val ListSymbol = typeOf[List[Any]].asInstanceOf[TypeRef].sym
@@ -21,6 +23,9 @@ object Symbols {
   val JavaHashSetSymbol = typeOf[java.util.HashSet[Any]].asInstanceOf[TypeRef].sym
   val JavaMapSymbol = typeOf[java.util.Map[Any, Any]].asInstanceOf[TypeRef].sym
   val JavaHashMapSymbol = typeOf[java.util.HashMap[Any, Any]].asInstanceOf[TypeRef].sym
+
+  val PairSymbol = typeOf[tuple.Pair[Any, Any]].asInstanceOf[TypeRef].sym
+  val TripleSymbol = typeOf[tuple.Triple[Any, Any, Any]].asInstanceOf[TypeRef].sym
 
   val ListSymbols = Set(
     ListSymbol, VectorSymbol, SeqSymbol, IndexedSeqSymbol, IterableSymbol,

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/TypeConverterTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/TypeConverterTest.scala
@@ -310,6 +310,25 @@ class TypeConverterTest {
   }
 
   @Test
+  def testPair(): Unit = {
+    val scalaPair = (1, 2)
+    val converter = TypeConverter.forType[org.apache.commons.lang3.tuple.Pair[Int, String]]
+    val commonsPair = converter.convert(scalaPair)
+    assertEquals(1, commonsPair.getLeft)
+    assertEquals("2", commonsPair.getRight)
+  }
+
+  @Test
+  def testTriple(): Unit = {
+    val scalaTriple = (1, 2, 3)
+    val converter = TypeConverter.forType[org.apache.commons.lang3.tuple.Triple[Int, String, Long]]
+    val commonsTriple = converter.convert(scalaTriple)
+    assertEquals(1, commonsTriple.getLeft)
+    assertEquals("2", commonsTriple.getMiddle)
+    assertEquals(3L, commonsTriple.getRight)
+  }
+
+  @Test
   def testOptionToNullConverter() {
     val c = new TypeConverter.OptionToNullConverter(TypeConverter.IntConverter)
     assertEquals(1.asInstanceOf[AnyRef], c.convert(Some(1)))


### PR DESCRIPTION
This ticket introduces a new TupleValue class for storing Cassandra
tuples. Because tuples don't have named components, we moved all
the "by-index" getters out of GettableData to a new
GettableByIndex trait, implemented by TupleValue. TupleValue serves
the same purpose as Java Driver TupleValue class, but contrary to
that class, it is Serializable and hooks into the TypeConverter system
so it supports specific Scala types. An analogue TupleValue class
has been introduced in the Java API.

TupleValues can be nested in CassandraRows, UDTValues or other
TupleValues. In order to get TupleValues from  CassandraRows or
UDTValues, a new method getTupleValue has been added to the
ScalaGettableData,  ScalaGettableByIndexData, JavaGettableData and
JavaGettableByIndexData.

Direct mapping from Cassandra tuples to Scala tuples is also
supported for reads only. For this feature to work,
GettableDataToMappedTypeConverter needed two improvements: (1)
understanding fields described by any StructDef not just
UserDefinedType and (2) reading data by-index from GettableByIndexData
objects.