### PR TITLE
SPARKC-226: Change output.TP_mb_per_sec -> double

### DIFF
--- a/doc/5_saving.md
+++ b/doc/5_saving.md
@@ -140,7 +140,7 @@ increase your performance based on your workload:
   - `spark.cassandra.output.batch.buffer.size`: how many batches per single Spark task can be stored in memory before sending to Cassandra; default 1000
   - `spark.cassandra.output.concurrent.writes`: maximum number of batches executed in parallel by a single Spark task; defaults to 5
   - `spark.cassandra.output.consistency.level`: consistency level for writing; defaults to LOCAL_ONE.
-  - `spark.cassandra.output.throughput_mb_per_sec`: maximum write throughput allowed per single core in MB/s
+  - `spark.cassandra.output.throughput_mb_per_sec`: (Floating points allowed) maximum write throughput allowed per single core in MB/s
                                                     limit this on long (+8 hour) runs to 70% of your max 
                                                     throughput as seen on a smaller job for stability
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -129,7 +129,7 @@ class TableWriter[T] private (
       val batchKeyGenerator = batchRoutingKey(session, routingKeyGenerator) _
       val batchBuilder = new GroupingBatchBuilder(boundStmtBuilder, batchStmtBuilder, batchKeyGenerator,
         writeConf.batchSize, writeConf.batchGroupingBufferSize, rowIterator)
-      val rateLimiter = new RateLimiter(writeConf.throughputMiBPS * 1024L * 1024L, 1024L * 1024L)
+      val rateLimiter = new RateLimiter((writeConf.throughputMiBPS * 1024 * 1024).toLong, 1024 * 1024)
 
       logDebug(s"Writing data partition to $keyspaceName.$tableName in batches of ${writeConf.batchSize}.")
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
@@ -27,7 +27,7 @@ case class WriteConf(batchSize: BatchSize = BatchSize.Automatic,
                      batchGroupingKey: BatchGroupingKey = WriteConf.DefaultBatchGroupingKey,
                      consistencyLevel: ConsistencyLevel = WriteConf.DefaultConsistencyLevel,
                      parallelismLevel: Int = WriteConf.DefaultParallelismLevel,
-                     throughputMiBPS: Int = WriteConf.DefaultThroughputMiBPS,
+                     throughputMiBPS: Double = WriteConf.DefaultThroughputMiBPS,
                      ttl: TTLOption = TTLOption.defaultValue,
                      timestamp: TimestampOption = TimestampOption.defaultValue,
                      taskMetricsEnabled: Boolean = WriteConf.DefaultWriteTaskMetricsEnabled) {
@@ -114,7 +114,7 @@ object WriteConf {
     val parallelismLevel = conf.getInt(
       WriteParallelismLevelProperty, DefaultParallelismLevel)
 
-    val throughputMiBPS = conf.getInt(
+    val throughputMiBPS = conf.getDouble(
       WriteThroughputMiBPS, DefaultThroughputMiBPS)
 
     val metricsEnabled = conf.getBoolean(

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/WriteConfTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/WriteConfTest.scala
@@ -16,6 +16,13 @@ class WriteConfTest extends FlatSpec with Matchers {
     writeConf.parallelismLevel should be(WriteConf.DefaultParallelismLevel)
   }
 
+  it should "allow setting the rate limit as a decimal" in {
+    val conf = new SparkConf(false)
+      .set("spark.cassandra.output.throughput_mb_per_sec", "0.5")
+    val writeConf = WriteConf.fromSparkConf(conf)
+      writeConf.throughputMiBPS should equal ( 0.5 +- 0.02 )
+  }
+
   it should "allow to set consistency level" in {
     val conf = new SparkConf(false)
       .set("spark.cassandra.output.consistency.level", "THREE")


### PR DESCRIPTION
We found that having only a whole number granularity made it difficult
to actually tune the output to get maximum throuhgput. This ticket
allows the conf to be set to a double rather than an Int providing the
end user with a much greater ability to control thorughput while
maintaining backwards compatibility.