### PR TITLE
SPARKC-221: Added configurable delay between subsequent query retries

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 1.2.4
  * Cassandra native count is performed by `cassandraCount` method (SPARKC-215)
+ * Add a configurable delay between subsequent query retries (SPARKC-221)
 
 1.2.3
  * Support for connection compressions configuration (SPARKC-124)

--- a/doc/1_connecting.md
+++ b/doc/1_connecting.md
@@ -27,6 +27,7 @@ spark.cassandra.auth.username                        | login name for password a
 spark.cassandra.auth.password                        | password for password authentication                              |
 spark.cassandra.auth.conf.factory                    | name of a Scala module or class implementing `AuthConfFactory` providing custom authentication configuration | `com.datastax.spark.connector.cql.DefaultAuthConfFactory`
 spark.cassandra.query.retry.count                    | number of times to retry a timed-out query                        | 10
+spark.cassandra.query.retry.delay                    | the delay between subsequent retries (can be constant, like 1000; linearly increasing, like 1000+100; or exponential, like 1000\*2) | 4000\*1.5
 spark.cassandra.read.timeout_ms                      | maximum period of time to wait for a read to return               | 12000 ms
 spark.cassandra.connection.ssl.enabled               | enable secure connection to Cassandra cluster                     | false
 spark.cassandra.connection.ssl.trustStore.path       | path for the trust store being used                               | None
@@ -51,6 +52,14 @@ To import Cassandra-specific functions on `SparkContext` and `RDD` objects, call
 ```scala
 import com.datastax.spark.connector._                                    
 ```
+
+Query retry delay can be configured in few different ways:
+* `<delay in ms>` - for a constant delay before each retry
+* `<initial delay in ms>+<increase in ms>` - for a linearly increasing delay - delay before each retry
+  will be longer than the delay before the previous retry by increase factor
+* `<initial delay in ms>*<increase multiplier, float>` - for an exponentially increasing delay - delay 
+  before each retry will be as many times longer than the previous retry delay as specified 
+  by the multiplier
 
 ### Connection management
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
@@ -89,7 +89,7 @@ object DefaultConnectionFactory extends CassandraConnectionFactory {
       .addContactPoints(conf.hosts.toSeq: _*)
       .withPort(conf.nativePort)
       .withRetryPolicy(
-        new MultipleRetryPolicy(conf.queryRetryCount))
+        new MultipleRetryPolicy(conf.queryRetryCount, conf.queryRetryDelay))
       .withReconnectionPolicy(
         new ExponentialReconnectionPolicy(conf.minReconnectionDelayMillis, conf.maxReconnectionDelayMillis))
       .withLoadBalancingPolicy(

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
@@ -41,6 +41,7 @@ import com.datastax.spark.connector.cql.CassandraConnectorConf.CassandraSSLConf
   *   - `spark.cassandra.auth.password`:                        password for password authentication
   *   - `spark.cassandra.auth.conf.factory`:                    name of a Scala module or class implementing [[AuthConfFactory]] that allows to plugin custom authentication configuration
   *   - `spark.cassandra.query.retry.count`:                    how many times to reattempt a failed query (default 10)
+  *   - `spark.cassandra.query.retry.delay`:                    the delay between subsequent retries
   *   - `spark.cassandra.connection.ssl.enabled`:               enable secure connection to Cassandra cluster
   *   - `spark.cassandra.connection.ssl.trustStore.path`:      path for the trust store being used
   *   - `spark.cassandra.connection.ssl.trustStore.password`:  trust store password
@@ -229,7 +230,8 @@ object CassandraConnector extends Logging {
             connectTimeoutMillis: Int = CassandraConnectorConf.DefaultConnectTimeoutMillis,
             readTimeoutMillis: Int = CassandraConnectorConf.DefaultReadTimeoutMillis,
             connectionFactory: CassandraConnectionFactory = DefaultConnectionFactory,
-            cassandraSSLConf: CassandraSSLConf = CassandraConnectorConf.DefaultCassandraSSLConf) = {
+            cassandraSSLConf: CassandraSSLConf = CassandraConnectorConf.DefaultCassandraSSLConf,
+            queryRetryDelay: CassandraConnectorConf.RetryDelayConf = CassandraConnectorConf.DefaultQueryRetryDelay) = {
 
     val config = CassandraConnectorConf(
       hosts = hosts,
@@ -244,7 +246,9 @@ object CassandraConnector extends Logging {
       connectTimeoutMillis = connectTimeoutMillis,
       readTimeoutMillis = readTimeoutMillis,
       connectionFactory = connectionFactory,
-      cassandraSSLConf = cassandraSSLConf)
+      cassandraSSLConf = cassandraSSLConf,
+      queryRetryDelay = queryRetryDelay
+    )
 
     new CassandraConnector(config)
   }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -2,6 +2,9 @@ package com.datastax.spark.connector.cql
 
 import java.net.InetAddress
 
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scala.util.Try
 import scala.util.control.NonFatal
 
 import org.apache.spark.{Logging, SparkConf}
@@ -25,7 +28,8 @@ case class CassandraConnectorConf(
   connectTimeoutMillis: Int = CassandraConnectorConf.DefaultConnectTimeoutMillis,
   readTimeoutMillis: Int = CassandraConnectorConf.DefaultReadTimeoutMillis,
   connectionFactory: CassandraConnectionFactory = DefaultConnectionFactory,
-  cassandraSSLConf: CassandraConnectorConf.CassandraSSLConf = CassandraConnectorConf.DefaultCassandraSSLConf
+  cassandraSSLConf: CassandraConnectorConf.CassandraSSLConf = CassandraConnectorConf.DefaultCassandraSSLConf,
+  queryRetryDelay: CassandraConnectorConf.RetryDelayConf = CassandraConnectorConf.DefaultQueryRetryDelay
 )
 
 /** A factory for [[CassandraConnectorConf]] objects.
@@ -44,6 +48,59 @@ object CassandraConnectorConf extends Logging {
     enabledAlgorithms: Array[String] = SSLOptions.DEFAULT_SSL_CIPHER_SUITES
   )
 
+  trait RetryDelayConf {
+    def forRetry(retryNumber: Int): Duration
+  }
+
+  object RetryDelayConf extends Serializable {
+
+    case class ConstantDelay(delay: Duration) extends RetryDelayConf {
+      require(delay.length >= 0, "Delay must not be negative")
+
+      override def forRetry(nbRetry: Int) = delay
+    }
+
+    case class LinearDelay(initialDelay: Duration, increaseBy: Duration) extends RetryDelayConf {
+      require(initialDelay.length >= 0, "Initial delay must not be negative")
+      require(increaseBy.length > 0, "Delay increase must be greater than 0")
+
+      override def forRetry(nbRetry: Int) = initialDelay + (increaseBy * (nbRetry - 1).max(0))
+    }
+
+    case class ExponentialDelay(initialDelay: Duration, increaseBy: Double) extends RetryDelayConf {
+      require(initialDelay.length >= 0, "Initial delay must not be negative")
+      require(increaseBy > 0, "Delay increase must be greater than 0")
+
+      override def forRetry(nbRetry: Int) =
+        (initialDelay.toMillis * math.pow(increaseBy, (nbRetry - 1).max(0))).toLong milliseconds
+    }
+
+    private val ConstantDelayEx = """(\d+)""".r
+    private val LinearDelayEx = """(\d+)\+(.+)""".r
+    private val ExponentialDelayEx = """(\d+)\*(.+)""".r
+
+    def fromString(s: String): Option[RetryDelayConf] = s.trim match {
+      case "" => None
+
+      case ConstantDelayEx(delayStr) =>
+        val d = for (delay <- Try(delayStr.toInt)) yield ConstantDelay(delay milliseconds)
+        d.toOption.orElse(throw new IllegalArgumentException(
+          s"Invalid format of constant delay: $s; it should be <integer number>."))
+
+      case LinearDelayEx(delayStr, increaseStr) =>
+        val d = for (delay <- Try(delayStr.toInt); increaseBy <- Try(increaseStr.toInt))
+          yield LinearDelay(delay milliseconds, increaseBy milliseconds)
+        d.toOption.orElse(throw new IllegalArgumentException(
+          s"Invalid format of linearly increasing delay: $s; it should be <integer number>+<integer number>"))
+
+      case ExponentialDelayEx(delayStr, increaseStr) =>
+        val d = for (delay <- Try(delayStr.toInt); increaseBy <- Try(increaseStr.toDouble))
+          yield ExponentialDelay(delay milliseconds, increaseBy)
+        d.toOption.orElse(throw new IllegalArgumentException(
+          s"Invalid format of exponentially increasing delay: $s; it should be <integer number>*<real number>"))
+    }
+  }
+
   val DefaultRpcPort = 9160
   val DefaultNativePort = 9042
 
@@ -51,6 +108,7 @@ object CassandraConnectorConf extends Logging {
   val DefaultMinReconnectionDelayMillis = 1000
   val DefaultMaxReconnectionDelayMillis = 60000
   val DefaultQueryRetryCount = 10
+  val DefaultQueryRetryDelay = RetryDelayConf.ExponentialDelay(4 seconds, 1.5d)
   val DefaultConnectTimeoutMillis = 5000
   val DefaultReadTimeoutMillis = 12000
   val DefaultCassandraConnectionCompression = ProtocolOptions.Compression.NONE
@@ -68,6 +126,7 @@ object CassandraConnectorConf extends Logging {
   val CassandraMaxReconnectionDelayProperty = "spark.cassandra.connection.reconnection_delay_ms.max"
   val CassandraConnectionCompressionProperty = "spark.cassandra.connection.compression"
   val CassandraQueryRetryCountProperty = "spark.cassandra.query.retry.count"
+  val CassandraQueryRetryDelayProperty = "spark.cassandra.query.retry.delay"
   val CassandraReadTimeoutProperty = "spark.cassandra.read.timeout_ms"
 
   val CassandraConnectionSSLEnabledProperty = "spark.cassandra.connection.ssl.enabled"
@@ -89,6 +148,7 @@ object CassandraConnectorConf extends Logging {
     CassandraMaxReconnectionDelayProperty,
     CassandraConnectionCompressionProperty,
     CassandraQueryRetryCountProperty,
+    CassandraQueryRetryDelayProperty,
     CassandraReadTimeoutProperty,
     CassandraConnectionSSLEnabledProperty,
     CassandraConnectionSSLTrustStorePathProperty,
@@ -124,6 +184,8 @@ object CassandraConnectorConf extends Logging {
     val minReconnectionDelay = conf.getInt(CassandraMinReconnectionDelayProperty, DefaultMinReconnectionDelayMillis)
     val maxReconnectionDelay = conf.getInt(CassandraMaxReconnectionDelayProperty, DefaultMaxReconnectionDelayMillis)
     val queryRetryCount = conf.getInt(CassandraQueryRetryCountProperty, DefaultQueryRetryCount)
+    val queryRetryDelay = RetryDelayConf.fromString(conf.get(CassandraQueryRetryDelayProperty, ""))
+      .getOrElse(DefaultQueryRetryDelay)
     val connectTimeout = conf.getInt(CassandraConnectionTimeoutProperty, DefaultConnectTimeoutMillis)
     val readTimeout = conf.getInt(CassandraReadTimeoutProperty, DefaultReadTimeoutMillis)
 
@@ -166,7 +228,8 @@ object CassandraConnectorConf extends Logging {
       connectTimeoutMillis = connectTimeout,
       readTimeoutMillis = readTimeout,
       connectionFactory = connectionFactory,
-      cassandraSSLConf = cassandraSSLConf
+      cassandraSSLConf = cassandraSSLConf,
+      queryRetryDelay = queryRetryDelay
     )
   }
 }

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/cql/CassandraConnectorConfSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/cql/CassandraConnectorConfSpec.scala
@@ -1,8 +1,13 @@
 package com.datastax.spark.connector.cql
 
+import scala.language.postfixOps
+
 import org.apache.commons.lang3.SerializationUtils
 import org.apache.spark.SparkConf
+import scala.concurrent.duration._
 import org.scalatest.{Matchers, FlatSpec}
+
+import com.datastax.spark.connector.cql.CassandraConnectorConf.RetryDelayConf
 
 class CassandraConnectorConfSpec extends FlatSpec with Matchers {
 
@@ -39,6 +44,37 @@ class CassandraConnectorConfSpec extends FlatSpec with Matchers {
     connConf.cassandraSSLConf.trustStoreType shouldBe "JCEKS"
     connConf.cassandraSSLConf.protocol shouldBe "SSLv3"
     connConf.cassandraSSLConf.enabledAlgorithms should contain theSameElementsAs Seq("TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384", "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256")
+  }
+
+  it should "resolve default retry delay settings correctly" in {
+    val sparkConf = new SparkConf(loadDefaults = false)
+
+    val connConf = CassandraConnectorConf(sparkConf)
+    connConf.queryRetryDelay shouldBe CassandraConnectorConf.DefaultQueryRetryDelay
+  }
+
+  it should "resolve constant retry delay settings" in {
+    val sparkConf = new SparkConf(loadDefaults = false)
+    sparkConf.set("spark.cassandra.query.retry.delay", "1234")
+
+    val connConf = CassandraConnectorConf(sparkConf)
+    connConf.queryRetryDelay shouldBe RetryDelayConf.ConstantDelay(1234 milliseconds)
+  }
+
+  it should "resolve linear retry delay settings" in {
+    val sparkConf = new SparkConf(loadDefaults = false)
+    sparkConf.set("spark.cassandra.query.retry.delay", "1234+2000")
+
+    val connConf = CassandraConnectorConf(sparkConf)
+    connConf.queryRetryDelay shouldBe RetryDelayConf.LinearDelay(1234 milliseconds, 2000 milliseconds)
+  }
+
+  it should "resolve exponential retry delay settings" in {
+    val sparkConf = new SparkConf(loadDefaults = false)
+    sparkConf.set("spark.cassandra.query.retry.delay", "1234*2.3")
+
+    val connConf = CassandraConnectorConf(sparkConf)
+    connConf.queryRetryDelay shouldBe RetryDelayConf.ExponentialDelay(1234 milliseconds, 2.3d)
   }
 
 }

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/cql/RetryDelayConfSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/cql/RetryDelayConfSpec.scala
@@ -1,0 +1,33 @@
+package com.datastax.spark.connector.cql
+
+import scala.language.postfixOps
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.duration._
+import com.datastax.spark.connector.cql.CassandraConnectorConf.RetryDelayConf.{ExponentialDelay, LinearDelay, ConstantDelay}
+
+class RetryDelayConfSpec extends FlatSpec with Matchers {
+
+  "ConstantDelay" should "return the same delay regardless of the retry number" in {
+    val d = ConstantDelay(1234 milliseconds)
+    d.forRetry(1) shouldBe (1234 milliseconds)
+    d.forRetry(2) shouldBe (1234 milliseconds)
+    d.forRetry(3) shouldBe (1234 milliseconds)
+  }
+
+  "LinearDelay" should "return the calculated delay for different retry numbers" in {
+    val d = LinearDelay(1234 milliseconds, 200 milliseconds)
+    d.forRetry(1) shouldBe (1234 milliseconds)
+    d.forRetry(2) shouldBe (1434 milliseconds)
+    d.forRetry(3) shouldBe (1634 milliseconds)
+  }
+
+  "ExponentialDelay" should "return the calculated delay for different retry numbers" in {
+    val d = ExponentialDelay(1200 milliseconds, 2.5d)
+    d.forRetry(1) shouldBe (1200 milliseconds)
+    d.forRetry(2) shouldBe (3000 milliseconds)
+    d.forRetry(3) shouldBe (7500 milliseconds)
+  }
+
+}


### PR DESCRIPTION
A new configuration parameters has been introduced which can configure
various delays and delay calculation methods. It is possible to configure
a constant delay, linearly increasing delay and exponentially increasing
delay.