### PR TITLE
SPARKC-215: Cassandra native count is performed by `cassandraCount` method

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+1.2.4
+ * Cassandra native count is performed by `cassandraCount` method (SPARKC-215)
+
 1.2.3
  * Support for connection compressions configuration (SPARKC-124)
  * Support for connection encryption configuration (SPARKC-118)

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraJavaPairRDD.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraJavaPairRDD.java
@@ -199,4 +199,12 @@ public class CassandraJavaPairRDD<K, V> extends JavaPairRDD<K, V> {
     ) {
         return new PairRDDJavaFunctions<>(rdd()).spanBy(function, getClassTag(uClass));
     }
+
+    /**
+     * Counts the number of items in this RDD by selecting count(*) on Cassandra table.
+     */
+    public long cassandraCount() {
+        return rdd().cassandraCount();
+    }
+
 }

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraJavaRDD.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraJavaRDD.java
@@ -1,14 +1,10 @@
 package com.datastax.spark.connector.japi.rdd;
 
-import scala.collection.Seq;
-import scala.reflect.ClassTag;
-
-import static com.datastax.spark.connector.japi.CassandraJavaUtil.toSelectableColumnRefs;
-import static com.datastax.spark.connector.util.JavaApiHelper.getClassTag;
-import static com.datastax.spark.connector.util.JavaApiHelper.toScalaSeq;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.Function;
+import scala.collection.Seq;
+import scala.reflect.ClassTag;
 
 import com.datastax.spark.connector.SelectableColumnRef;
 import com.datastax.spark.connector.cql.CassandraConnector;
@@ -18,6 +14,10 @@ import com.datastax.spark.connector.japi.StreamingContextJavaFunctions;
 import com.datastax.spark.connector.rdd.CassandraRDD;
 import com.datastax.spark.connector.rdd.ReadConf;
 import com.datastax.spark.connector.util.JavaApiHelper;
+
+import static com.datastax.spark.connector.japi.CassandraJavaUtil.toSelectableColumnRefs;
+import static com.datastax.spark.connector.util.JavaApiHelper.getClassTag;
+import static com.datastax.spark.connector.util.JavaApiHelper.toScalaSeq;
 
 /**
  * A Java API wrapper over {@link CassandraRDD} to provide Spark Cassandra Connector functionality in
@@ -174,5 +174,12 @@ public class CassandraJavaRDD<R> extends JavaRDD<R> {
     public CassandraJavaRDD<R> toEmptyCassandraRDD() {
         CassandraRDD<R> newRDD = rdd().toEmptyCassandraRDD();
         return wrap(newRDD);
+    }
+
+    /**
+     * Counts the number of items in this RDD by selecting count(*) on Cassandra table.
+     */
+    public long cassandraCount() {
+        return rdd().cassandraCount();
     }
 }

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -531,7 +531,7 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
 
   // This is to trigger result set paging, unused in most other tests:
   it should "allow to count a high number of rows" in {
-    val count = sc.cassandraTable(ks, "big_table").count()
+    val count = sc.cassandraTable(ks, "big_table").cassandraCount()
     count should be (bigTableRowCount)
   }
 
@@ -690,12 +690,12 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
   }
 
   it should "count the CassandraRDD items" in {
-    val result = sc.cassandraTable(ks, "big_table").count()
+    val result = sc.cassandraTable(ks, "big_table").cassandraCount()
     result shouldBe bigTableRowCount
   }
 
   it should "count the CassandraRDD items with where predicate" in {
-    val result = sc.cassandraTable(ks, "big_table").where("key=1").count()
+    val result = sc.cassandraTable(ks, "big_table").where("key=1").cassandraCount()
     result shouldBe 1
   }
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
@@ -272,7 +272,7 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
 
   it should "have be able to be counted" in {
     val source = sc.parallelize(keys).map(x => (x, x * 100))
-    val someCass = source.joinWithCassandraTable(ks, wideTable).on(SomeColumns("key", "group")).count()
+    val someCass = source.joinWithCassandraTable(ks, wideTable).on(SomeColumns("key", "group")).cassandraCount()
     someCass should be (201)
 
   }

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
@@ -258,7 +258,7 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase {
     val rowCount = 10000
     val col = for (i <- 1 to rowCount) yield (i, 1)
     sc.parallelize(col).saveToCassandra(ks, "counters2", SomeColumns("pkey", "c"))
-    sc.cassandraTable(ks, "counters2").count should be(rowCount)
+    sc.cassandraTable(ks, "counters2").cassandraCount() should be(rowCount)
   }
 
   it should "write values of user-defined classes" in {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
@@ -80,7 +80,7 @@ class CassandraJoinRDD[L, R] private[connector](
       }
   }
 
-  override def count(): Long = {
+  override def cassandraCount(): Long = {
     columnNames match {
       case SomeColumns(_) =>
         logWarning("You are about to count rows but an explicit projection has been specified.")

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
@@ -17,6 +17,8 @@ abstract class CassandraRDD[R : ClassTag](
     dep: Seq[Dependency[_]])
   extends RDD[R](sc, dep) {
 
+  require(limit.isEmpty || limit.get > 0, "Limit must be greater than 0")
+
   /** This is slightly different than Scala this.type.
     * this.type is the unique singleton type of an object which is not compatible with other
     * instances of the same type, so returning anything other than `this` is not really possible
@@ -38,13 +40,14 @@ abstract class CassandraRDD[R : ClassTag](
 
   protected def limit: Option[Long]
 
-  require(limit.isEmpty || limit.get > 0, "Limit must be greater than 0")
-
   protected def clusteringOrder: Option[ClusteringOrder]
 
   protected def connector: CassandraConnector
 
   def toEmptyCassandraRDD: EmptyCassandraRDD[R]
+
+  /** Counts the number of items in this RDD by selecting count(*) on Cassandra table */
+  def cassandraCount(): Long
 
   /** Allows to copy this RDD with changing some of the properties */
   protected def copy(

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
@@ -223,7 +223,7 @@ class CassandraTableScanRDD[R] private[connector](
       readConf = readConf)
   }
 
-  override def count(): Long = {
+  override def cassandraCount(): Long = {
     columnNames match {
       case SomeColumns(_) =>
         logWarning("You are about to count rows but an explicit projection has been specified.")

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/EmptyCassandraRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/EmptyCassandraRDD.scala
@@ -41,6 +41,8 @@ class EmptyCassandraRDD[R : ClassTag](
       readConf = readConf)
   }
 
+  override val cassandraCount: Long = 0L
+
   override protected def getPartitions: Array[Partition] = Array.empty
 
   @DeveloperApi


### PR DESCRIPTION
Previously native Cassandra count overrode `count` method from RDD. Because of
some request for more control when to execute native count and when not to, we
renamed Cassandra native count to `cassandraCount`. Now `count` is pure Spark
count.