### PR TITLE
SPARKC-206: Tuples support in Java API

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,7 +10,7 @@
  * Refactored ColumnSelector to avoid circular dependency on TableDef (SPARKC-177)
  * Support for modifying C* Collections using saveToCassandra (SPARKC-147)
  * Add the abilty to use Custom Mappers with repartitionByCassandraReplica (SPARKC-104)
-
+ * Add methods to work with tuples in Java API (SPARKC-206)
 
 
 1.3.0 M1

--- a/doc/7_java_api.md
+++ b/doc/7_java_api.md
@@ -249,6 +249,44 @@ of *RDD* elements and uses a default `JavaBeanColumnMapper` to map those element
 to attribute translations can be specified in order to override the default logic. If `JavaBeanColumnMapper` is not an
 option, a custom column mapper can be specified as well.
 
+### Working with tuples
+
+Since 1.3 there new methods to work with Scala tuples. 
+
+To read a Cassandra table as an RDD of tuples, just use one of `mapRowToTuple` methods to create 
+the appropriate `RowReaderFactory` instance. The arity of the tuple is determined by the number 
+of parameters which are provided to the mentioned method. 
+
+Example:
+
+```java
+CassandraJavaRDD<Tuple3<String, Integer, Double>> rdd = javaFunctions(sc)
+        .cassandraTable("ks", tuples", mapRowToTuple(String.class, Integer.class, Double.class))
+        .select("stringCol", "intCol", "doubleCol")
+```
+
+Remember to explicitly specify the columns to be selected because the values from the selected columns
+are resolved by the column position rather than its name.
+
+There are also new methods `mapTupleToRow` to create `RowWriterFactory` instance for tuples. 
+Those methods require all the tuple arguments types to be provided. The number of them determines the
+arity of tuples.
+
+Example:
+
+```java
+CassandraJavaUtil.javaFunctions(sc.makeRDD(Arrays.asList(tuple)))
+        .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+                String.class,
+                Integer.class,
+                Double.class
+        )).withColumnSelector(someColumns("stringCol", "intCol", "doubleCol"))
+        .saveToCassandra()
+```
+
+Similarly to reading data as tuples, it is highly recommended to explicitly specify the columns which are
+to be populated.
+
 ### Extensions for Spark Streaming
 
 The main entry point for Spark Streaming in Java is `JavaStreamingContext` object. Like for `JavaSparkContext`, we 

--- a/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/CassandraJavaUtilSpec.scala
+++ b/spark-cassandra-connector-java/src/it/scala/com/datastax/spark/connector/CassandraJavaUtilSpec.scala
@@ -1,14 +1,15 @@
 package com.datastax.spark.connector
 
+import scala.collection.JavaConversions._
+
+import org.apache.spark.rdd.RDD
+import org.scalatest.BeforeAndAfter
+
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.embedded.SparkTemplate._
 import com.datastax.spark.connector.embedded._
 import com.datastax.spark.connector.japi.CassandraJavaUtil
 import com.datastax.spark.connector.japi.CassandraJavaUtil._
-import org.apache.spark.rdd.RDD
-import org.scalatest.BeforeAndAfter
-
-import scala.collection.JavaConversions._
 
 class CassandraJavaUtilSpec extends SparkCassandraITFlatSpecBase with BeforeAndAfter {
 
@@ -17,19 +18,87 @@ class CassandraJavaUtilSpec extends SparkCassandraITFlatSpecBase with BeforeAndA
 
   val conn = CassandraConnector(defaultConf)
 
-  before {
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
     conn.withSessionDo { session =>
-      session.execute("CREATE KEYSPACE IF NOT EXISTS java_api_test WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }")
+      session.execute("DROP KEYSPACE IF EXISTS cassandra_java_util_spec")
+      session.execute("CREATE KEYSPACE cassandra_java_util_spec WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }")
 
-      session.execute("DROP TABLE IF EXISTS java_api_test.test_table")
-      session.execute("CREATE TABLE java_api_test.test_table (key INT, value TEXT, PRIMARY KEY (key))")
-      session.execute("DROP TABLE IF EXISTS java_api_test.test_table2")
-      session.execute("CREATE TABLE java_api_test.test_table2 (key INT, value TEXT, sub_class_field TEXT, PRIMARY KEY (key))")
+      session.execute("CREATE TABLE cassandra_java_util_spec.test_table (key INT, value TEXT, PRIMARY KEY (key))")
+      session.execute("CREATE TABLE cassandra_java_util_spec.test_table_2 (key INT, value TEXT, sub_class_field TEXT, PRIMARY KEY (key))")
+      session.execute(
+        """
+          |CREATE TABLE cassandra_java_util_spec.test_table_3 (
+          | c1 INT PRIMARY KEY,
+          | c2 TEXT,
+          | c3 INT,
+          | c4 TEXT,
+          | c5 INT,
+          | c6 TEXT,
+          | c7 INT,
+          | c8 TEXT,
+          | c9 INT,
+          | c10 TEXT,
+          | c11 INT,
+          | c12 TEXT,
+          | c13 INT,
+          | c14 TEXT,
+          | c15 INT,
+          | c16 TEXT,
+          | c17 INT,
+          | c18 TEXT,
+          | c19 INT,
+          | c20 TEXT,
+          | c21 INT,
+          | c22 TEXT
+          |)
+        """.stripMargin)
+      session.execute(
+        """
+          |INSERT INTO cassandra_java_util_spec.test_table_3 (
+          |  c1, c2, c3, c4, c5, c6, c7, c8, c9, c10,
+          |  c11, c12, c13, c14, c15, c16, c17, c18, c19, c20,
+          |  c21, c22
+          |) VALUES (
+          |  1, '2', 3, '4', 5, '6', 7, '8', 9, '10',
+          |  11, '12', 13, '14', 15, '16', 17, '18', 19, '20',
+          |  21, '22'
+          |)
+        """.stripMargin)
+      session.execute(
+        """
+          |CREATE TABLE cassandra_java_util_spec.test_table_4 (
+          | c1 INT PRIMARY KEY,
+          | c2 TEXT,
+          | c3 INT,
+          | c4 TEXT,
+          | c5 INT,
+          | c6 TEXT,
+          | c7 INT,
+          | c8 TEXT,
+          | c9 INT,
+          | c10 TEXT,
+          | c11 INT,
+          | c12 TEXT,
+          | c13 INT,
+          | c14 TEXT,
+          | c15 INT,
+          | c16 TEXT,
+          | c17 INT,
+          | c18 TEXT,
+          | c19 INT,
+          | c20 TEXT,
+          | c21 INT,
+          | c22 TEXT
+          |)
+        """.stripMargin)
     }
+
   }
 
+
   "CassandraJavaUtil" should "allow to save beans (with multiple constructors) to Cassandra" in {
-    assert(conn.withSessionDo(_.execute("SELECT * FROM java_api_test.test_table")).all().isEmpty)
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table"))
 
     val beansRdd: RDD[SampleJavaBeanWithMultipleCtors] = sc.parallelize(Seq(
       new SampleJavaBeanWithMultipleCtors(1, "one"),
@@ -38,10 +107,10 @@ class CassandraJavaUtilSpec extends SparkCassandraITFlatSpecBase with BeforeAndA
     ))
 
     CassandraJavaUtil.javaFunctions(beansRdd)
-      .writerBuilder("java_api_test", "test_table", mapToRow(classOf[SampleJavaBeanWithMultipleCtors]))
+      .writerBuilder("cassandra_java_util_spec", "test_table", mapToRow(classOf[SampleJavaBeanWithMultipleCtors]))
       .saveToCassandra()
 
-    val results = conn.withSessionDo(_.execute("SELECT * FROM java_api_test.test_table"))
+    val results = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table"))
 
     val rows = results.all()
     assert(rows.size() == 3)
@@ -52,7 +121,7 @@ class CassandraJavaUtilSpec extends SparkCassandraITFlatSpecBase with BeforeAndA
 
 
   it should "allow to save beans to Cassandra" in {
-    assert(conn.withSessionDo(_.execute("SELECT * FROM java_api_test.test_table")).all().isEmpty)
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table"))
 
     val beansRdd = sc.parallelize(Seq(
       SampleJavaBean.newInstance(1, "one"),
@@ -61,10 +130,10 @@ class CassandraJavaUtilSpec extends SparkCassandraITFlatSpecBase with BeforeAndA
     ))
 
     CassandraJavaUtil.javaFunctions(beansRdd)
-      .writerBuilder("java_api_test", "test_table", mapToRow(classOf[SampleJavaBean]))
+      .writerBuilder("cassandra_java_util_spec", "test_table", mapToRow(classOf[SampleJavaBean]))
       .saveToCassandra()
 
-    val results = conn.withSessionDo(_.execute("SELECT * FROM java_api_test.test_table"))
+    val results = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table"))
 
     val rows = results.all()
     assert(rows.size() == 3)
@@ -74,7 +143,7 @@ class CassandraJavaUtilSpec extends SparkCassandraITFlatSpecBase with BeforeAndA
   }
 
   it should "allow to save beans with transient fields to Cassandra" in {
-    assert(conn.withSessionDo(_.execute("SELECT * FROM java_api_test.test_table")).all().isEmpty)
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table"))
 
     val beansRdd = sc.parallelize(Seq(
       SampleJavaBeanWithTransientFields.newInstance(1, "one"),
@@ -83,10 +152,10 @@ class CassandraJavaUtilSpec extends SparkCassandraITFlatSpecBase with BeforeAndA
     ))
 
     CassandraJavaUtil.javaFunctions(beansRdd)
-      .writerBuilder("java_api_test", "test_table", mapToRow(classOf[SampleJavaBeanWithTransientFields]))
+      .writerBuilder("cassandra_java_util_spec", "test_table", mapToRow(classOf[SampleJavaBeanWithTransientFields]))
       .saveToCassandra()
 
-    val results = conn.withSessionDo(_.execute("SELECT * FROM java_api_test.test_table"))
+    val results = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table"))
 
     val rows = results.all()
     assert(rows.size() == 3)
@@ -96,7 +165,7 @@ class CassandraJavaUtilSpec extends SparkCassandraITFlatSpecBase with BeforeAndA
   }
 
   it should "allow to save beans with inherited fields to Cassandra" in {
-    assert(conn.withSessionDo(_.execute("SELECT * FROM java_api_test.test_table2")).all().isEmpty)
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_2"))
 
     val beansRdd = sc.parallelize(Seq(
       SampleJavaBeanSubClass.newInstance(1, "one", "a"),
@@ -105,10 +174,10 @@ class CassandraJavaUtilSpec extends SparkCassandraITFlatSpecBase with BeforeAndA
     ))
 
     CassandraJavaUtil.javaFunctions(beansRdd)
-      .writerBuilder("java_api_test", "test_table2", mapToRow(classOf[SampleJavaBeanSubClass]))
+      .writerBuilder("cassandra_java_util_spec", "test_table_2", mapToRow(classOf[SampleJavaBeanSubClass]))
       .saveToCassandra()
 
-    val results = conn.withSessionDo(_.execute("SELECT * FROM java_api_test.test_table2"))
+    val results = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_2"))
     val rows = results.all()
 
     rows should have size 3
@@ -120,7 +189,7 @@ class CassandraJavaUtilSpec extends SparkCassandraITFlatSpecBase with BeforeAndA
   }
 
   it should "allow to save nested beans to Cassandra" in {
-    assert(conn.withSessionDo(_.execute("SELECT * FROM java_api_test.test_table")).all().isEmpty)
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table"))
 
     val outer = new SampleWithNestedJavaBean
 
@@ -131,16 +200,1873 @@ class CassandraJavaUtilSpec extends SparkCassandraITFlatSpecBase with BeforeAndA
     ))
 
     CassandraJavaUtil.javaFunctions(beansRdd)
-      .writerBuilder("java_api_test", "test_table", mapToRow(classOf[outer.InnerClass]))
+      .writerBuilder("cassandra_java_util_spec", "test_table", mapToRow(classOf[outer.InnerClass]))
       .saveToCassandra()
 
-    val results = conn.withSessionDo(_.execute("SELECT * FROM java_api_test.test_table"))
+    val results = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table"))
 
     val rows = results.all()
     assert(rows.size() == 3)
     assert(rows.exists(row ⇒ row.getString("value") == "one" && row.getInt("key") == 1))
     assert(rows.exists(row ⇒ row.getString("value") == "two" && row.getInt("key") == 2))
     assert(rows.exists(row ⇒ row.getString("value") == "three" && row.getInt("key") == 3))
+  }
+
+  it should "allow to read rows as Tuple1" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer]
+    )).select(
+        "c1"
+      )
+      .collect().head
+    tuple shouldBe Tuple1(
+      1: Integer
+    )
+  }
+
+
+  it should "allow to read rows as Tuple2" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String]
+    )).select(
+        "c1", "c2"
+      )
+      .collect().head
+    tuple shouldBe Tuple2(
+      1: Integer,
+      "2"
+    )
+  }
+
+
+  it should "allow to read rows as Tuple3" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer]
+    )).select(
+        "c1", "c2", "c3"
+      )
+      .collect().head
+    tuple shouldBe Tuple3(
+      1: Integer,
+      "2",
+      3: Integer
+    )
+  }
+
+
+  it should "allow to read rows as Tuple4" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String]
+    )).select(
+        "c1", "c2", "c3", "c4"
+      )
+      .collect().head
+    tuple shouldBe Tuple4(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4"
+    )
+  }
+
+
+  it should "allow to read rows as Tuple5" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer]
+    )).select(
+        "c1", "c2", "c3", "c4", "c5"
+      )
+      .collect().head
+    tuple shouldBe Tuple5(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer
+    )
+  }
+
+
+  it should "allow to read rows as Tuple6" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String]
+    )).select(
+        "c1", "c2", "c3", "c4", "c5", "c6"
+      )
+      .collect().head
+    tuple shouldBe Tuple6(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6"
+    )
+  }
+
+
+  it should "allow to read rows as Tuple7" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer]
+    )).select(
+        "c1", "c2", "c3", "c4", "c5", "c6", "c7"
+      )
+      .collect().head
+    tuple shouldBe Tuple7(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer
+    )
+  }
+
+
+  it should "allow to read rows as Tuple8" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String]
+    )).select(
+        "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8"
+      )
+      .collect().head
+    tuple shouldBe Tuple8(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8"
+    )
+  }
+
+
+  it should "allow to read rows as Tuple9" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer]
+    )).select(
+        "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9"
+      )
+      .collect().head
+    tuple shouldBe Tuple9(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer
+    )
+  }
+
+
+  it should "allow to read rows as Tuple10" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String]
+    )).select(
+        "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10"
+      )
+      .collect().head
+    tuple shouldBe Tuple10(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10"
+    )
+  }
+
+
+  it should "allow to read rows as Tuple11" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer]
+    )).select(
+        "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11"
+      )
+      .collect().head
+    tuple shouldBe Tuple11(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer
+    )
+  }
+
+
+  it should "allow to read rows as Tuple12" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String]
+    )).select(
+        "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12"
+      )
+      .collect().head
+    tuple shouldBe Tuple12(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12"
+    )
+  }
+
+
+  it should "allow to read rows as Tuple13" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer]
+    )).select(
+        "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12", "c13"
+      )
+      .collect().head
+    tuple shouldBe Tuple13(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12",
+      13: Integer
+    )
+  }
+
+
+  it should "allow to read rows as Tuple14" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String]
+    )).select(
+        "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12", "c13", "c14"
+      )
+      .collect().head
+    tuple shouldBe Tuple14(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12",
+      13: Integer,
+      "14"
+    )
+  }
+
+
+  it should "allow to read rows as Tuple15" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer]
+    )).select(
+        "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12", "c13", "c14", "c15"
+      )
+      .collect().head
+    tuple shouldBe Tuple15(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12",
+      13: Integer,
+      "14",
+      15: Integer
+    )
+  }
+
+
+  it should "allow to read rows as Tuple16" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String]
+    )).select(
+        "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12", "c13", "c14", "c15", "c16"
+      )
+      .collect().head
+    tuple shouldBe Tuple16(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12",
+      13: Integer,
+      "14",
+      15: Integer,
+      "16"
+    )
+  }
+
+
+  it should "allow to read rows as Tuple17" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer]
+    )).select(
+        "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12", "c13", "c14", "c15", "c16", "c17"
+      )
+      .collect().head
+    tuple shouldBe Tuple17(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12",
+      13: Integer,
+      "14",
+      15: Integer,
+      "16",
+      17: Integer
+    )
+  }
+
+
+  it should "allow to read rows as Tuple18" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String]
+    )).select(
+        "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12", "c13", "c14", "c15", "c16", "c17", "c18"
+      )
+      .collect().head
+    tuple shouldBe Tuple18(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12",
+      13: Integer,
+      "14",
+      15: Integer,
+      "16",
+      17: Integer,
+      "18"
+    )
+  }
+
+
+  it should "allow to read rows as Tuple19" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer]
+    )).select(
+        "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12", "c13", "c14", "c15", "c16", "c17", "c18", "c19"
+      )
+      .collect().head
+    tuple shouldBe Tuple19(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12",
+      13: Integer,
+      "14",
+      15: Integer,
+      "16",
+      17: Integer,
+      "18",
+      19: Integer
+    )
+  }
+
+
+  it should "allow to read rows as Tuple20" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String]
+    )).select(
+        "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12", "c13", "c14", "c15", "c16", "c17", "c18", "c19", "c20"
+      )
+      .collect().head
+    tuple shouldBe Tuple20(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12",
+      13: Integer,
+      "14",
+      15: Integer,
+      "16",
+      17: Integer,
+      "18",
+      19: Integer,
+      "20"
+    )
+  }
+
+
+  it should "allow to read rows as Tuple21" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer]
+    )).select(
+        "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12", "c13", "c14", "c15", "c16", "c17", "c18", "c19", "c20", "c21"
+      )
+      .collect().head
+    tuple shouldBe Tuple21(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12",
+      13: Integer,
+      "14",
+      15: Integer,
+      "16",
+      17: Integer,
+      "18",
+      19: Integer,
+      "20",
+      21: Integer
+    )
+  }
+
+
+  it should "allow to read rows as Tuple22" in {
+    val tuple = CassandraJavaUtil.javaFunctions(sc)
+      .cassandraTable("cassandra_java_util_spec", "test_table_3", mapRowToTuple(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String]
+    )).select(
+        "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12", "c13", "c14", "c15", "c16", "c17", "c18", "c19", "c20", "c21", "c22"
+      )
+      .collect().head
+    tuple shouldBe Tuple22(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12",
+      13: Integer,
+      "14",
+      15: Integer,
+      "16",
+      17: Integer,
+      "18",
+      19: Integer,
+      "20",
+      21: Integer,
+      "22"
+    )
+  }
+
+
+  it should "allow to write Tuple1 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple1(
+      1: Integer
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer]
+    )).withColumnSelector(someColumns(
+      "c1"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+  }
+
+
+
+  it should "allow to write Tuple2 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple2(
+      1: Integer,
+      "2"
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String]
+    )).withColumnSelector(someColumns(
+      "c1", "c2"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+  }
+
+
+
+  it should "allow to write Tuple3 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple3(
+      1: Integer,
+      "2",
+      3: Integer
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer]
+    )).withColumnSelector(someColumns(
+      "c1", "c2", "c3"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+    row.getInt("c3") shouldBe (3: Integer)
+  }
+
+
+
+  it should "allow to write Tuple4 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple4(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4"
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String]
+    )).withColumnSelector(someColumns(
+      "c1", "c2", "c3", "c4"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+    row.getInt("c3") shouldBe (3: Integer)
+    row.getString("c4") shouldBe "4"
+  }
+
+
+
+  it should "allow to write Tuple5 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple5(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer]
+    )).withColumnSelector(someColumns(
+      "c1", "c2", "c3", "c4", "c5"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+    row.getInt("c3") shouldBe (3: Integer)
+    row.getString("c4") shouldBe "4"
+    row.getInt("c5") shouldBe (5: Integer)
+  }
+
+
+
+  it should "allow to write Tuple6 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple6(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6"
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String]
+    )).withColumnSelector(someColumns(
+      "c1", "c2", "c3", "c4", "c5", "c6"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+    row.getInt("c3") shouldBe (3: Integer)
+    row.getString("c4") shouldBe "4"
+    row.getInt("c5") shouldBe (5: Integer)
+    row.getString("c6") shouldBe "6"
+  }
+
+
+
+  it should "allow to write Tuple7 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple7(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer]
+    )).withColumnSelector(someColumns(
+      "c1", "c2", "c3", "c4", "c5", "c6", "c7"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+    row.getInt("c3") shouldBe (3: Integer)
+    row.getString("c4") shouldBe "4"
+    row.getInt("c5") shouldBe (5: Integer)
+    row.getString("c6") shouldBe "6"
+    row.getInt("c7") shouldBe (7: Integer)
+  }
+
+
+
+  it should "allow to write Tuple8 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple8(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8"
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String]
+    )).withColumnSelector(someColumns(
+      "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+    row.getInt("c3") shouldBe (3: Integer)
+    row.getString("c4") shouldBe "4"
+    row.getInt("c5") shouldBe (5: Integer)
+    row.getString("c6") shouldBe "6"
+    row.getInt("c7") shouldBe (7: Integer)
+    row.getString("c8") shouldBe "8"
+  }
+
+
+
+  it should "allow to write Tuple9 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple9(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer]
+    )).withColumnSelector(someColumns(
+      "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+    row.getInt("c3") shouldBe (3: Integer)
+    row.getString("c4") shouldBe "4"
+    row.getInt("c5") shouldBe (5: Integer)
+    row.getString("c6") shouldBe "6"
+    row.getInt("c7") shouldBe (7: Integer)
+    row.getString("c8") shouldBe "8"
+    row.getInt("c9") shouldBe (9: Integer)
+  }
+
+
+
+  it should "allow to write Tuple10 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple10(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10"
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String]
+    )).withColumnSelector(someColumns(
+      "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+    row.getInt("c3") shouldBe (3: Integer)
+    row.getString("c4") shouldBe "4"
+    row.getInt("c5") shouldBe (5: Integer)
+    row.getString("c6") shouldBe "6"
+    row.getInt("c7") shouldBe (7: Integer)
+    row.getString("c8") shouldBe "8"
+    row.getInt("c9") shouldBe (9: Integer)
+    row.getString("c10") shouldBe "10"
+  }
+
+
+
+  it should "allow to write Tuple11 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple11(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer]
+    )).withColumnSelector(someColumns(
+      "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+    row.getInt("c3") shouldBe (3: Integer)
+    row.getString("c4") shouldBe "4"
+    row.getInt("c5") shouldBe (5: Integer)
+    row.getString("c6") shouldBe "6"
+    row.getInt("c7") shouldBe (7: Integer)
+    row.getString("c8") shouldBe "8"
+    row.getInt("c9") shouldBe (9: Integer)
+    row.getString("c10") shouldBe "10"
+    row.getInt("c11") shouldBe (11: Integer)
+  }
+
+
+
+  it should "allow to write Tuple12 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple12(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12"
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String]
+    )).withColumnSelector(someColumns(
+      "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+    row.getInt("c3") shouldBe (3: Integer)
+    row.getString("c4") shouldBe "4"
+    row.getInt("c5") shouldBe (5: Integer)
+    row.getString("c6") shouldBe "6"
+    row.getInt("c7") shouldBe (7: Integer)
+    row.getString("c8") shouldBe "8"
+    row.getInt("c9") shouldBe (9: Integer)
+    row.getString("c10") shouldBe "10"
+    row.getInt("c11") shouldBe (11: Integer)
+    row.getString("c12") shouldBe "12"
+  }
+
+
+
+  it should "allow to write Tuple13 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple13(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12",
+      13: Integer
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer]
+    )).withColumnSelector(someColumns(
+      "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12", "c13"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+    row.getInt("c3") shouldBe (3: Integer)
+    row.getString("c4") shouldBe "4"
+    row.getInt("c5") shouldBe (5: Integer)
+    row.getString("c6") shouldBe "6"
+    row.getInt("c7") shouldBe (7: Integer)
+    row.getString("c8") shouldBe "8"
+    row.getInt("c9") shouldBe (9: Integer)
+    row.getString("c10") shouldBe "10"
+    row.getInt("c11") shouldBe (11: Integer)
+    row.getString("c12") shouldBe "12"
+    row.getInt("c13") shouldBe (13: Integer)
+  }
+
+
+
+  it should "allow to write Tuple14 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple14(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12",
+      13: Integer,
+      "14"
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String]
+    )).withColumnSelector(someColumns(
+      "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12", "c13", "c14"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+    row.getInt("c3") shouldBe (3: Integer)
+    row.getString("c4") shouldBe "4"
+    row.getInt("c5") shouldBe (5: Integer)
+    row.getString("c6") shouldBe "6"
+    row.getInt("c7") shouldBe (7: Integer)
+    row.getString("c8") shouldBe "8"
+    row.getInt("c9") shouldBe (9: Integer)
+    row.getString("c10") shouldBe "10"
+    row.getInt("c11") shouldBe (11: Integer)
+    row.getString("c12") shouldBe "12"
+    row.getInt("c13") shouldBe (13: Integer)
+    row.getString("c14") shouldBe "14"
+  }
+
+
+
+  it should "allow to write Tuple15 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple15(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12",
+      13: Integer,
+      "14",
+      15: Integer
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer]
+    )).withColumnSelector(someColumns(
+      "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12", "c13", "c14", "c15"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+    row.getInt("c3") shouldBe (3: Integer)
+    row.getString("c4") shouldBe "4"
+    row.getInt("c5") shouldBe (5: Integer)
+    row.getString("c6") shouldBe "6"
+    row.getInt("c7") shouldBe (7: Integer)
+    row.getString("c8") shouldBe "8"
+    row.getInt("c9") shouldBe (9: Integer)
+    row.getString("c10") shouldBe "10"
+    row.getInt("c11") shouldBe (11: Integer)
+    row.getString("c12") shouldBe "12"
+    row.getInt("c13") shouldBe (13: Integer)
+    row.getString("c14") shouldBe "14"
+    row.getInt("c15") shouldBe (15: Integer)
+  }
+
+
+
+  it should "allow to write Tuple16 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple16(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12",
+      13: Integer,
+      "14",
+      15: Integer,
+      "16"
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String]
+    )).withColumnSelector(someColumns(
+      "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12", "c13", "c14", "c15", "c16"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+    row.getInt("c3") shouldBe (3: Integer)
+    row.getString("c4") shouldBe "4"
+    row.getInt("c5") shouldBe (5: Integer)
+    row.getString("c6") shouldBe "6"
+    row.getInt("c7") shouldBe (7: Integer)
+    row.getString("c8") shouldBe "8"
+    row.getInt("c9") shouldBe (9: Integer)
+    row.getString("c10") shouldBe "10"
+    row.getInt("c11") shouldBe (11: Integer)
+    row.getString("c12") shouldBe "12"
+    row.getInt("c13") shouldBe (13: Integer)
+    row.getString("c14") shouldBe "14"
+    row.getInt("c15") shouldBe (15: Integer)
+    row.getString("c16") shouldBe "16"
+  }
+
+
+
+  it should "allow to write Tuple17 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple17(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12",
+      13: Integer,
+      "14",
+      15: Integer,
+      "16",
+      17: Integer
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer]
+    )).withColumnSelector(someColumns(
+      "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12", "c13", "c14", "c15", "c16", "c17"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+    row.getInt("c3") shouldBe (3: Integer)
+    row.getString("c4") shouldBe "4"
+    row.getInt("c5") shouldBe (5: Integer)
+    row.getString("c6") shouldBe "6"
+    row.getInt("c7") shouldBe (7: Integer)
+    row.getString("c8") shouldBe "8"
+    row.getInt("c9") shouldBe (9: Integer)
+    row.getString("c10") shouldBe "10"
+    row.getInt("c11") shouldBe (11: Integer)
+    row.getString("c12") shouldBe "12"
+    row.getInt("c13") shouldBe (13: Integer)
+    row.getString("c14") shouldBe "14"
+    row.getInt("c15") shouldBe (15: Integer)
+    row.getString("c16") shouldBe "16"
+    row.getInt("c17") shouldBe (17: Integer)
+  }
+
+
+
+  it should "allow to write Tuple18 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple18(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12",
+      13: Integer,
+      "14",
+      15: Integer,
+      "16",
+      17: Integer,
+      "18"
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String]
+    )).withColumnSelector(someColumns(
+      "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12", "c13", "c14", "c15", "c16", "c17", "c18"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+    row.getInt("c3") shouldBe (3: Integer)
+    row.getString("c4") shouldBe "4"
+    row.getInt("c5") shouldBe (5: Integer)
+    row.getString("c6") shouldBe "6"
+    row.getInt("c7") shouldBe (7: Integer)
+    row.getString("c8") shouldBe "8"
+    row.getInt("c9") shouldBe (9: Integer)
+    row.getString("c10") shouldBe "10"
+    row.getInt("c11") shouldBe (11: Integer)
+    row.getString("c12") shouldBe "12"
+    row.getInt("c13") shouldBe (13: Integer)
+    row.getString("c14") shouldBe "14"
+    row.getInt("c15") shouldBe (15: Integer)
+    row.getString("c16") shouldBe "16"
+    row.getInt("c17") shouldBe (17: Integer)
+    row.getString("c18") shouldBe "18"
+  }
+
+
+
+  it should "allow to write Tuple19 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple19(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12",
+      13: Integer,
+      "14",
+      15: Integer,
+      "16",
+      17: Integer,
+      "18",
+      19: Integer
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer]
+    )).withColumnSelector(someColumns(
+      "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12", "c13", "c14", "c15", "c16", "c17", "c18", "c19"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+    row.getInt("c3") shouldBe (3: Integer)
+    row.getString("c4") shouldBe "4"
+    row.getInt("c5") shouldBe (5: Integer)
+    row.getString("c6") shouldBe "6"
+    row.getInt("c7") shouldBe (7: Integer)
+    row.getString("c8") shouldBe "8"
+    row.getInt("c9") shouldBe (9: Integer)
+    row.getString("c10") shouldBe "10"
+    row.getInt("c11") shouldBe (11: Integer)
+    row.getString("c12") shouldBe "12"
+    row.getInt("c13") shouldBe (13: Integer)
+    row.getString("c14") shouldBe "14"
+    row.getInt("c15") shouldBe (15: Integer)
+    row.getString("c16") shouldBe "16"
+    row.getInt("c17") shouldBe (17: Integer)
+    row.getString("c18") shouldBe "18"
+    row.getInt("c19") shouldBe (19: Integer)
+  }
+
+
+
+  it should "allow to write Tuple20 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple20(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12",
+      13: Integer,
+      "14",
+      15: Integer,
+      "16",
+      17: Integer,
+      "18",
+      19: Integer,
+      "20"
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String]
+    )).withColumnSelector(someColumns(
+      "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12", "c13", "c14", "c15", "c16", "c17", "c18", "c19", "c20"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+    row.getInt("c3") shouldBe (3: Integer)
+    row.getString("c4") shouldBe "4"
+    row.getInt("c5") shouldBe (5: Integer)
+    row.getString("c6") shouldBe "6"
+    row.getInt("c7") shouldBe (7: Integer)
+    row.getString("c8") shouldBe "8"
+    row.getInt("c9") shouldBe (9: Integer)
+    row.getString("c10") shouldBe "10"
+    row.getInt("c11") shouldBe (11: Integer)
+    row.getString("c12") shouldBe "12"
+    row.getInt("c13") shouldBe (13: Integer)
+    row.getString("c14") shouldBe "14"
+    row.getInt("c15") shouldBe (15: Integer)
+    row.getString("c16") shouldBe "16"
+    row.getInt("c17") shouldBe (17: Integer)
+    row.getString("c18") shouldBe "18"
+    row.getInt("c19") shouldBe (19: Integer)
+    row.getString("c20") shouldBe "20"
+  }
+
+
+
+  it should "allow to write Tuple21 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple21(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12",
+      13: Integer,
+      "14",
+      15: Integer,
+      "16",
+      17: Integer,
+      "18",
+      19: Integer,
+      "20",
+      21: Integer
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer]
+    )).withColumnSelector(someColumns(
+      "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12", "c13", "c14", "c15", "c16", "c17", "c18", "c19", "c20", "c21"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+    row.getInt("c3") shouldBe (3: Integer)
+    row.getString("c4") shouldBe "4"
+    row.getInt("c5") shouldBe (5: Integer)
+    row.getString("c6") shouldBe "6"
+    row.getInt("c7") shouldBe (7: Integer)
+    row.getString("c8") shouldBe "8"
+    row.getInt("c9") shouldBe (9: Integer)
+    row.getString("c10") shouldBe "10"
+    row.getInt("c11") shouldBe (11: Integer)
+    row.getString("c12") shouldBe "12"
+    row.getInt("c13") shouldBe (13: Integer)
+    row.getString("c14") shouldBe "14"
+    row.getInt("c15") shouldBe (15: Integer)
+    row.getString("c16") shouldBe "16"
+    row.getInt("c17") shouldBe (17: Integer)
+    row.getString("c18") shouldBe "18"
+    row.getInt("c19") shouldBe (19: Integer)
+    row.getString("c20") shouldBe "20"
+    row.getInt("c21") shouldBe (21: Integer)
+  }
+
+
+
+  it should "allow to write Tuple22 to Cassandra" in {
+    conn.withSessionDo(_.execute("TRUNCATE cassandra_java_util_spec.test_table_4"))
+    val tuple = Tuple22(
+      1: Integer,
+      "2",
+      3: Integer,
+      "4",
+      5: Integer,
+      "6",
+      7: Integer,
+      "8",
+      9: Integer,
+      "10",
+      11: Integer,
+      "12",
+      13: Integer,
+      "14",
+      15: Integer,
+      "16",
+      17: Integer,
+      "18",
+      19: Integer,
+      "20",
+      21: Integer,
+      "22"
+    )
+    CassandraJavaUtil.javaFunctions(sc.makeRDD(Seq(tuple)))
+      .writerBuilder("cassandra_java_util_spec", "test_table_4", mapTupleToRow(
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String],
+      classOf[Integer],
+      classOf[String]
+    )).withColumnSelector(someColumns(
+      "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11", "c12", "c13", "c14", "c15", "c16", "c17", "c18", "c19", "c20", "c21", "c22"
+    )).saveToCassandra()
+
+    val row = conn.withSessionDo(_.execute("SELECT * FROM cassandra_java_util_spec.test_table_4").one())
+    row.getInt("c1") shouldBe (1: Integer)
+    row.getString("c2") shouldBe "2"
+    row.getInt("c3") shouldBe (3: Integer)
+    row.getString("c4") shouldBe "4"
+    row.getInt("c5") shouldBe (5: Integer)
+    row.getString("c6") shouldBe "6"
+    row.getInt("c7") shouldBe (7: Integer)
+    row.getString("c8") shouldBe "8"
+    row.getInt("c9") shouldBe (9: Integer)
+    row.getString("c10") shouldBe "10"
+    row.getInt("c11") shouldBe (11: Integer)
+    row.getString("c12") shouldBe "12"
+    row.getInt("c13") shouldBe (13: Integer)
+    row.getString("c14") shouldBe "14"
+    row.getInt("c15") shouldBe (15: Integer)
+    row.getString("c16") shouldBe "16"
+    row.getInt("c17") shouldBe (17: Integer)
+    row.getString("c18") shouldBe "18"
+    row.getInt("c19") shouldBe (19: Integer)
+    row.getString("c20") shouldBe "20"
+    row.getInt("c21") shouldBe (21: Integer)
+    row.getString("c22") shouldBe "22"
   }
 
 }

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/CassandraJavaUtil.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/CassandraJavaUtil.java
@@ -5,13 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import scala.Option;
-import scala.reflect.ClassTag;
-import scala.reflect.ClassTag$;
-import scala.reflect.api.TypeTags;
-
 import akka.japi.JAPI;
-import static com.datastax.spark.connector.util.JavaApiHelper.*;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.spark.SparkContext;
@@ -19,11 +13,49 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.rdd.RDD;
+import scala.Option;
+import scala.Tuple1;
+import scala.Tuple10;
+import scala.Tuple11;
+import scala.Tuple12;
+import scala.Tuple13;
+import scala.Tuple14;
+import scala.Tuple15;
+import scala.Tuple16;
+import scala.Tuple17;
+import scala.Tuple18;
+import scala.Tuple19;
+import scala.Tuple2;
+import scala.Tuple20;
+import scala.Tuple21;
+import scala.Tuple22;
+import scala.Tuple3;
+import scala.Tuple4;
+import scala.Tuple5;
+import scala.Tuple6;
+import scala.Tuple7;
+import scala.Tuple8;
+import scala.Tuple9;
+import scala.reflect.ClassTag;
+import scala.reflect.ClassTag$;
+import scala.reflect.api.TypeTags;
 
-import com.datastax.spark.connector.*;
+import com.datastax.spark.connector.AllColumns$;
+import com.datastax.spark.connector.BatchSize;
+import com.datastax.spark.connector.BatchSize$;
+import com.datastax.spark.connector.BytesInBatch$;
+import com.datastax.spark.connector.ColumnName;
+import com.datastax.spark.connector.ColumnName$;
+import com.datastax.spark.connector.ColumnRef;
+import com.datastax.spark.connector.ColumnSelector;
+import com.datastax.spark.connector.RowsInBatch$;
+import com.datastax.spark.connector.SomeColumns$;
+import com.datastax.spark.connector.TTL;
+import com.datastax.spark.connector.WriteTime;
 import com.datastax.spark.connector.cql.CassandraConnector;
 import com.datastax.spark.connector.mapper.ColumnMapper;
 import com.datastax.spark.connector.mapper.JavaBeanColumnMapper;
+import com.datastax.spark.connector.mapper.TupleColumnMapper;
 import com.datastax.spark.connector.rdd.reader.ClassBasedRowReaderFactory;
 import com.datastax.spark.connector.rdd.reader.RowReaderFactory;
 import com.datastax.spark.connector.rdd.reader.ValueRowReaderFactory;
@@ -33,6 +65,9 @@ import com.datastax.spark.connector.util.JavaApiHelper;
 import com.datastax.spark.connector.util.JavaApiHelper$;
 import com.datastax.spark.connector.writer.BatchGroupingKey;
 import com.datastax.spark.connector.writer.RowWriterFactory;
+
+import static com.datastax.spark.connector.util.JavaApiHelper.defaultRowWriterFactory;
+import static com.datastax.spark.connector.util.JavaApiHelper.javaBeanColumnMapper;
 
 /**
  * The main entry point to Spark Cassandra Connector Java API.
@@ -135,7 +170,10 @@ public class CassandraJavaUtil {
      * List<String>>}
      */
     public static <T> TypeTags.TypeTag<T> typeTag(
-            Class<?> main, TypeTags.TypeTag<?> typeParam1, TypeTags.TypeTag<?>... typeParams) {
+            Class<?> main,
+            TypeTags.TypeTag<?> typeParam1,
+            TypeTags.TypeTag<?>... typeParams
+    ) {
         return JavaApiHelper.getTypeTag(main, JAPI.seq(ArrayUtils.add(typeParams, 0, typeParam1)));
     }
 
@@ -147,7 +185,7 @@ public class CassandraJavaUtil {
      * <p/>
      * For example, the following code: {@code typeTag(List.class, String.class)} returns a type tag of
      * {@code List<String>}, and the following code: {@code typeTag(Map.class, String.class,
-     *Integer.class)} returns a type tag of {@code Map<String, Integer>}.
+     * Integer.class)} returns a type tag of {@code Map<String, Integer>}.
      * <p/>
      * This is a short-hand method for calling {@link #typeTag(Class, TypeTags.TypeTag,
      * TypeTags.TypeTag[])} and providing type parameters with {@link #safeTypeTag(Class)}.
@@ -213,7 +251,10 @@ public class CassandraJavaUtil {
      */
     @SuppressWarnings("unchecked")
     public static <T> TypeConverter<T> typeConverter(
-            Class<?> main, TypeTags.TypeTag<?> typeParam1, TypeTags.TypeTag<?>... typeParams) {
+            Class<?> main,
+            TypeTags.TypeTag<?> typeParam1,
+            TypeTags.TypeTag<?>... typeParams
+    ) {
         return TypeConverter$.MODULE$.forType(CassandraJavaUtil.<T>typeTag(main, typeParam1, typeParams));
     }
 
@@ -240,14 +281,13 @@ public class CassandraJavaUtil {
      * or a list).
      * <p/>
      * For example the following code: {@code javaFunctions(sc).cassandraTable("ks", "tab",
-     *mapColumnToListOf(String.class))} returns an RDD of {@code List<String>}.
+     * mapColumnToListOf(String.class))} returns an RDD of {@code List<String>}.
      * <p/>
      * It is a short-hand method for calling {@link #mapColumnTo(Class, Class, Class[])} with the main
      * type being {@link java.util.List} and the type parameter being the given target class.
      */
     public static <T> RowReaderFactory<List<T>> mapColumnToListOf(Class<T> targetClass) {
-        return new ValueRowReaderFactory<>(
-                CassandraJavaUtil.<List<T>>typeConverter(List.class, targetClass));
+        return new ValueRowReaderFactory<>(CassandraJavaUtil.<List<T>>typeConverter(List.class, targetClass));
     }
 
     /**
@@ -258,14 +298,13 @@ public class CassandraJavaUtil {
      * or a list).
      * <p/>
      * For example the following code: {@code javaFunctions(sc).cassandraTable("ks", "tab",
-     *mapColumnToSetOf(String.class))} returns an RDD of {@code Set<String>}.
+     * mapColumnToSetOf(String.class))} returns an RDD of {@code Set<String>}.
      * <p/>
      * It is a short-hand method for calling {@link #mapColumnTo(Class, Class, Class[])} with the main
      * type being {@link java.util.Set} and the type parameter being the given target class.
      */
     public static <T> RowReaderFactory<Set<T>> mapColumnToSetOf(Class<T> targetClass) {
-        return new ValueRowReaderFactory<>(
-                CassandraJavaUtil.<Set<T>>typeConverter(Set.class, targetClass));
+        return new ValueRowReaderFactory<>(CassandraJavaUtil.<Set<T>>typeConverter(Set.class, targetClass));
     }
 
     /**
@@ -275,14 +314,16 @@ public class CassandraJavaUtil {
      * The method should be used when we have to deal with a column of a map type.
      * <p/>
      * For example the following code: {@code javaFunctions(sc).cassandraTable("ks", "tab",
-     *mapColumnToMapOf(String.class, Integer.class))} returns an RDD of {@code Map<String, Integer>}.
+     * mapColumnToMapOf(String.class, Integer.class))} returns an RDD of {@code Map<String, Integer>}.
      * <p/>
      * It is a short-hand method for calling {@link #mapColumnTo(Class, Class, Class[])} with the main
      * type being {@link java.util.Map} and the type parameters being the given target key and target
      * value classes.
      */
     public static <K, V> RowReaderFactory<Map<K, V>> mapColumnToMapOf(
-            Class<K> targetKeyClass, Class<V> targetValueClass) {
+            Class<K> targetKeyClass,
+            Class<V> targetValueClass
+    ) {
         return new ValueRowReaderFactory<>(
                 CassandraJavaUtil.<Map<K, V>>typeConverter(Map.class, targetKeyClass, targetValueClass));
     }
@@ -295,10 +336,8 @@ public class CassandraJavaUtil {
      * resolved by calling {@link #typeConverter(Class, Class, Class[])}.
      */
     @SuppressWarnings("unchecked")
-    public static <T> RowReaderFactory<T> mapColumnTo(
-            Class targetClass, Class typeParam1, Class... typeParams) {
-        return new ValueRowReaderFactory<>(
-                CassandraJavaUtil.<T>typeConverter(targetClass, typeParam1, typeParams));
+    public static <T> RowReaderFactory<T> mapColumnTo(Class targetClass, Class typeParam1, Class... typeParams) {
+        return new ValueRowReaderFactory<>(CassandraJavaUtil.<T>typeConverter(targetClass, typeParam1, typeParams));
     }
 
     /**
@@ -334,8 +373,7 @@ public class CassandraJavaUtil {
      * The method uses {@link JavaBeanColumnMapper} as the column mapper. If another column mapper has to
      * be used, see {@link #mapRowTo(Class, ColumnMapper)} method.
      */
-    public static <T> RowReaderFactory<T> mapRowTo(
-            Class<T> targetClass, Map<String, String> columnMapping) {
+    public static <T> RowReaderFactory<T> mapRowTo(Class<T> targetClass, Map<String, String> columnMapping) {
         TypeTags.TypeTag<T> tt = typeTag(targetClass);
         ColumnMapper<T> mapper = javaBeanColumnMapper(safeClassTag(targetClass), columnMapping);
         return new ClassBasedRowReaderFactory<>(tt, mapper);
@@ -356,8 +394,7 @@ public class CassandraJavaUtil {
      */
     public static <T> RowReaderFactory<T> mapRowTo(Class<T> targetClass, Pair... columnMappings) {
         TypeTags.TypeTag<T> tt = typeTag(targetClass);
-        ColumnMapper<T> mapper = javaBeanColumnMapper(
-                safeClassTag(targetClass), convertToMap(columnMappings));
+        ColumnMapper<T> mapper = javaBeanColumnMapper(safeClassTag(targetClass), convertToMap(columnMappings));
         return new ClassBasedRowReaderFactory<>(tt, mapper);
     }
 
@@ -371,6 +408,758 @@ public class CassandraJavaUtil {
     }
 
     // -------------------------------------------------------------------------
+    //              Row to tuples mapper
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A> RowReaderFactory<Tuple1<A>> mapRowToTuple(
+            Class<A> a
+    ) {
+        final TypeTags.TypeTag<Tuple1<A>> tupleTT =
+                typeTag(Tuple1.class,
+                        typeTag(a)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple1ColumnMapper(a));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B> RowReaderFactory<Tuple2<A, B>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b
+    ) {
+        final TypeTags.TypeTag<Tuple2<A, B>> tupleTT =
+                typeTag(Tuple2.class,
+                        typeTag(a),
+                        typeTag(b)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple2ColumnMapper(a, b));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B, C> RowReaderFactory<Tuple3<A, B, C>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c
+    ) {
+        final TypeTags.TypeTag<Tuple3<A, B, C>> tupleTT =
+                typeTag(Tuple3.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple3ColumnMapper(a, b, c));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B, C, D> RowReaderFactory<Tuple4<A, B, C, D>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d
+    ) {
+        final TypeTags.TypeTag<Tuple4<A, B, C, D>> tupleTT =
+                typeTag(Tuple4.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple4ColumnMapper(a, b, c, d));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B, C, D, E> RowReaderFactory<Tuple5<A, B, C, D, E>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e
+    ) {
+        final TypeTags.TypeTag<Tuple5<A, B, C, D, E>> tupleTT =
+                typeTag(Tuple5.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple5ColumnMapper(a, b, c, d, e));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F> RowReaderFactory<Tuple6<A, B, C, D, E, F>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f
+    ) {
+        final TypeTags.TypeTag<Tuple6<A, B, C, D, E, F>> tupleTT =
+                typeTag(Tuple6.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple6ColumnMapper(a, b, c, d, e, f));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G> RowReaderFactory<Tuple7<A, B, C, D, E, F, G>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g
+    ) {
+        final TypeTags.TypeTag<Tuple7<A, B, C, D, E, F, G>> tupleTT =
+                typeTag(Tuple7.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple7ColumnMapper(a, b, c, d, e, f, g));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H> RowReaderFactory<Tuple8<A, B, C, D, E, F, G, H>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h
+    ) {
+        final TypeTags.TypeTag<Tuple8<A, B, C, D, E, F, G, H>> tupleTT =
+                typeTag(Tuple8.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple8ColumnMapper(a, b, c, d, e, f, g, h));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I> RowReaderFactory<Tuple9<A, B, C, D, E, F, G, H, I>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i
+    ) {
+        final TypeTags.TypeTag<Tuple9<A, B, C, D, E, F, G, H, I>> tupleTT =
+                typeTag(Tuple9.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple9ColumnMapper(a, b, c, d, e, f, g, h, i));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J> RowReaderFactory<Tuple10<A, B, C, D, E, F, G, H, I, J>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j
+    ) {
+        final TypeTags.TypeTag<Tuple10<A, B, C, D, E, F, G, H, I, J>> tupleTT =
+                typeTag(Tuple10.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple10ColumnMapper(a, b, c, d, e, f, g, h, i, j));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K> RowReaderFactory<Tuple11<A, B, C, D, E, F, G, H, I, J, K>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k
+    ) {
+        final TypeTags.TypeTag<Tuple11<A, B, C, D, E, F, G, H, I, J, K>> tupleTT =
+                typeTag(Tuple11.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple11ColumnMapper(a, b, c, d, e, f, g, h, i, j, k));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L> RowReaderFactory<Tuple12<A, B, C, D, E, F, G, H, I, J, K, L>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l
+    ) {
+        final TypeTags.TypeTag<Tuple12<A, B, C, D, E, F, G, H, I, J, K, L>> tupleTT =
+                typeTag(Tuple12.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple12ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M> RowReaderFactory<Tuple13<A, B, C, D, E, F, G, H, I, J, K, L, M>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m
+    ) {
+        final TypeTags.TypeTag<Tuple13<A, B, C, D, E, F, G, H, I, J, K, L, M>> tupleTT =
+                typeTag(Tuple13.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l),
+                        typeTag(m)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple13ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l, m));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N> RowReaderFactory<Tuple14<A, B, C, D, E, F, G, H, I, J, K, L, M, N>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n
+    ) {
+        final TypeTags.TypeTag<Tuple14<A, B, C, D, E, F, G, H, I, J, K, L, M, N>> tupleTT =
+                typeTag(Tuple14.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l),
+                        typeTag(m),
+                        typeTag(n)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple14ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l, m, n));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> RowReaderFactory<Tuple15<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o
+    ) {
+        final TypeTags.TypeTag<Tuple15<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>> tupleTT =
+                typeTag(Tuple15.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l),
+                        typeTag(m),
+                        typeTag(n),
+                        typeTag(o)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple15ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> RowReaderFactory<Tuple16<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p
+    ) {
+        final TypeTags.TypeTag<Tuple16<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>> tupleTT =
+                typeTag(Tuple16.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l),
+                        typeTag(m),
+                        typeTag(n),
+                        typeTag(o),
+                        typeTag(p)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple16ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> RowReaderFactory<Tuple17<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p,
+            Class<Q> q
+    ) {
+        final TypeTags.TypeTag<Tuple17<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>> tupleTT =
+                typeTag(Tuple17.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l),
+                        typeTag(m),
+                        typeTag(n),
+                        typeTag(o),
+                        typeTag(p),
+                        typeTag(q)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple17ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> RowReaderFactory<Tuple18<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p,
+            Class<Q> q,
+            Class<R> r
+    ) {
+        final TypeTags.TypeTag<Tuple18<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>> tupleTT =
+                typeTag(Tuple18.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l),
+                        typeTag(m),
+                        typeTag(n),
+                        typeTag(o),
+                        typeTag(p),
+                        typeTag(q),
+                        typeTag(r)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple18ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> RowReaderFactory<Tuple19<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p,
+            Class<Q> q,
+            Class<R> r,
+            Class<S> s
+    ) {
+        final TypeTags.TypeTag<Tuple19<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>> tupleTT =
+                typeTag(Tuple19.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l),
+                        typeTag(m),
+                        typeTag(n),
+                        typeTag(o),
+                        typeTag(p),
+                        typeTag(q),
+                        typeTag(r),
+                        typeTag(s)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple19ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> RowReaderFactory<Tuple20<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p,
+            Class<Q> q,
+            Class<R> r,
+            Class<S> s,
+            Class<T> t
+    ) {
+        final TypeTags.TypeTag<Tuple20<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>> tupleTT =
+                typeTag(Tuple20.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l),
+                        typeTag(m),
+                        typeTag(n),
+                        typeTag(o),
+                        typeTag(p),
+                        typeTag(q),
+                        typeTag(r),
+                        typeTag(s),
+                        typeTag(t)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple20ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> RowReaderFactory<Tuple21<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p,
+            Class<Q> q,
+            Class<R> r,
+            Class<S> s,
+            Class<T> t,
+            Class<U> u
+    ) {
+        final TypeTags.TypeTag<Tuple21<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>> tupleTT =
+                typeTag(Tuple21.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l),
+                        typeTag(m),
+                        typeTag(n),
+                        typeTag(o),
+                        typeTag(p),
+                        typeTag(q),
+                        typeTag(r),
+                        typeTag(s),
+                        typeTag(t),
+                        typeTag(u)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple21ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u));
+    }
+
+    /**
+     * Creates a RowReaderFactory instance for reading tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> RowReaderFactory<Tuple22<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>> mapRowToTuple(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p,
+            Class<Q> q,
+            Class<R> r,
+            Class<S> s,
+            Class<T> t,
+            Class<U> u,
+            Class<V> v
+    ) {
+        final TypeTags.TypeTag<Tuple22<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>> tupleTT =
+                typeTag(Tuple22.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l),
+                        typeTag(m),
+                        typeTag(n),
+                        typeTag(o),
+                        typeTag(p),
+                        typeTag(q),
+                        typeTag(r),
+                        typeTag(s),
+                        typeTag(t),
+                        typeTag(u),
+                        typeTag(v)
+                );
+        return new ClassBasedRowReaderFactory<>(tupleTT, tuple22ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v));
+    }
+
+    // -------------------------------------------------------------------------
     //              Row writer factory creation methods 
     // -------------------------------------------------------------------------
 
@@ -378,8 +1167,18 @@ public class CassandraJavaUtil {
      * Creates a row writer factory which can map objects supported by a given column mapper to columns
      * in a table.
      */
-    public static <T> RowWriterFactory<T> mapToRow(Class<T> targetClass, ColumnMapper<T> columnMapper) {
+    @SuppressWarnings("unchecked")
+    public static <T> RowWriterFactory<T> mapToRow(Class<?> targetClass, ColumnMapper<T> columnMapper) {
         TypeTags.TypeTag<T> tt = typeTag(targetClass);
+        return defaultRowWriterFactory(tt, columnMapper);
+    }
+
+    /**
+     * Creates a row writer factory which can map objects supported by a given column mapper to columns
+     * in a table.
+     */
+    public static <T> RowWriterFactory<T> safeMapToRow(Class<T> targetClass, ColumnMapper<T> columnMapper) {
+        TypeTags.TypeTag<T> tt = safeTypeTag(targetClass);
         return defaultRowWriterFactory(tt, columnMapper);
     }
 
@@ -400,7 +1199,8 @@ public class CassandraJavaUtil {
      * be used, see {@link #mapToRow(Class, ColumnMapper)} method.
      */
     public static <T> RowWriterFactory<T> mapToRow(
-            Class<T> sourceClass, Map<String, String> columnNameMappings) {
+            Class<T> sourceClass, Map<String, String> columnNameMappings
+    ) {
         ColumnMapper<T> mapper = javaBeanColumnMapper(safeClassTag(sourceClass), columnNameMappings);
         return mapToRow(sourceClass, mapper);
     }
@@ -420,6 +1220,439 @@ public class CassandraJavaUtil {
      */
     public static <T> RowWriterFactory<T> mapToRow(Class<T> sourceClass, Pair... columnNameMappings) {
         return mapToRow(sourceClass, convertToMap(columnNameMappings));
+    }
+
+    // -------------------------------------------------------------------------
+    //              Tuples to row mapper
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A> RowWriterFactory<Tuple1<A>> mapTupleToRow(
+            Class<A> a
+    ) {
+        return mapToRow(Tuple1.class, tuple1ColumnMapper(a));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B> RowWriterFactory<Tuple2<A, B>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b
+    ) {
+        return mapToRow(Tuple2.class, tuple2ColumnMapper(a, b));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B, C> RowWriterFactory<Tuple3<A, B, C>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c
+    ) {
+        return mapToRow(Tuple3.class, tuple3ColumnMapper(a, b, c));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B, C, D> RowWriterFactory<Tuple4<A, B, C, D>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d
+    ) {
+        return mapToRow(Tuple4.class, tuple4ColumnMapper(a, b, c, d));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B, C, D, E> RowWriterFactory<Tuple5<A, B, C, D, E>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e
+    ) {
+        return mapToRow(Tuple5.class, tuple5ColumnMapper(a, b, c, d, e));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F> RowWriterFactory<Tuple6<A, B, C, D, E, F>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f
+    ) {
+        return mapToRow(Tuple6.class, tuple6ColumnMapper(a, b, c, d, e, f));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G> RowWriterFactory<Tuple7<A, B, C, D, E, F, G>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g
+    ) {
+        return mapToRow(Tuple7.class, tuple7ColumnMapper(a, b, c, d, e, f, g));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H> RowWriterFactory<Tuple8<A, B, C, D, E, F, G, H>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h
+    ) {
+        return mapToRow(Tuple8.class, tuple8ColumnMapper(a, b, c, d, e, f, g, h));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I> RowWriterFactory<Tuple9<A, B, C, D, E, F, G, H, I>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i
+    ) {
+        return mapToRow(Tuple9.class, tuple9ColumnMapper(a, b, c, d, e, f, g, h, i));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J> RowWriterFactory<Tuple10<A, B, C, D, E, F, G, H, I, J>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j
+    ) {
+        return mapToRow(Tuple10.class, tuple10ColumnMapper(a, b, c, d, e, f, g, h, i, j));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K> RowWriterFactory<Tuple11<A, B, C, D, E, F, G, H, I, J, K>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k
+    ) {
+        return mapToRow(Tuple11.class, tuple11ColumnMapper(a, b, c, d, e, f, g, h, i, j, k));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L> RowWriterFactory<Tuple12<A, B, C, D, E, F, G, H, I, J, K, L>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l
+    ) {
+        return mapToRow(Tuple12.class, tuple12ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M> RowWriterFactory<Tuple13<A, B, C, D, E, F, G, H, I, J, K, L, M>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m
+    ) {
+        return mapToRow(Tuple13.class, tuple13ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l, m));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N> RowWriterFactory<Tuple14<A, B, C, D, E, F, G, H, I, J, K, L, M, N>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n
+    ) {
+        return mapToRow(Tuple14.class, tuple14ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l, m, n));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> RowWriterFactory<Tuple15<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o
+    ) {
+        return mapToRow(Tuple15.class, tuple15ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> RowWriterFactory<Tuple16<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p
+    ) {
+        return mapToRow(Tuple16.class, tuple16ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> RowWriterFactory<Tuple17<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p,
+            Class<Q> q
+    ) {
+        return mapToRow(Tuple17.class, tuple17ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> RowWriterFactory<Tuple18<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p,
+            Class<Q> q,
+            Class<R> r
+    ) {
+        return mapToRow(Tuple18.class, tuple18ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> RowWriterFactory<Tuple19<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p,
+            Class<Q> q,
+            Class<R> r,
+            Class<S> s
+    ) {
+        return mapToRow(Tuple19.class, tuple19ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> RowWriterFactory<Tuple20<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p,
+            Class<Q> q,
+            Class<R> r,
+            Class<S> s,
+            Class<T> t
+    ) {
+        return mapToRow(Tuple20.class, tuple20ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> RowWriterFactory<Tuple21<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p,
+            Class<Q> q,
+            Class<R> r,
+            Class<S> s,
+            Class<T> t,
+            Class<U> u
+    ) {
+        return mapToRow(Tuple21.class, tuple21ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u));
+    }
+
+    /**
+     * Creates a RowWriterFactory instance for writing tuples with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> RowWriterFactory<Tuple22<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>> mapTupleToRow(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p,
+            Class<Q> q,
+            Class<R> r,
+            Class<S> s,
+            Class<T> t,
+            Class<U> u,
+            Class<V> v
+    ) {
+        return mapToRow(Tuple22.class, tuple22ColumnMapper(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v));
     }
 
     // -------------------------------------------------------------------------
@@ -515,5 +1748,756 @@ public class CassandraJavaUtil {
         return Option.apply(connector);
     }
 
+    // -------------------------------------------------------------------------
+    //              Tuple column mappers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A> TupleColumnMapper<Tuple1<A>> tuple1ColumnMapper(
+            Class<A> a
+    ) {
+        final TypeTags.TypeTag<Tuple1<A>> typeTag =
+                typeTag(Tuple1.class,
+                        typeTag(a)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B> TupleColumnMapper<Tuple2<A, B>> tuple2ColumnMapper(
+            Class<A> a,
+            Class<B> b
+    ) {
+        final TypeTags.TypeTag<Tuple2<A, B>> typeTag =
+                typeTag(Tuple2.class,
+                        typeTag(a),
+                        typeTag(b)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B, C> TupleColumnMapper<Tuple3<A, B, C>> tuple3ColumnMapper(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c
+    ) {
+        final TypeTags.TypeTag<Tuple3<A, B, C>> typeTag =
+                typeTag(Tuple3.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B, C, D> TupleColumnMapper<Tuple4<A, B, C, D>> tuple4ColumnMapper(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d
+    ) {
+        final TypeTags.TypeTag<Tuple4<A, B, C, D>> typeTag =
+                typeTag(Tuple4.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B, C, D, E> TupleColumnMapper<Tuple5<A, B, C, D, E>> tuple5ColumnMapper(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e
+    ) {
+        final TypeTags.TypeTag<Tuple5<A, B, C, D, E>> typeTag =
+                typeTag(Tuple5.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B, C, D, E, F> TupleColumnMapper<Tuple6<A, B, C, D, E, F>> tuple6ColumnMapper(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f
+    ) {
+        final TypeTags.TypeTag<Tuple6<A, B, C, D, E, F>> typeTag =
+                typeTag(Tuple6.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G> TupleColumnMapper<Tuple7<A, B, C, D, E, F, G>> tuple7ColumnMapper(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g
+    ) {
+        final TypeTags.TypeTag<Tuple7<A, B, C, D, E, F, G>> typeTag =
+                typeTag(Tuple7.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H> TupleColumnMapper<Tuple8<A, B, C, D, E, F, G, H>> tuple8ColumnMapper(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h
+    ) {
+        final TypeTags.TypeTag<Tuple8<A, B, C, D, E, F, G, H>> typeTag =
+                typeTag(Tuple8.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I> TupleColumnMapper<Tuple9<A, B, C, D, E, F, G, H, I>> tuple9ColumnMapper(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i
+    ) {
+        final TypeTags.TypeTag<Tuple9<A, B, C, D, E, F, G, H, I>> typeTag =
+                typeTag(Tuple9.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J> TupleColumnMapper<Tuple10<A, B, C, D, E, F, G, H, I, J>> tuple10ColumnMapper(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j
+    ) {
+        final TypeTags.TypeTag<Tuple10<A, B, C, D, E, F, G, H, I, J>> typeTag =
+                typeTag(Tuple10.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K> TupleColumnMapper<Tuple11<A, B, C, D, E, F, G, H, I, J, K>> tuple11ColumnMapper(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k
+    ) {
+        final TypeTags.TypeTag<Tuple11<A, B, C, D, E, F, G, H, I, J, K>> typeTag =
+                typeTag(Tuple11.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L> TupleColumnMapper<Tuple12<A, B, C, D, E, F, G, H, I, J, K, L>> tuple12ColumnMapper(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l
+    ) {
+        final TypeTags.TypeTag<Tuple12<A, B, C, D, E, F, G, H, I, J, K, L>> typeTag =
+                typeTag(Tuple12.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M> TupleColumnMapper<Tuple13<A, B, C, D, E, F, G, H, I, J, K, L, M>> tuple13ColumnMapper(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m
+    ) {
+        final TypeTags.TypeTag<Tuple13<A, B, C, D, E, F, G, H, I, J, K, L, M>> typeTag =
+                typeTag(Tuple13.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l),
+                        typeTag(m)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N> TupleColumnMapper<Tuple14<A, B, C, D, E, F, G, H, I, J, K, L, M, N>> tuple14ColumnMapper(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n
+    ) {
+        final TypeTags.TypeTag<Tuple14<A, B, C, D, E, F, G, H, I, J, K, L, M, N>> typeTag =
+                typeTag(Tuple14.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l),
+                        typeTag(m),
+                        typeTag(n)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> TupleColumnMapper<Tuple15<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>> tuple15ColumnMapper(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o
+    ) {
+        final TypeTags.TypeTag<Tuple15<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>> typeTag =
+                typeTag(Tuple15.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l),
+                        typeTag(m),
+                        typeTag(n),
+                        typeTag(o)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> TupleColumnMapper<Tuple16<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>> tuple16ColumnMapper(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p
+    ) {
+        final TypeTags.TypeTag<Tuple16<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>> typeTag =
+                typeTag(Tuple16.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l),
+                        typeTag(m),
+                        typeTag(n),
+                        typeTag(o),
+                        typeTag(p)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> TupleColumnMapper<Tuple17<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>> tuple17ColumnMapper(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p,
+            Class<Q> q
+    ) {
+        final TypeTags.TypeTag<Tuple17<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>> typeTag =
+                typeTag(Tuple17.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l),
+                        typeTag(m),
+                        typeTag(n),
+                        typeTag(o),
+                        typeTag(p),
+                        typeTag(q)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> TupleColumnMapper<Tuple18<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>> tuple18ColumnMapper(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p,
+            Class<Q> q,
+            Class<R> r
+    ) {
+        final TypeTags.TypeTag<Tuple18<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>> typeTag =
+                typeTag(Tuple18.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l),
+                        typeTag(m),
+                        typeTag(n),
+                        typeTag(o),
+                        typeTag(p),
+                        typeTag(q),
+                        typeTag(r)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> TupleColumnMapper<Tuple19<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>> tuple19ColumnMapper(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p,
+            Class<Q> q,
+            Class<R> r,
+            Class<S> s
+    ) {
+        final TypeTags.TypeTag<Tuple19<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>> typeTag =
+                typeTag(Tuple19.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l),
+                        typeTag(m),
+                        typeTag(n),
+                        typeTag(o),
+                        typeTag(p),
+                        typeTag(q),
+                        typeTag(r),
+                        typeTag(s)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> TupleColumnMapper<Tuple20<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>> tuple20ColumnMapper(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p,
+            Class<Q> q,
+            Class<R> r,
+            Class<S> s,
+            Class<T> t
+    ) {
+        final TypeTags.TypeTag<Tuple20<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>> typeTag =
+                typeTag(Tuple20.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l),
+                        typeTag(m),
+                        typeTag(n),
+                        typeTag(o),
+                        typeTag(p),
+                        typeTag(q),
+                        typeTag(r),
+                        typeTag(s),
+                        typeTag(t)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> TupleColumnMapper<Tuple21<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>> tuple21ColumnMapper(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p,
+            Class<Q> q,
+            Class<R> r,
+            Class<S> s,
+            Class<T> t,
+            Class<U> u
+    ) {
+        final TypeTags.TypeTag<Tuple21<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>> typeTag =
+                typeTag(Tuple21.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l),
+                        typeTag(m),
+                        typeTag(n),
+                        typeTag(o),
+                        typeTag(p),
+                        typeTag(q),
+                        typeTag(r),
+                        typeTag(s),
+                        typeTag(t),
+                        typeTag(u)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
+
+    /**
+     * Provides a column mapper for the tuple with given parameter types.
+     */
+    public static <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> TupleColumnMapper<Tuple22<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>> tuple22ColumnMapper(
+            Class<A> a,
+            Class<B> b,
+            Class<C> c,
+            Class<D> d,
+            Class<E> e,
+            Class<F> f,
+            Class<G> g,
+            Class<H> h,
+            Class<I> i,
+            Class<J> j,
+            Class<K> k,
+            Class<L> l,
+            Class<M> m,
+            Class<N> n,
+            Class<O> o,
+            Class<P> p,
+            Class<Q> q,
+            Class<R> r,
+            Class<S> s,
+            Class<T> t,
+            Class<U> u,
+            Class<V> v
+    ) {
+        final TypeTags.TypeTag<Tuple22<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>> typeTag =
+                typeTag(Tuple22.class,
+                        typeTag(a),
+                        typeTag(b),
+                        typeTag(c),
+                        typeTag(d),
+                        typeTag(e),
+                        typeTag(f),
+                        typeTag(g),
+                        typeTag(h),
+                        typeTag(i),
+                        typeTag(j),
+                        typeTag(k),
+                        typeTag(l),
+                        typeTag(m),
+                        typeTag(n),
+                        typeTag(o),
+                        typeTag(p),
+                        typeTag(q),
+                        typeTag(r),
+                        typeTag(s),
+                        typeTag(t),
+                        typeTag(u),
+                        typeTag(v)
+                );
+        return new TupleColumnMapper<>(typeTag);
+    }
 
 }


### PR DESCRIPTION
Added methods to CassandraJavaUtil which allow to create RowReaderFactory and RowWriterFactory for tuples.