### PR TITLE
Remove white spaces in c* connection host string

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -105,11 +105,10 @@ object CassandraConnectorConf extends Logging {
 
   def apply(conf: SparkConf): CassandraConnectorConf = {
     ConfigCheck.checkConfig(conf)
-    val hostsStr = "\\s+".r.replaceAllIn(conf.get(CassandraConnectionHostProperty,
-                                                  InetAddress.getLocalHost.getHostAddress), "")
+    val hostsStr = conf.get(CassandraConnectionHostProperty, InetAddress.getLocalHost.getHostAddress)
     val hosts = for {
       hostName <- hostsStr.split(",").toSet[String]
-      hostAddress <- resolveHost(hostName)
+      hostAddress <- resolveHost(hostName.trim)
     } yield hostAddress
     
     val port = conf.getInt(CassandraConnectionPortProperty, DefaultPort)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -105,7 +105,8 @@ object CassandraConnectorConf extends Logging {
 
   def apply(conf: SparkConf): CassandraConnectorConf = {
     ConfigCheck.checkConfig(conf)
-    val hostsStr = conf.get(CassandraConnectionHostProperty, InetAddress.getLocalHost.getHostAddress)
+    val hostsStr = "\\s+".r.replaceAllIn(conf.get(CassandraConnectionHostProperty,
+                                                  InetAddress.getLocalHost.getHostAddress), "")
     val hosts = for {
       hostName <- hostsStr.split(",").toSet[String]
       hostAddress <- resolveHost(hostName)


### PR DESCRIPTION
Given comma separated list and if there is space after comma then name resolution fails.