### PR TITLE
SPARKC-125: Allow aliases to be used with tuples

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,6 +23,8 @@
    - added support for Filter and Expression predicates
    - improved code testability and added unit-tests
  * Basic Datasource API integration and keyspace/cluster level settings (SPARKC-112, SPARKC-162)
+ * Added support to use aliases with Tuples (SPARKC-125)
+********************************************************************************
 
 ********************************************************************************
 

--- a/doc/5_saving.md
+++ b/doc/5_saving.md
@@ -37,6 +37,26 @@ collection.saveToCassandra("test", "words", SomeColumns("word", "count"))
 
     (4 rows)
    
+Using a custom mapper is also supported with tuples
+
+```sql
+CREATE TABLE test.words (word text PRIMARY KEY, count int);
+```
+
+```scala
+val collection = sc.parallelize(Seq((30, "cat"), (40, "fox")))
+collection.saveToCassandra("test", "words", SomeColumns("word" as "_2", "count" as "_1"))
+```
+    
+    cqlsh:test> select * from words;
+
+     word | count
+    ------+-------
+      cat |    30
+      fox |    40
+
+    (2 rows)
+
 ## Saving a collection of objects
 When saving a collection of objects of a user-defined class, the items to be saved
 must provide appropriately named public property accessors for getting every column


### PR DESCRIPTION
Currently there is no way to specify only certain elements of a tuple
in a column mapper for savingToCassandra or for using
partitionByCassandraReplica. This patch allows usage of the "as" syntax
to also apply to tuple field names "_1" ,"_2" so if a tuple was provdied
like (int,int,int,int) one could specify "Pkey" as "_3", "ckey" as "_2"