### PR TITLE
SPARKC-225 Added UDF to collection

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+* Added UDF for collection (SPARKC-225)
+
+
 1.3.0
  * Remove white spaces in c* connection host string (fix by Noorul Islam K M)
  * Included from 1.2.5

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/udf/CollectionUDF.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/udf/CollectionUDF.scala
@@ -1,0 +1,47 @@
+package org.apache.spark.sql.cassandra.udf
+
+object CollectionUDF {
+
+  def collectionSize(s: Seq[_]): Int = {
+    s.size
+  }
+  def collectionSize(s: Set[_]): Int = {
+    s.size
+  }
+
+  def collectionSize(m: Map[_,_]): Int = {
+    m.size
+  }
+
+  def mapKeys[T](map: Map[T, _]): Seq[T] = {
+    map.keySet.toSeq
+  }
+
+  def mapValues[T](map: Map[_, T]): Seq[T] = {
+    map.values.toList.toSeq
+  }
+
+  def mapKeyContains[T](map: Map[T, _], key: T): Boolean = {
+    map.keySet.contains(key)
+  }
+
+  def mapValueContains[T](map: Map[_, T], value: T): Boolean = {
+    map.values.exists(_ == value)
+  }
+
+  def seqContains[T](seq: Seq[T], value: T): Boolean = {
+    seq.contains(value)
+  }
+
+  def setContains[T](set: Set[T], value: T): Boolean = {
+    set.contains(value)
+  }
+
+  def sortSeq[T: Ordering](seq: Seq[T]): Seq[T] = {
+    seq.sorted
+  }
+
+  def mapValue[K, V](map: Map[K, V], key: K): V = {
+    map(key)
+  }
+}


### PR DESCRIPTION
Since Spark SQL doesn't have special query parser
for operation on collection column, we need create
UDF to operate on collection at Spark SQL side.

But those UDF filters can't be pushed down to
Cassandra side though Cassandra introduced UDF
and index on collection as well.

Future work should be a custom query parser to parse
filters on collection column.
