### PR TITLE
SPARKC-262: Set write consistency level to LOCAL_QUORUM.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@
  * Added support for tinyint and smallint types (SPARKC-269)
  * Updated Java driver version to 3.0.0-alpha3.
  * Changed the way CassandraConnectorSource is obtained due to SPARK-7171 (SPARKC-268)
+ * Change write ConsistencyLevel to LOCAL_QUORUM (SPARKC-262)
 
 1.5.0 M2
  * Bump Java Driver to 2.2.0-rc3, Guava to 16.0.1 and test against Cassandra 2.2.1 (SPARKC-229)

--- a/doc/5_saving.md
+++ b/doc/5_saving.md
@@ -81,7 +81,7 @@ collection.saveToCassandra("test", "words", SomeColumns("word", "count"))
       cow |    60
       
 The driver will execute a CQL `INSERT` statement for every object in the `RDD`, 
-grouped in unlogged batches. The consistency level for writes is `ONE`. 
+grouped in unlogged batches. The consistency level for writes is `LOCAL_QUORUM`. 
 
 It is possible to specify custom column to property mapping with `SomeColumns`. If the property
 names in objects to be saved do not correspond to the column names in the destination table, use

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -228,7 +228,7 @@ in each row</td>
 </tr>
 <tr>
   <td><code>output.consistency.level</code></td>
-  <td>LOCAL_ONE</td>
+  <td>LOCAL_QUORUM</td>
   <td>Consistency level for writing</td>
 </tr>
 <tr>

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WritableToCassandra.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WritableToCassandra.scala
@@ -30,7 +30,7 @@ abstract class WritableToCassandra[T] {
    *   rdd.saveToCassandra("test", "words")
    * }}}
    *
-   * By default, writes are performed at ConsistencyLevel.ONE in order to leverage data-locality and minimize network traffic.
+   * By default, writes are performed at ConsistencyLevel.LOCAL_QUORUM.
    * This write consistency level is controlled by the following property:
    *   - spark.cassandra.output.consistency.level: consistency level for RDD writes, string matching the ConsistencyLevel enum name.
    *

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
@@ -15,7 +15,7 @@ import org.apache.spark.SparkConf
   * @param batchGroupingBufferSize the number of distinct batches that can be buffered before
   *                        they are written to Cassandra
   * @param batchGroupingKey which rows can be grouped into a single batch
-  * @param consistencyLevel consistency level for writes, default LOCAL_ONE
+  * @param consistencyLevel consistency level for writes, default LOCAL_QUORUM
   * @param parallelismLevel number of batches to be written in parallel
   * @param ttl       the default TTL value which is used when it is defined (in seconds)
   * @param timestamp the default timestamp value which is used when it is defined (in microseconds)
@@ -57,7 +57,7 @@ object WriteConf {
   val ConsistencyLevelParam = ConfigParameter[ConsistencyLevel](
     name = "spark.cassandra.output.consistency.level",
     section = ReferenceSection,
-    default = ConsistencyLevel.LOCAL_ONE,
+    default = ConsistencyLevel.LOCAL_QUORUM,
     description = """Consistency level for writing""")
 
   val BatchSizeRowsParam = ConfigParameter[Option[Int]](
@@ -131,8 +131,6 @@ object WriteConf {
     ThroughputMiBPSParam,
     TaskMetricsParam
   )
-
-
 
   def fromSparkConf(conf: SparkConf): WriteConf = {
 


### PR DESCRIPTION
With the current default write consistency level of LOCAL_ONE,
it's relatively easy to overwhelm a cluster because it only waits
for one replica to ack the write before proceeding on.
Changing the default write consistency level to LOCAL_QUORUM means
that it will do a little more natural throttling to allow the cluster to keep up
with the writes for multiple replicas.
It seems like it would make for a more stable out of the box experience.