### PR TITLE
Make OptionConverter handle Nones as well as nulls

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
@@ -493,6 +493,7 @@ object TypeConverter {
 
     def convertPF = {
       case null => None
+      case None => None
       case other => Some(c.convert(other))
     }
   }

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/reader/CassandraRowTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/reader/CassandraRowTest.scala
@@ -25,6 +25,14 @@ class CassandraRowTest extends FunSuite with ShouldMatchers {
     assertEquals(1, row.size)
   }
 
+  test("NoneAccessTest") {
+    val row = new CassandraRow(Array("value"), Array(None))
+    assertEquals(None, row.getStringOption(0))
+    assertEquals(None, row.getStringOption("value"))
+    assertEquals(1, row.size)
+  }
+
+
   test("nullToStringTest") {
     val row = new CassandraRow(Array("value"), Array(null))
     assertEquals("CassandraRow{value: null}", row.toString())

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/TypeConverterTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/TypeConverterTest.scala
@@ -192,6 +192,7 @@ class TypeConverterTest {
   def testOption() {
     val c = TypeConverter.forType[Option[String]]
     assertEquals(None, c.convert(null))
+    assertEquals(None, c.convert(None))
     assertEquals(Some("not-null"), c.convert("not-null"))
   }
 


### PR DESCRIPTION
It would be nice if OptionConverter could handle Nones as well as null to make behaviour more intuitive.

Right now the OptionConverter will fail if I do something like:

`val none_value : Option[UUID] = None`

`val row = CassandraRow.fromMap(Map("value" -> none_value))`

`val value = row.getUUIDOption("value")`