### PR TITLE
SPARKC-194: Remove underlines from Cassandra DataSource options.

### DIFF
--- a/doc/14_data_frames.md
+++ b/doc/14_data_frames.md
@@ -18,10 +18,10 @@ Those followed with a default of N/A are required, all others are optional.
 
 | Option Key  | Controls                                              | Values        | Default  |
 |-------------|-------------------------------------------------------|---------------|----------|
-| c_table     | The Cassandra Table to connect to                     | String        | N/A      |
-| keyspace    | The Keyspace where c_table is looked for              | String        | N/A      |
+| table       | The Cassandra Table to connect to                     | String        | N/A      |
+| keyspace    | The Keyspace where table is looked for                | String        | N/A      |
 | cluster     | The group of the Cluster Level Settings to inherit    | String        | "default"|
-| push_down   | Enables pushing down predicates to C* when applicable | (true,false)  | true     |
+| pushdown    | Enables pushing down predicates to C* when applicable | (true,false)  | true     |
 
 ####Read, Writing and CassandraConnector Options
 Any normal Spark Connector configuration options for Connecting, Reading or Writing
@@ -47,18 +47,18 @@ val conf = new SparkConf()
 
 val df = sqlContext.load(
   "org.apache.spark.sql.cassandra", 
-   options = Map( "c_table" -> "words", "keyspace" -> "test" 
+   options = Map( "table" -> "words", "keyspace" -> "test" 
 )// This DataFrame will use a spark.cassandra.input.size of 5000
 
 val otherdf =  sqlContext.load(
   "org.apache.spark.sql.cassandra", 
-   options = Map( "c_table" -> "words", "keyspace" -> "test" , "cluster" -> "ClusterOne" )
+   options = Map( "table" -> "words", "keyspace" -> "test" , "cluster" -> "ClusterOne" )
 )// This DataFrame will use a spark.cassandra.input.size of 1000
 
 val lastdf = sqlContext.load(
                "org.apache.spark.sql.cassandra", 
                 options = Map( 
-                  "c_table" -> "words", 
+                  "table" -> "words", 
                   "keyspace" -> "test" ,
                   "cluster" -> "ClusterOne",
                   "spark.cassandra.input.split.size" -> 500
@@ -76,7 +76,7 @@ Example Creating a DataFrame using a Load Command
 ```scala
 val df = sqlContext.load(
   "org.apache.spark.sql.cassandra", 
-   options = Map( "c_table" -> "words", "keyspace" -> "test" )
+   options = Map( "table" -> "words", "keyspace" -> "test" )
    )
 df.show
 //word count
@@ -90,9 +90,9 @@ Accessing data Frames using Spark SQL involves creating temporary tables and spe
 source as `org.apache.spark.sql.cassandra`. The `OPTIONS` passed to this table are used to
 establish a relation between the CassandraTable and the internally used DataSource.
 
-Because of a limitation in SparkSQL, SparkSQL `OPTIONS` must have their
-`.` characters replaced with `_`. This means `spark.cassandra.input.split.size` becomes 
-`spark_cassandra_input_split_size`. 
+Because of a limitation in SparkSQL 1.4.0 DDL parser, SparkSQL `OPTIONS` 
+do not accept "." and "_" characters in option names, so options containing these 
+characters can be only set in the `SparkConf` or `SQLConf` objects.
 
 Example Creating a Source Using Spark SQL:
 ```scala
@@ -101,14 +101,11 @@ scala> sqlContext.sql(
    """CREATE TEMPORARY TABLE words 
      |USING org.apache.spark.sql.cassandra 
      |OPTIONS ( 
-     |  c_table "words",
+     |  table "words",
      |  keyspace "test", 
      |  cluster "Test Cluster", 
-     |  push_down "true", 
-     |  spark_cassandra_input_page_row_size "10", 
-     |  spark_cassandra_output_consistency_level "ONE", 
-     |  spark_cassandra_connection_timeout_ms "1000" 
-     |  )""".stripMargin)
+     |  pushdown "true" 
+     |)""".stripMargin)
 scala> val df = sqlContext.sql("SELECT * FROM words")
 scala> df.show()
 //word count
@@ -134,11 +131,11 @@ Example Copying Between Two Tables Using DataFrames
 ```scala
 val df = sqlContext.load(
   "org.apache.spark.sql.cassandra", 
-  options = Map( "c_table" -> "words", "keyspace" -> "test" )
+  options = Map( "table" -> "words", "keyspace" -> "test" )
 )
 
 df.save(
   "org.apache.spark.sql.cassandra",
-  options = Map( "c_table" -> "words_copy", "keyspace" -> "test")
+  options = Map( "table" -> "words_copy", "keyspace" -> "test")
 )
 ```

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSpec.scala
@@ -56,7 +56,7 @@ class CassandraDataFrameSpec extends SparkCassandraITFlatSpecBase {
     val df = sqlContext.load(
       "org.apache.spark.sql.cassandra",
       Map(
-        "c_Table" -> "kv",
+        "table" -> "kv",
         "keyspace" -> keyspace
       )
     )
@@ -68,7 +68,7 @@ class CassandraDataFrameSpec extends SparkCassandraITFlatSpecBase {
       val df = sqlContext.load(
         "org.apache.spark.sql.cassandra",
         Map(
-          "c_Table" -> "randomtable",
+          "table" -> "randomtable",
           "keyspace" -> keyspace
         )
       )
@@ -81,7 +81,7 @@ class CassandraDataFrameSpec extends SparkCassandraITFlatSpecBase {
       val df = sqlContext.load(
         "org.apache.spark.sql.cassandra",
         Map(
-          "c_Table" -> "hardertoremembertablename",
+          "table" -> "hardertoremembertablename",
           "keyspace" -> keyspace
         )
       )

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
@@ -52,14 +52,9 @@ class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase {
         |CREATE TEMPORARY TABLE $tmpTable
         |USING org.apache.spark.sql.cassandra
         |OPTIONS (
-        | c_table "$table",
+        | table "$table",
         | keyspace "$keyspace",
-        | push_down "$pushDown",
-        | spark_cassandra_input_page_row_size "10",
-        | spark_cassandra_output_consistency_level "ONE",
-        | spark_cassandra_connection_timeout_ms "1000",
-        | spark_cassandra_connection_host "127.0.0.1"
-        | )
+        | pushdown "$pushDown")
       """.stripMargin.replaceAll("\n", " "))
   }
 
@@ -101,7 +96,7 @@ class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase {
     sqlContext.sql("SELECT a, b from tmpTable").save(
       "org.apache.spark.sql.cassandra",
       ErrorIfExists,
-      Map("c_table" -> "test_insert1", "keyspace" -> "sql_ds_test"))
+      Map("table" -> "test_insert1", "keyspace" -> "sql_ds_test"))
 
     cassandraTable(TableRef("test_insert1", "sql_ds_test")).collect() should have length 1
 
@@ -109,7 +104,7 @@ class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase {
       sqlContext.sql("SELECT a, b from tmpTable").save(
         "org.apache.spark.sql.cassandra",
         ErrorIfExists,
-        Map("c_table" -> "test_insert1", "keyspace" -> "sql_ds_test"))
+        Map("table" -> "test_insert1", "keyspace" -> "sql_ds_test"))
     }.getMessage
 
     assert(
@@ -127,7 +122,7 @@ class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase {
     sqlContext.sql("SELECT a, b from tmpTable").save(
       "org.apache.spark.sql.cassandra",
       Overwrite,
-      Map("c_table" -> "test_insert2", "keyspace" -> "sql_ds_test"))
+      Map("table" -> "test_insert2", "keyspace" -> "sql_ds_test"))
     createTempTable("sql_ds_test", "test_insert2", "insertTable2")
     sqlContext.sql("SELECT * FROM insertTable2").collect() should have length 1
     sqlContext.dropTempTable("insertTable2")

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/DefaultSource.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/DefaultSource.scala
@@ -23,10 +23,10 @@ import DefaultSource._
  *      CREATE TEMPORARY TABLE tmpTable
  *      USING org.apache.spark.sql.cassandra
  *      OPTIONS (
- *       c_table "table",
+ *       table "table",
  *       keyspace "keyspace",
  *       cluster "test_cluster",
- *       push_down "true",
+ *       pushdown "true",
  *       spark_cassandra_input_page_row_size "10",
  *       spark_cassandra_output_consistency_level "ONE",
  *       spark_cassandra_connection_timeout_ms "1000"
@@ -38,10 +38,10 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
    * Creates a new relation for a cassandra table.
    * The parameters map stores table level data. User can specify vale for following keys
    *
-   *    c_table        -- table name, required
+   *    table        -- table name, required
    *    keyspace       -- keyspace name, required
    *    cluster        -- cluster name, optional, default name is "default"
-   *    push_down      -- true/false, optional, default is true
+   *    pushdown      -- true/false, optional, default is true
    *    Cassandra connection settings  -- optional, e.g. spark_cassandra_connection_timeout_ms
    *    Cassandra Read Settings        -- optional, e.g. spark_cassandra_input_page_row_size
    *    Cassandra Write settings       -- optional, e.g. spark_cassandra_output_consistency_level
@@ -106,11 +106,11 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
 case class CassandraSourceOptions(pushdown: Boolean = true, cassandraConfs: Map[String, String] = Map.empty)
 
 object DefaultSource {
-  val CassandraDataSourceTableNameProperty = "c_table"
+  val CassandraDataSourceTableNameProperty = "table"
   val CassandraDataSourceKeyspaceNameProperty = "keyspace"
   val CassandraDataSourceClusterNameProperty = "cluster"
   val CassandraDataSourceUserDefinedSchemaNameProperty = "schema"
-  val CassandraDataSourcePushdownEnableProperty = "push_down"
+  val CassandraDataSourcePushdownEnableProperty = "pushdown"
   val CassandraDataSourceProviderPackageName = DefaultSource.getClass.getPackage.getName
   val CassandraDataSourceProviderClassName = CassandraDataSourceProviderPackageName + ".DefaultSource"
 


### PR DESCRIPTION
Renamed c_table to table.
Renamed push_down to pushdown.
The reason for this is that, probably due to a bug, Spark 1.4.0 does not accept underlines in data source options.