### PR TITLE
SPARKC-208: Fix setting split size in MB

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableRowReaderProvider.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableRowReaderProvider.scala
@@ -31,7 +31,7 @@ trait CassandraTableRowReaderProvider[R] {
 
   protected def splitCount: Option[Int] = readConf.splitCount
 
-  protected def splitSizeInMB: Int = readConf.splitSizeInMB
+  protected def splitSize: Int = readConf.splitSizeInMB * 1024 * 1024
 
   protected def fetchSize: Int = readConf.fetchSizeInRows
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
@@ -116,7 +116,7 @@ class CassandraTableScanRDD[R] private[connector](
 
   override def getPartitions: Array[Partition] = {
     verify() // let's fail fast
-    val partitioner = CassandraRDDPartitioner(connector, tableDef, splitCount, splitSizeInMB)
+    val partitioner = CassandraRDDPartitioner(connector, tableDef, splitCount, splitSize)
     val partitions = partitioner.partitions(where)
     logDebug(s"Created total ${partitions.length} partitions for $keyspaceName.$tableName.")
     logTrace("Partitions: \n" + partitions.mkString("\n"))


### PR DESCRIPTION
The parameter spark.cassandra.input.split_size_in_mb now sets the
size in megabytes, not bytes.