### PR TITLE
SPARKC-147: Modify C* collections from Spark

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,8 @@
    - Cassandra listen addresses fetched from system.peers table
    - spark.cassandra.connection.(rpc|native).port replaced with spark.cassandra.connection.port
  * Refactored ColumnSelector to avoid circular dependency on TableDef (SPARKC-177)
+ * Support for modifying C* Collections using saveToCassandra (SPARKC-147)
+
 
 1.3.0 M1
  * Removed use of Thrift describe_ring and replaced it with native Java Driver

--- a/doc/5_saving.md
+++ b/doc/5_saving.md
@@ -97,6 +97,70 @@ val collection = sc.parallelize(Seq(WordCount("dog", 50), WordCount("cow", 60)))
 collection.saveToCassandra("test", "words2", SomeColumns("word", "num" as "count"))
 ```
 
+## Modifying CQL Collections
+The default behavior of the Spark Cassandra Connector is to overwrite collections when inserted into
+a cassandra table. To override this behavior you can specify a custom mapper with instructions on
+how you would like the collection to be treated.
+
+The following operations are supported
+
+- append/add  (lists, sets, maps)
+- prepend (lists)
+- remove  (lists, sets)
+- overwrite (lists, sets, maps) :: Default
+
+Remove is not supported for Maps.
+
+These are applied by adding the desired behavior to the ColumnSelector
+
+Example Usage
+
+Takes the elements from rddSetField and removes them from corrosponding C* column
+"a_set" and takes elements from "rddMapField" and adds them to C* column "a_map" where C*
+column key == key in the RDD elements. 
+   
+    ("key", "a_set" as "rddSetField" remove , "a_map" as "rddMapField" append)
+
+
+Example Schema
+
+```sql
+CREATE TABLE ks.collections_mod (
+      key int PRIMARY KEY,
+      lcol list<text>,
+      mcol map<text, text>,
+      scol set<text>
+  )
+```
+
+Example Appending/Prepending Lists
+
+```scala
+val listElements = sc.parallelize(Seq(
+  (1,Vector("One")),
+  (1,Vector("Two")),
+  (1,Vector("Three"))))
+
+val prependElements = sc.parallelize(Seq(
+  (1,Vector("PrependOne")),
+  (1,Vector("PrependTwo")),
+  (1,Vector("PrependThree"))))
+
+listElements.saveToCassandra("ks", "collections_mod", SomeColumns("key", "lcol" append))
+prependElements.saveToCassandra("ks", "collections_mod", SomeColumns("key", "lcol" prepend))
+```
+
+```sql
+cqlsh> Select * from ks.collections_mod where key = 1
+   ... ;
+
+ key | lcol                                                                | mcol | scol
+-----+---------------------------------------------------------------------+------+------
+   1 | ['PrependThree', 'PrependTwo', 'PrependOne', 'One', 'Two', 'Three'] | null | null
+
+(1 rows)
+```
+
 ## Saving objects of Cassandra User Defined Types
 To save structures consisting of many fields, use `com.datastax.spark.connector.UDTValue`
 class. An instance of this class can be easily obtained from a Scala `Map` by calling `fromMap`

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
@@ -48,6 +48,7 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase {
 
     session.execute(s"""CREATE TABLE IF NOT EXISTS "$ks".nulls (key INT PRIMARY KEY, text_value TEXT, int_value INT)""")
     session.execute(s"""CREATE TABLE IF NOT EXISTS "$ks".collections (key INT PRIMARY KEY, l list<text>, s set<text>, m map<text, text>)""")
+    session.execute(s"""CREATE TABLE IF NOT EXISTS "$ks".collections_mod (key INT PRIMARY KEY, lcol list<text>, scol set<text>, mcol map<text, text>)""")
     session.execute(s"""CREATE TABLE IF NOT EXISTS "$ks".blobs (key INT PRIMARY KEY, b blob)""")
     session.execute(s"""CREATE TABLE IF NOT EXISTS "$ks".counters (pkey INT, ckey INT, c1 counter, c2 counter, PRIMARY KEY (pkey, ckey))""")
     session.execute(s"""CREATE TABLE IF NOT EXISTS "$ks".counters2 (pkey INT PRIMARY KEY, c counter)""")
@@ -557,6 +558,123 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase {
     val col = Seq(KeyValueWithTransient(1, 1L, "value1", "a"), KeyValueWithTransient(2, 2L, "value2", "b"), KeyValueWithTransient(3, 3L, "value3", "c"))
     sc.parallelize(col).saveToCassandra(ks, "key_value_19")
     verifyKeyValueTable("key_value_19")
+  }
+
+  it should "be able to append and prepend elements to a C* list" in {
+
+    val listElements = sc.parallelize(Seq(
+      (1, Vector("One")),
+      (1, Vector("Two")),
+      (1, Vector("Three"))))
+
+    val prependElements = sc.parallelize(Seq(
+      (1, Vector("PrependOne")),
+      (1, Vector("PrependTwo")),
+      (1, Vector("PrependThree"))))
+
+    listElements.saveToCassandra(ks, "collections_mod", SomeColumns("key", "lcol" append))
+    prependElements.saveToCassandra(ks, "collections_mod", SomeColumns("key", "lcol" prepend))
+
+    val testList = sc.cassandraTable[(Seq[String])](ks, "collections_mod")
+      .where("key = 1")
+      .select("lcol").take(1)(0)
+    testList.take(3) should contain allOf("PrependOne", "PrependTwo", "PrependThree")
+    testList.drop(3) should contain allOf("One", "Two", "Three")
+  }
+
+  it should "be able to remove elements from a C* list " in {
+    val listElements = sc.parallelize(Seq(
+      (2, Vector("One")),
+      (2, Vector("Two")),
+      (2, Vector("Three"))))
+    listElements.saveToCassandra(ks, "collections_mod", SomeColumns("key", "lcol" append))
+
+    sc.parallelize(Seq(
+      (2, Vector("Two")),
+      (2, Vector("Three"))))
+      .saveToCassandra(ks, "collections_mod", SomeColumns("key", "lcol" remove))
+
+    val testList = sc.cassandraTable[(Seq[String])](ks, "collections_mod")
+      .where("key = 2")
+      .select("lcol").take(1)(0)
+    testList should contain noneOf("Two", "Three")
+    testList should contain("One")
+  }
+
+  it should "be able to add elements to a C* set " in {
+    val setElements = sc.parallelize(Seq(
+      (3, Set("One")),
+      (3, Set("Two")),
+      (3, Set("Three"))))
+    setElements.saveToCassandra(ks, "collections_mod", SomeColumns("key", "scol" append))
+    val testSet = sc.cassandraTable[(Set[String])](ks, "collections_mod")
+      .where("key = 3")
+      .select("scol").take(1)(0)
+
+    testSet should contain allOf("One", "Two", "Three")
+  }
+
+  it should "be able to remove elements from a C* set" in {
+    val setElements = sc.parallelize(Seq(
+      (4, Set("One")),
+      (4, Set("Two")),
+      (4, Set("Three"))))
+    setElements.saveToCassandra(ks, "collections_mod", SomeColumns("key", "scol" append))
+
+    sc.parallelize(Seq((4, Set("Two")), (4, Set("Three"))))
+      .saveToCassandra(ks, "collections_mod", SomeColumns("key", "scol" remove))
+
+    val testSet = sc.cassandraTable[(Set[String])](ks, "collections_mod")
+      .where("key = 4")
+      .select("scol").take(1)(0)
+
+    testSet should contain noneOf("Two", "Three")
+    testSet should contain("One")
+  }
+
+  it should "be able to add key value pairs to a C* map" in {
+    val setElements = sc.parallelize(Seq(
+      (5, Map("One" -> "One")),
+      (5, Map("Two" -> "Two")),
+      (5, Map("Three" -> "Three"))))
+    setElements.saveToCassandra(ks, "collections_mod", SomeColumns("key", "mcol" append))
+
+    val testMap = sc.cassandraTable[(Map[String, String])](ks, "collections_mod")
+      .where("key = 5")
+      .select("mcol").take(1)(0)
+
+    testMap.toSeq should contain allOf(("One", "One"), ("Two", "Two"), ("Three", "Three"))
+  }
+
+  it should "throw an exception if you try to apply a collection behavior to a normal column" in {
+    val col = Seq((1, 1L, "value1"), (2, 2L, "value2"), (3, 3L, "value3"))
+    val e = intercept[IllegalArgumentException] {
+      sc.parallelize(col).saveToCassandra(ks, "key_value_1", SomeColumns("key", "group"
+        overwrite, "value"))
+    }
+    e.getMessage should include("group")
+  }
+
+  it should "throw an exception if you try to remove values from a map" in {
+    val setElements = sc.parallelize(Seq(
+      (5, Map("One" -> "One")),
+      (5, Map("Two" -> "Two")),
+      (5, Map("Three" -> "Three"))))
+    val e = intercept[IllegalArgumentException] {
+      setElements.saveToCassandra(ks, "collections_mod", SomeColumns("key", "mcol" remove))
+    }
+    e.getMessage should include("mcol")
+  }
+
+  it should "throw an exception if you prepend anything but a list" in {
+    val setElements = sc.parallelize(Seq(
+      (5, Map("One" -> "One"), Set("One"))))
+    val e = intercept[IllegalArgumentException] {
+      setElements.saveToCassandra(ks, "collections_mod", SomeColumns("key", "mcol" prepend,
+        "scol" prepend))
+    }
+    e.getMessage should include("mcol")
+    e.getMessage should include("scol")
   }
 
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ColumnRef.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ColumnRef.scala
@@ -24,6 +24,14 @@ sealed trait ColumnRef  {
   def cqlValueName: String
 }
 
+/** Insert behaviors for Collections. */
+sealed trait CollectionBehavior
+case object CollectionOverwrite extends CollectionBehavior
+case object CollectionAppend extends CollectionBehavior
+case object CollectionPrepend extends CollectionBehavior
+case object CollectionRemove extends CollectionBehavior
+
+
 /** References a column by name. */
 case class ColumnName(columnName: String, alias: Option[String] = None) extends ColumnRef {
   override val cql = s""""$columnName""""
@@ -31,7 +39,33 @@ case class ColumnName(columnName: String, alias: Option[String] = None) extends 
   override def selectedAs = alias.getOrElse(columnName)
   override def toString: String = columnName
 
+  def overwrite = CollectionColumnName(columnName, alias, CollectionOverwrite)
+  def add = CollectionColumnName(columnName, alias, CollectionAppend)
+  def append = CollectionColumnName(columnName, alias, CollectionAppend)
+  def prepend = CollectionColumnName(columnName, alias, CollectionPrepend)
+  def remove = CollectionColumnName(columnName, alias, CollectionRemove)
+
   def as(alias: String) = copy(alias = Some(alias))
+}
+
+/** References a collection column by name with insert instructions */
+case class CollectionColumnName(
+    columnName: String,
+    alias: Option[String] = None,
+    collectionBehavior: CollectionBehavior = CollectionOverwrite) extends ColumnRef {
+
+  override val cql = s""""$columnName""""
+  override def cqlValueName = columnName
+  override def selectedAs = alias.getOrElse(columnName)
+  override def toString: String = columnName
+
+  def as(alias: String) = copy(alias = Some(alias))
+
+  def overwrite = copy(collectionBehavior = CollectionOverwrite)
+  def add = copy(collectionBehavior = CollectionAppend)
+  def append = copy(collectionBehavior = CollectionAppend)
+  def prepend = copy(collectionBehavior = CollectionPrepend)
+  def remove = copy(collectionBehavior = CollectionRemove)
 }
 
 /** References TTL of a column. */

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/GettableDataToMappedTypeConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/GettableDataToMappedTypeConverter.scala
@@ -119,10 +119,10 @@ private[connector] class GettableDataToMappedTypeConverter[T : TypeTag : ColumnM
   /** Returns the type of the column, basing on the struct definition. */
   private def columnType(columnRef: ColumnRef): ColumnType[_] = {
     columnRef match {
-      case ColumnName(columnName, _) =>
-        structDef.columnByName(columnName).columnType
       case TTL(_, _) | WriteTime(_, _) | RowCountRef =>
         BigIntType
+      case c:ColumnRef =>
+        structDef.columnByName(c.columnName).columnType
     }
   }
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -2,6 +2,7 @@ package com.datastax.spark.connector.writer
 
 import java.io.IOException
 
+import com.datastax.spark.connector.types.{MapType, ListType, ColumnType}
 import org.apache.spark.metrics.OutputMetricsUpdater
 
 import com.datastax.driver.core.BatchStatement.Type
@@ -21,6 +22,7 @@ import scala.collection._
 class TableWriter[T] private (
     connector: CassandraConnector,
     tableDef: TableDef,
+    columnSelector: IndexedSeq[ColumnRef],
     rowWriter: RowWriter[T],
     writeConf: WriteConf) extends Serializable with Logging {
 
@@ -67,8 +69,23 @@ class TableWriter[T] private (
     val (primaryKey, regularColumns) = columns.partition(_.isPrimaryKeyColumn)
     val (counterColumns, nonCounterColumns) = regularColumns.partition(_.isCounterColumn)
 
+    val nameToBehavior = (columnSelector collect {
+        case cn:CollectionColumnName => cn.columnName -> cn.collectionBehavior
+      }).toMap
+
+    val setNonCounterColumnsClause = for {
+      colDef <- nonCounterColumns
+      name = colDef.columnName
+      collectionBehavior = nameToBehavior.get(name)
+      quotedName = quote(name)
+    } yield collectionBehavior match {
+        case Some(CollectionAppend)           => s"$quotedName = $quotedName + :$quotedName"
+        case Some(CollectionPrepend)          => s"$quotedName = :$quotedName + $quotedName"
+        case Some(CollectionRemove)           => s"$quotedName = $quotedName - :$quotedName"
+        case Some(CollectionOverwrite) | None => s"$quotedName = :$quotedName"
+      }
+
     def quotedColumnNames(columns: Seq[ColumnDef]) = columns.map(_.columnName).map(quote)
-    val setNonCounterColumnsClause = quotedColumnNames(nonCounterColumns).map(c => s"$c = :$c")
     val setCounterColumnsClause = quotedColumnNames(counterColumns).map(c => s"$c = $c + :$c")
     val setClause = (setNonCounterColumnsClause ++ setCounterColumnsClause).mkString(", ")
     val whereClause = quotedColumnNames(primaryKey).map(c => s"$c = :$c").mkString(" AND ")
@@ -79,8 +96,11 @@ class TableWriter[T] private (
   private val isCounterUpdate =
     tableDef.columns.exists(_.isCounterColumn)
 
+  private val containsCollectionBehaviors =
+    columnSelector.exists(_.isInstanceOf[CollectionColumnName])
+
   private val queryTemplate: String = {
-    if (isCounterUpdate)
+    if (isCounterUpdate || containsCollectionBehaviors)
       queryTemplateUsingUpdate
     else
       queryTemplateUsingInsert
@@ -151,11 +171,6 @@ class TableWriter[T] private (
 
 object TableWriter {
 
-  private def checkColumns(table: TableDef, columnNames: Seq[String]) = {
-    checkMissingColumns(table, columnNames)
-    checkMissingPrimaryKeyColumns(table, columnNames)
-  }
-
   private def checkMissingColumns(table: TableDef, columnNames: Seq[String]) {
     val allColumnNames = table.columns.map(_.columnName)
     val missingColumns = columnNames.toSet -- allColumnNames
@@ -170,6 +185,73 @@ object TableWriter {
     if (missingPrimaryKeyColumns.nonEmpty)
       throw new IllegalArgumentException(
         s"Some primary key columns are missing in RDD or have not been selected: ${missingPrimaryKeyColumns.mkString(", ")}")
+  }
+
+  /**
+   * Check whether a collection behavior is being applied to a non collection column
+   * Check whether prepend is used on any Sets or Maps
+   * Check whether remove is used on Maps
+   */
+  private def checkCollectionBehaviors(table: TableDef, columnRefs: IndexedSeq[ColumnRef]) {
+    val tableCollectionColumns = table.columns.filter(cd => cd.isCollection)
+    val tableCollectionColumnNames = tableCollectionColumns.map(_.columnName)
+    val tableListColumnNames = tableCollectionColumns
+      .map(c => (c.columnName, c.columnType))
+      .collect { case (name, x: ListType[_]) => name }
+
+    val tableMapColumnNames = tableCollectionColumns
+      .map(c => (c.columnName, c.columnType))
+      .collect { case (name, x: MapType[_, _]) => name }
+
+    val refsWithCollectionBehavior = columnRefs collect {
+      case columnName: CollectionColumnName => columnName
+    }
+
+    val collectionBehaviorColumnNames = refsWithCollectionBehavior.map(_.columnName)
+
+    //Check for non-collection columns with a collection Behavior
+    val collectionBehaviorNormalColumn =
+      collectionBehaviorColumnNames.toSet -- tableCollectionColumnNames.toSet
+
+    if (collectionBehaviorNormalColumn.nonEmpty)
+      throw new IllegalArgumentException(
+        s"""Collection behaviors (add/remove/append/prepend) are only allowed on collection columns.
+           |Normal Columns with illegal behavior: ${collectionBehaviorNormalColumn.mkString}"""
+          .stripMargin
+      )
+
+    //Check that prepend is used only on lists
+    val prependBehaviorColumnNames = refsWithCollectionBehavior
+      .filter(_.collectionBehavior == CollectionPrepend)
+      .map(_.columnName)
+    val prependOnNonList = prependBehaviorColumnNames.toSet -- tableListColumnNames.toSet
+
+    if (prependOnNonList.nonEmpty)
+      throw new IllegalArgumentException(
+        s"""The prepend collection behavior only applies to Lists. Prepend used on:
+           |${prependOnNonList.mkString}""".stripMargin
+      )
+
+    //Check that remove is not used on Maps
+
+    val removeBehaviorColumnNames = refsWithCollectionBehavior
+      .filter(_.collectionBehavior == CollectionRemove)
+      .map(_.columnName)
+
+    val removeOnMap = removeBehaviorColumnNames.toSet & tableMapColumnNames.toSet
+
+    if (removeOnMap.nonEmpty)
+      throw new IllegalArgumentException(
+        s"The remove operation is currently not supported for Maps. Remove used on: ${removeOnMap
+          .mkString}"
+      )
+  }
+
+  private def checkColumns(table: TableDef, columnRefs: IndexedSeq[ColumnRef]) = {
+    val columnNames = columnRefs.map(_.columnName)
+    checkMissingColumns(table, columnNames)
+    checkMissingPrimaryKeyColumns(table, columnNames)
+    checkCollectionBehaviors(table, columnRefs)
   }
 
   def apply[T : RowWriterFactory](
@@ -187,8 +269,8 @@ object TableWriter {
     val rowWriter = implicitly[RowWriterFactory[T]].rowWriter(
       tableDef.copy(regularColumns = tableDef.regularColumns ++ optionColumns),
       selectedColumns ++ optionColumns.map(_.ref))
-    
-    checkColumns(tableDef, selectedColumns.map(_.columnName))
-    new TableWriter[T](connector, tableDef, rowWriter, writeConf)
+
+    checkColumns(tableDef, selectedColumns)
+    new TableWriter[T](connector, tableDef, selectedColumns, rowWriter, writeConf)
   }
 }


### PR DESCRIPTION
Previously all statements with collections were treated as overwrites
limiting user's abiilty to modify collections in batch. This patch
provides new options within the ColumnMapper api to allow

- Appending (Lists)
- Prepending (Lists)
- Adding (Sets, Maps, Lists)
- Removing (Lists, Sets)

Removal of elements from maps is currenlty not supported as it would
require much more complicated syntax wrangiling and will be left for a
later ticket if anyone desires the functionality.

To accomplish this a new ColumnRef was created CollectionColumnRef
which contains one additional element CollectionBehavior. TableWriter
now directly takes the ColumnSelector so that it can access these
ColumnBehvaiors when crafting the CQL to do the update.