### PR TITLE
SPARKC-223: Add withoutLogging for noisy tests

### DIFF
--- a/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/SparkTemplate.scala
+++ b/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/SparkTemplate.scala
@@ -2,6 +2,7 @@ package com.datastax.spark.connector.embedded
 
 import akka.actor.ActorSystem
 import com.datastax.spark.connector.embedded.EmbeddedCassandra._
+import org.apache.log4j.{Level, Logger}
 import org.apache.spark.{SparkConf, SparkContext, SparkEnv}
 
 trait SparkTemplate {
@@ -58,6 +59,14 @@ object SparkTemplate {
   /** Obtains the [[akka.actor.ActorSystem ActorSystem]] associated with the active
     * `SparkEnv`. */
   def actorSystem: ActorSystem = SparkEnv.get.actorSystem
+
+  def withoutLogging[T]( f: => T): T={
+    val level = Logger.getRootLogger.getLevel
+    Logger.getRootLogger.setLevel(Level.OFF)
+    val ret = f
+    Logger.getRootLogger.setLevel(level)
+    ret
+  }
 
   resetSparkContext(defaultConf)
 }

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
@@ -3,9 +3,7 @@ package com.datastax.spark.connector.rdd
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.embedded.SparkTemplate._
-import com.datastax.spark.connector.embedded._
 import com.datastax.spark.connector.rdd.partitioner.EndpointPartition
-
 
 case class KVRow(key: Int)
 
@@ -24,6 +22,7 @@ case class MissingClustering3(pk1: Int, pk2: Int, pk3: Int, cc1: Int, cc3: Int)
 case class DataCol(pk1: Int, pk2: Int, pk3: Int, d1: Int)
 
 class RDDSpec extends SparkCassandraITFlatSpecBase {
+
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultSparkConf)
@@ -185,22 +184,21 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
     checkArrayCassandraRow(result)
   }
 
-  it should "throw a meaningful exception if partition column is null when joining with Cassandra table" in {
+  it should "throw a meaningful exception if partition column is null when joining with Cassandra table" in withoutLogging{
     val source = sc.parallelize(keys).map(x ⇒ new KVWithOptionRow(None))
-
-    val ex = the [Exception] thrownBy source.joinWithCassandraTable[(Int, Long, String)](ks, tableName).collect()
+    val ex = the[Exception] thrownBy source.joinWithCassandraTable[(Int, Long, String)](ks, tableName).collect()
     ex.getMessage should include("Invalid null value for partition key part key")
   }
 
-  it should "throw a meaningful exception if partition column is null when repartitioning by replica" in {
+  it should "throw a meaningful exception if partition column is null when repartitioning by replica" in withoutLogging{
     val source = sc.parallelize(keys).map(x ⇒ (None: Option[Int], x * 100: Long))
-    val ex = the [Exception] thrownBy source.repartitionByCassandraReplica(ks, tableName, 10).collect()
+    val ex = the[Exception] thrownBy source.repartitionByCassandraReplica(ks, tableName, 10).collect()
     ex.getMessage should include("Invalid null value for key column key")
   }
 
-  it should "throw a meaningful exception if partition column is null when saving" in {
+  it should "throw a meaningful exception if partition column is null when saving" in withoutLogging{
     val source = sc.parallelize(keys).map(x ⇒ (None: Option[Int], x * 100: Long, ""))
-    val ex = the [Exception] thrownBy source.saveToCassandra(ks, tableName)
+    val ex = the[Exception] thrownBy source.saveToCassandra(ks, tableName)
     ex.getMessage should include("Invalid null value for key column key")
   }
 
@@ -277,7 +275,6 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
     someCass should be (201)
 
   }
-
 
   "A CassandraRDD " should "be joinable with Cassandra" in {
     val source = sc.cassandraTable(ks, otherTable)


### PR DESCRIPTION
Three tests in particular in the IT suite were constantly logging ERRORs
as the executor processes terminated. These messages were expected since
these tests were meant to raise exceptions. To avoid having noisy logs a
withoutLogging wrapper was added which turns off logging for the
duration of a test case.