### PR TITLE
SPARKC-245: Separated Cassandra classpath from project classpath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ src_managed/
 project/boot/
 project/plugins/project/
 sbt/sbt-launch*.jar
+cassandra-server/*
 
 # Scala-IDE specific
 .scala_dependencies

--- a/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/SparkTemplate.scala
+++ b/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/SparkTemplate.scala
@@ -27,6 +27,7 @@ object SparkTemplate {
   val defaultConf = new SparkConf(true)
     .set("spark.cassandra.connection.host", getHost(0).getHostAddress)
     .set("spark.cassandra.connection.port", getPort(0).toString)
+    .set("spark.ui.enabled", "false")
     .set("spark.cleaner.ttl", "3600")
     .setMaster(sys.env.getOrElse("IT_TEST_SPARK_MASTER", "local[*]"))
     .setAppName("Test")

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/streaming/RDDStreamSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/streaming/RDDStreamSpec.scala
@@ -75,7 +75,7 @@ class RDDStreamingSpec
     ssc.start()
     eventually ( timeout(1 seconds) ){dataRDDs.isEmpty}
 
-    eventually ( timeout(2 seconds)) {
+    eventually ( timeout(5 seconds)) {
       val rdd = ssc.cassandraTable[WordCount]("demo", "streaming_wordcount")
       val result = rdd.collect
       result.nonEmpty should be(true)
@@ -101,7 +101,7 @@ class RDDStreamingSpec
 
      eventually ( timeout(1 seconds) ){dataRDDs.isEmpty}
 
-     eventually ( timeout(2 seconds)) {
+     eventually ( timeout(5 seconds)) {
        val rdd = ssc.cassandraTable[WordCount]("demo", "streaming_join_output")
        val result = rdd.collect
        result.nonEmpty should be(true)
@@ -140,7 +140,7 @@ class RDDStreamingSpec
 
       eventually ( timeout(1 seconds) ){dataRDDs.isEmpty}
 
-      eventually ( timeout(2 seconds)) {
+      eventually ( timeout(5 seconds)) {
         val rdd = ssc.cassandraTable[WordCount]("demo", "dstream_join_output")
         val result = rdd.collect
         result should have size (data.size)


### PR DESCRIPTION
There is a separate, independent project - cassandra-server which has a single
dependency - cassandra-all with transitive dependencies.
Classpath of this project is exported in env variable CASSANRA_CLASSPATH to JVM
running integration tests and used to run Cassandra.

Other changes:
- disable Spark UI for integration tests
- set SPARK_LOCAL_IP to 127.0.0.1 for integration tests