### PR TITLE
SPARKC-149: sbt assembly task reports 4 test cases failed.

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
@@ -6,6 +6,7 @@ import org.apache.spark.Logging
 
 import scala.collection.JavaConversions._
 import scala.language.existentials
+import scala.util.Properties
 import com.datastax.driver.core.{ColumnMetadata, Metadata, TableMetadata, KeyspaceMetadata}
 import com.datastax.spark.connector.types.{CounterType, ColumnType}
 import com.datastax.spark.connector.util.Quote._
@@ -144,8 +145,8 @@ case class TableDef(
   override lazy val columnByName: Map[String, ColumnDef] =
     super.columnByName
 
-  def cql = {    
-    val columnList = columns.map(_.cql).mkString(",\n  ")
+  def cql = {
+    val columnList = columns.map(_.cql).mkString(s",${Properties.lineSeparator}  ")
     val partitionKeyClause = partitionKey.map(_.columnName).map(quote).mkString("(", ", ", ")")
     val clusteringColumnNames = clusteringColumns.map(_.columnName).map(quote)
     val primaryKeyClause = (partitionKeyClause +: clusteringColumnNames).mkString(", ")


### PR DESCRIPTION
TableDefSpec was failing when building on Windows because TableDef.cql was using '\n' when generating the column list and this was being compared in the spec to a triple-quoted string with new line characters in it (which will be '\r\n' on Windows). This will make it use the platform-specific line separator instead when generating the column list.