### PR TITLE
SPARKC-210: Update DataFrame Tests and Docs to 1.4 API

### DIFF
--- a/doc/14_data_frames.md
+++ b/doc/14_data_frames.md
@@ -25,7 +25,7 @@ Those followed with a default of N/A are required, all others are optional.
 
 ####Read, Writing and CassandraConnector Options
 Any normal Spark Connector configuration options for Connecting, Reading or Writing
-can be passed through as DataFrame options as well. When using the `load` command below these 
+can be passed through as DataFrame options as well. When using the `read` command below these 
 options should appear exactly the same as when set in the SparkConf.
 
 ####Setting Cluster and Keyspace Level Options
@@ -45,39 +45,44 @@ val conf = new SparkConf()
 
 ...
 
-val df = sqlContext.load(
-  "org.apache.spark.sql.cassandra", 
-   options = Map( "table" -> "words", "keyspace" -> "test" 
-)// This DataFrame will use a spark.cassandra.input.size of 5000
+val df = sqlContext
+  .read
+  .format("org.apache.spark.sql.cassandra")
+  .options(Map( "table" -> "words", "keyspace" -> "test"))
+  .load()// This DataFrame will use a spark.cassandra.input.size of 5000
 
-val otherdf =  sqlContext.load(
-  "org.apache.spark.sql.cassandra", 
-   options = Map( "table" -> "words", "keyspace" -> "test" , "cluster" -> "ClusterOne" )
-)// This DataFrame will use a spark.cassandra.input.size of 1000
+val otherdf =  sqlContext
+  .read
+  .format("org.apache.spark.sql.cassandra")
+  .options(Map( "table" -> "words", "keyspace" -> "test" , "cluster" -> "ClusterOne"))
+  .load()// This DataFrame will use a spark.cassandra.input.size of 1000
 
-val lastdf = sqlContext.load(
-               "org.apache.spark.sql.cassandra", 
-                options = Map( 
-                  "table" -> "words", 
-                  "keyspace" -> "test" ,
-                  "cluster" -> "ClusterOne",
-                  "spark.cassandra.input.split.size" -> 500
-                )
-)// This DataFrame will use a spark.cassandra.input.split.size of 500
+val lastdf = sqlContext
+  .read
+  .format("org.apache.spark.sql.cassandra")
+  .options(Map( 
+    "table" -> "words", 
+    "keyspace" -> "test" ,
+    "cluster" -> "ClusterOne",
+    "spark.cassandra.input.split.size" -> 500
+    )
+  ).load()// This DataFrame will use a spark.cassandra.input.split.size of 500
 ```
 
-###Creating DataFrames using Load Commands
+###Creating DataFrames using Read Commands
 
-The most programmatic way to create a data frame is to invoke a `load` command on the SQLContext. 
-This function takes a `String` (the DataSource Class) as the first argument and a 
-`Map[String,String]` of options as described above.
+The most programmatic way to create a data frame is to invoke a `read` command on the SQLContext. This
+ will build a `DataFrameReader`. Specify `format` as `org.apache.spark.sql.cassandra`. 
+ You can then use `options` to give a map of `Map[String,String]` of options as described above. 
+ Then finish by calling `load` to actually get a `DataFrame`.
 
-Example Creating a DataFrame using a Load Command
+Example Creating a DataFrame using a Read Command
 ```scala
-val df = sqlContext.load(
-  "org.apache.spark.sql.cassandra", 
-   options = Map( "table" -> "words", "keyspace" -> "test" )
-   )
+val df = sqlContext
+  .read
+  .source("org.apache.spark.sql.cassandra")
+  .options(Map( "table" -> "words", "keyspace" -> "test" ))
+  .load()
 df.show
 //word count
 //cat  30
@@ -129,13 +134,14 @@ Table.
 
 Example Copying Between Two Tables Using DataFrames
 ```scala
-val df = sqlContext.load(
-  "org.apache.spark.sql.cassandra", 
-  options = Map( "table" -> "words", "keyspace" -> "test" )
-)
+val df = sqlContext
+  .read
+  .format("org.apache.spark.sql.cassandra")
+  .options(Map( "table" -> "words", "keyspace" -> "test" ))
+  .load()
 
-df.save(
-  "org.apache.spark.sql.cassandra",
-  options = Map( "table" -> "words_copy", "keyspace" -> "test")
-)
+df.write
+  .format("org.apache.spark.sql.cassandra")
+  .options(Map( "table" -> "words_copy", "keyspace" -> "test"))
+  .save()
 ```

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
@@ -95,18 +95,22 @@ class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase with Logging 
       session.execute("CREATE TABLE IF NOT EXISTS sql_ds_test.test_insert1 (a INT PRIMARY KEY, b INT)")
     }
 
-    sqlContext.sql("SELECT a, b from tmpTable").save(
-      "org.apache.spark.sql.cassandra",
-      ErrorIfExists,
-      Map("table" -> "test_insert1", "keyspace" -> "sql_ds_test"))
+    sqlContext.sql("SELECT a, b from tmpTable")
+      .write
+      .format("org.apache.spark.sql.cassandra")
+      .mode(ErrorIfExists)
+      .options(Map("table" -> "test_insert1", "keyspace" -> "sql_ds_test"))
+      .save()
 
     cassandraTable(TableRef("test_insert1", "sql_ds_test")).collect() should have length 1
 
     val message = intercept[UnsupportedOperationException] {
-      sqlContext.sql("SELECT a, b from tmpTable").save(
-        "org.apache.spark.sql.cassandra",
-        ErrorIfExists,
-        Map("table" -> "test_insert1", "keyspace" -> "sql_ds_test"))
+      sqlContext.sql("SELECT a, b from tmpTable")
+        .write
+        .format("org.apache.spark.sql.cassandra")
+        .mode(ErrorIfExists)
+        .options(Map("table" -> "test_insert1", "keyspace" -> "sql_ds_test"))
+        .save()
     }.getMessage
 
     assert(
@@ -121,10 +125,12 @@ class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase with Logging 
       session.execute("INSERT INTO sql_ds_test.test_insert2 (a, b) VALUES (5,6)")
     }
 
-    sqlContext.sql("SELECT a, b from tmpTable").save(
-      "org.apache.spark.sql.cassandra",
-      Overwrite,
-      Map("table" -> "test_insert2", "keyspace" -> "sql_ds_test"))
+    sqlContext.sql("SELECT a, b from tmpTable")
+      .write
+      .format("org.apache.spark.sql.cassandra")
+      .mode(Overwrite)
+      .options(Map("table" -> "test_insert2", "keyspace" -> "sql_ds_test"))
+      .save()
     createTempTable("sql_ds_test", "test_insert2", "insertTable2")
     sqlContext.sql("SELECT * FROM insertTable2").collect() should have length 1
     sqlContext.dropTempTable("insertTable2")


### PR DESCRIPTION
This switches the tests from the .load(source,options) to the new
.read.format(source).options(options).load syntax which is now defined
in the SPARK 1.4 Dataframes API. A similar switch happened for the
saving operations.