### PR TITLE
SPARKC-231: Create Cassandra table from DataFrame schema

### DIFF
--- a/doc/0_quick_start.md
+++ b/doc/0_quick_start.md
@@ -66,7 +66,7 @@ Create a `SparkContext`. Substitute `127.0.0.1` with the actual address of your 
 val sc = new SparkContext("spark://127.0.0.1:7077", "test", conf)
 ```
 
-Enable Cassandra-specific functions on the `SparkContext` and `RDD`:
+Enable Cassandra-specific functions on the `SparkContext`, `RDD`, and `DataFrame`:
 
 ```scala
 import com.datastax.spark.connector._

--- a/doc/14_data_frames.md
+++ b/doc/14_data_frames.md
@@ -146,6 +146,32 @@ df.write
   .save()
 ```
 
+###Creating a New Cassandra Table From a DataFrame Schema
+Spark Cassandra Connector adds a method to `DataFrame` that allows it to create a new Cassandra table from
+the `StructType` schema of the DataFrame. This is convenient for persisting a DataFrame to a new table, especially
+when the schema of the DataFrame is not known (fully or at all) ahead of time (at compile time of your application).
+Once the new table is created, you can persist the DataFrame to the new table using the save function described above.
+
+Example Transform DataFrame and Save to New Table
+```scala
+// Add spark connector specific methods to DataFrame
+import com.datastax.spark.connector._
+
+val df = sqlContext
+  .read
+  .format("org.apache.spark.sql.cassandra")
+  .options(Map( "table" -> "words", "keyspace" -> "test" ))
+  .load()
+
+val renamed = df.withColumnRenamed("col1", "newcolumnname")
+renamed.createCassandraTable("test", "renamed")
+
+renamed.write
+  .format("org.apache.spark.sql.cassandra")
+  .options(Map( "table" -> "renamed", "keyspace" -> "test"))
+  .save()
+```
+
 ###Pushing down clauses to Cassandra
 The dataframe api will automatically pushdown valid where clauses to Cassandra as long as the
 pushdown option is enabled (defaults to enabled.)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/DataFrameFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/DataFrameFunctions.scala
@@ -1,0 +1,20 @@
+package com.datastax.spark.connector
+
+import com.datastax.spark.connector.cql._
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.DataFrame
+
+/** Provides Cassandra-specific methods on [[org.apache.spark.sql.DataFrame]] */
+class DataFrameFunctions(dataFrame: DataFrame) extends Serializable {
+
+  val sparkContext: SparkContext = dataFrame.sqlContext.sparkContext
+
+  def createCassandraTable(keyspaceName: String,
+                           tableName: String)
+                          (implicit connector: CassandraConnector = CassandraConnector(sparkContext.getConf)): Unit = {
+
+    val table = TableDef.fromDataFrame(dataFrame, keyspaceName, tableName)
+    connector.withSessionDo(session => session.execute(table.cql))
+  }
+
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
@@ -1,8 +1,9 @@
 package com.datastax.spark.connector.cql
 
 import com.datastax.spark.connector._
-import com.datastax.spark.connector.mapper.ColumnMapper
+import com.datastax.spark.connector.mapper.{DataFrameColumnMapper, ColumnMapper}
 import org.apache.spark.Logging
+import org.apache.spark.sql.DataFrame
 
 import scala.collection.JavaConversions._
 import scala.language.existentials
@@ -169,6 +170,9 @@ object TableDef {
     * appropriate [[com.datastax.spark.connector.mapper.ColumnMapper]] for the given type. */
   def fromType[T : ColumnMapper](keyspaceName: String, tableName: String): TableDef =
     implicitly[ColumnMapper[T]].newTable(keyspaceName, tableName)
+
+  def fromDataFrame(dataFrame: DataFrame, keyspaceName: String, tableName: String): TableDef =
+    new DataFrameColumnMapper(dataFrame.schema).newTable(keyspaceName, tableName)
 }
 
 /** A Cassandra keyspace metadata that can be serialized. */

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/DataFrameColumnMapper.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/DataFrameColumnMapper.scala
@@ -1,0 +1,23 @@
+package com.datastax.spark.connector.mapper
+
+import com.datastax.spark.connector.ColumnRef
+import com.datastax.spark.connector.cql._
+import com.datastax.spark.connector.types.ColumnType
+import org.apache.spark.sql.types.StructType
+
+class DataFrameColumnMapper[T](structType: StructType) extends ColumnMapper[T] {
+  override def columnMapForWriting(struct: StructDef,
+                                   selectedColumns: IndexedSeq[ColumnRef]): ColumnMapForWriting = ???
+
+  override def columnMapForReading(struct: StructDef,
+                                   selectedColumns: IndexedSeq[ColumnRef]): ColumnMapForReading = ???
+
+  override def newTable(keyspaceName: String, tableName: String): TableDef = {
+    val columns = structType.zipWithIndex.map { case (field, i) => {
+      val columnRole = if (i == 0) PartitionKeyColumn else RegularColumn
+      ColumnDef(field.name, columnRole, ColumnType.fromSparkSqlType(field.dataType))
+    }}
+
+    TableDef(keyspaceName, tableName, Seq(columns.head), Seq.empty, columns.tail)
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/package.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/package.scala
@@ -2,6 +2,7 @@ package com.datastax.spark
 
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.DataFrame
 
 import scala.language.implicitConversions
 
@@ -57,6 +58,9 @@ package object connector {
 
   implicit def toRDDFunctions[T](rdd: RDD[T]): RDDFunctions[T] =
     new RDDFunctions(rdd)
+
+  implicit def toDataFrameFunctions(dataFrame: DataFrame): DataFrameFunctions =
+    new DataFrameFunctions(dataFrame)
 
   implicit def toPairRDDFunctions[K, V](rdd: RDD[(K, V)]): PairRDDFunctions[K, V] =
     new PairRDDFunctions(rdd)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/ColumnType.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/ColumnType.scala
@@ -10,6 +10,10 @@ import com.datastax.spark.connector.util.Symbols
 import scala.collection.JavaConversions._
 import scala.reflect.runtime.universe._
 
+import org.apache.spark.sql.types.{DataType => SparkSqlDataType, FloatType => SparkSqlFloatType,
+    DoubleType => SparkSqlDoubleType, DecimalType => SparkSqlDecimalType, BooleanType => SparkSqlBooleanType,
+    TimestampType => SparkSqlTimestampType, MapType => SparkSqlMapType, _}
+
 /** Serializable representation of column data type. */
 trait ColumnType[T] extends Serializable {
 
@@ -77,6 +81,36 @@ object ColumnType {
       case (userType: DriverUserType, _) => UserDefinedType(userType.getTypeName, fields(userType))
       case (tupleType: DriverTupleType, _) => TupleType(fields(tupleType): _*)
       case _ => primitiveTypeMap(dataType)
+    }
+  }
+
+  /** Returns natural Cassandra type for representing data of the given Spark SQL type */
+  def fromSparkSqlType(dataType: SparkSqlDataType): ColumnType[_] = {
+
+    def unsupportedType() = throw new IllegalArgumentException(s"Unsupported type: $dataType")
+
+    dataType match {
+      case ByteType => IntType
+      case ShortType => IntType
+      case IntegerType => IntType
+      case LongType => BigIntType
+      case SparkSqlFloatType => FloatType
+      case SparkSqlDoubleType => DoubleType
+      case StringType => VarCharType
+      case BinaryType => BlobType
+      case SparkSqlBooleanType => BooleanType
+      case SparkSqlTimestampType => TimestampType
+      case DateType => TimestampType
+      case SparkSqlDecimalType() => DecimalType
+      case ArrayType(sparkSqlElementType, containsNull) =>
+        val argType = fromSparkSqlType(sparkSqlElementType)
+        ListType(argType)
+      case SparkSqlMapType(sparkSqlKeyType, sparkSqlValueType, containsNull) =>
+        val keyType = fromSparkSqlType(sparkSqlKeyType)
+        val valueType = fromSparkSqlType(sparkSqlValueType)
+        MapType(keyType, valueType)
+      case _ =>
+        unsupportedType()
     }
   }
 

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/mapper/DataFrameColumnMapperTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/mapper/DataFrameColumnMapperTest.scala
@@ -1,0 +1,27 @@
+package com.datastax.spark.connector.mapper
+
+import com.datastax.spark.connector.types.{BooleanType, _}
+import org.apache.spark.sql.types.{BooleanType => SparkSqlBooleanType, _}
+import org.junit.Assert._
+import org.junit.Test
+
+class DataFrameColumnMapperTest {
+
+  @Test
+  def testNewTable(): Unit = {
+    val structType = StructType(Array(StructField("column1", IntegerType),
+      StructField("column2", ArrayType(StringType)),
+      StructField("column3", SparkSqlBooleanType)))
+
+    val columnMapper = new DataFrameColumnMapper[DataFrameColumnMapperTest](structType)
+    val table = columnMapper.newTable("keyspace", "table")
+    assertEquals("keyspace", table.keyspaceName)
+    assertEquals("table", table.tableName)
+    assertEquals(3, table.columns.size)
+    assertEquals(1, table.partitionKey.size)
+    assertEquals(IntType, table.partitionKey(0).columnType)
+    assertEquals(ListType(VarCharType), table.columns(1).columnType)
+    assertEquals(BooleanType, table.columns(2).columnType)
+  }
+
+}

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/ColumnTypeSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/ColumnTypeSpec.scala
@@ -4,6 +4,10 @@ import java.net.InetAddress
 import java.nio.ByteBuffer
 import java.util.{UUID, Date}
 
+import org.apache.spark.sql.types.{BooleanType => SparkSqlBooleanType, FloatType => SparkSqlFloatType,
+    DoubleType => SparkSqlDoubleType, TimestampType => SparkSqlTimestampType, DateType => SparkSqlDateType,
+    MapType => SparkSqlMapType, DecimalType => SparkSqlDecimalType, _}
+
 import scala.reflect.runtime.universe._
 import org.scalatest.{WordSpec, GivenWhenThen, Matchers}
 
@@ -82,6 +86,53 @@ class ColumnTypeSpec extends WordSpec with Matchers with GivenWhenThen {
       }
       "given an Option[Vector[Int]] should return ListType(IntType)" in {
         assert (ColumnType.fromScalaType(typeOf[Option[Vector[Int]]]) === ListType(IntType))
+      }
+    }
+
+    "allow to obtain a proper ColumnType from Spark SQL type" when {
+
+      "given a ByteType should return IntType" in {
+        assert (ColumnType.fromSparkSqlType(ByteType) === IntType)
+      }
+      "given a ShortType should return IntType" in {
+        assert (ColumnType.fromSparkSqlType(ShortType) === IntType)
+      }
+      "given a BooleanType should return BooleanType" in {
+        assert (ColumnType.fromSparkSqlType(SparkSqlBooleanType) === BooleanType)
+      }
+      "given an IntegerType should return IntType" in {
+        assert (ColumnType.fromSparkSqlType(IntegerType) === IntType)
+      }
+      "given a LongType should return BigIntType" in {
+        assert (ColumnType.fromSparkSqlType(LongType) === BigIntType)
+      }
+      "given a FloatType should return FloatType" in {
+        assert (ColumnType.fromSparkSqlType(SparkSqlFloatType) === FloatType)
+      }
+      "given a DoubleType should return DoubleType" in {
+        assert (ColumnType.fromSparkSqlType(SparkSqlDoubleType) === DoubleType)
+      }
+      "given a DecimalType should return DecimalType" in {
+        assert (ColumnType.fromSparkSqlType(SparkSqlDecimalType(None)) === DecimalType)
+      }
+      "given a StringType should return VarcharType" in {
+        assert (ColumnType.fromSparkSqlType(StringType) === VarCharType)
+      }
+      "given a TimestampType should return TimestampType" in {
+        assert (ColumnType.fromSparkSqlType(SparkSqlTimestampType) === TimestampType)
+      }
+      "given a DateType should return TimestampType" in {
+        assert (ColumnType.fromSparkSqlType(SparkSqlDateType) === TimestampType)
+      }
+      "given a BinaryType should return BlobType" in {
+        assert (ColumnType.fromSparkSqlType(BinaryType) === BlobType)
+      }
+      "given a ArrayType(String) should return ListType(VarcharType)" in {
+        assert (ColumnType.fromSparkSqlType(ArrayType(StringType)) === ListType(VarCharType))
+      }
+      "given a MapType(IntegerType, DateType) should return MapType(IntType, TimestampType)" in {
+        assert (ColumnType.fromSparkSqlType(SparkSqlMapType(IntegerType, SparkSqlDateType))
+            === MapType(IntType, TimestampType))
       }
     }
   }


### PR DESCRIPTION
Add methods to aid in creating a new Cassandra table based on the schema of a spark DataFrame. This makes it easy for an application to save a DataFrame to a new Cassandra table without knowing its schema.

One use case for this is to be able to read a DataFrame from a Cassandra table (not knowing or caring about its existing schema), add new columns to the schema, and save the result as a new Cassandra table.