### PR TITLE
SPARKC-205: Improve thread-leak test even more

### DIFF
--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -438,23 +438,31 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
   }
 
   it should "not leak threads" in {
+
+    def threadCount() = {
+      // Before returning active thread count, wait while thread count is decreasing,
+      // to give spark some time to terminate temporary threads and not count them
+      val counts = Iterator.continually { Thread.sleep(500); Thread.activeCount() }
+      counts.sliding(2)
+        .dropWhile { case Seq(prev, current) => current < prev }
+        .next().head
+    }
+
     // compute a few RDDs so the thread pools get initialized
     // using parallel range, to initialize parallel collections fork-join-pools
-    val iterationCount = 128
+    val iterationCount = 256
     for (i <- (1 to iterationCount).par)
       sc.cassandraTable(ks, "key_value").collect()
-    Thread.sleep(1000)  // give Spark some time to close any background threads it created
 
     // subsequent computations of RDD should reuse already created thread pools,
     // not instantiate new ones
-    val startThreadCount = Thread.activeCount()
+    val startThreadCount = threadCount()
     val oldThreads = Thread.getAllStackTraces.keySet().toSet
 
     for (i <- (1 to iterationCount).par)
       sc.cassandraTable(ks, "key_value").collect()
 
-    Thread.sleep(1000)  // give Spark some time to close any background threads it created
-    val endThreadCount = Thread.activeCount()
+    val endThreadCount = threadCount()
     val newThreads = Thread.getAllStackTraces.keySet().toSet
     val createdThreads = newThreads -- oldThreads
     println("Start thread count: " + startThreadCount)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -443,6 +443,7 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
     val iterationCount = 128
     for (i <- (1 to iterationCount).par)
       sc.cassandraTable(ks, "key_value").collect()
+    Thread.sleep(1000)  // give Spark some time to close any background threads it created
 
     // subsequent computations of RDD should reuse already created thread pools,
     // not instantiate new ones
@@ -452,6 +453,7 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
     for (i <- (1 to iterationCount).par)
       sc.cassandraTable(ks, "key_value").collect()
 
+    Thread.sleep(1000)  // give Spark some time to close any background threads it created
     val endThreadCount = Thread.activeCount()
     val newThreads = Thread.getAllStackTraces.keySet().toSet
     val createdThreads = newThreads -- oldThreads


### PR DESCRIPTION
Added Thread.sleep before measuring active thread count. It looks
like Spark 1.3 is not immediately terminating some worker threads after
doing all the work.