### PR TITLE
SPARKC-266 Fixed VarInt Column filter error In Spark SQL

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+ * VarInt Column is converted to decimal stored n Spark SQL (SPARKC-266)
  * Retrieve TableSize from Cassandra system table for datasource relation (SPARKC-164)
  * Upgrade integration tests to use Cassandra 2.1.9 and upgrade Java Driver 
    to 2.1.7.1, Spark to 1.4.1 (SPARKC-248)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/SqlRowWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/SqlRowWriter.scala
@@ -2,6 +2,7 @@ package com.datastax.spark.connector.writer
 
 import com.datastax.spark.connector.ColumnRef
 import com.datastax.spark.connector.cql.TableDef
+import com.datastax.spark.connector.types.{VarIntType, ColumnType}
 import org.apache.spark.sql.catalyst.expressions.Row
 
 /** A [[RowWriter]] that can write SparkSQL `Row` objects. */
@@ -11,14 +12,22 @@ class SqlRowWriter(val table: TableDef, val selectedColumns: IndexedSeq[ColumnRe
   override val columnNames = selectedColumns.map(_.columnName)
 
   private val columns = columnNames.map(table.columnByName)
+  private val columnTypes = columns.map(_.columnType)
   private val converters = columns.map(_.columnType.converterToCassandra)
 
   /** Extracts column values from `data` object and writes them into the given buffer
     * in the same order as they are listed in the columnNames sequence. */
   override def readColumnValues(row: Row, buffer: Array[Any]) = {
     require(row.size == columnNames.size, s"Invalid row size: ${row.size} instead of ${columnNames.size}.")
-    for (i <- 0 until row.size)
-      buffer(i) = converters(i).convert(row(i))
+    for (i <- 0 until row.size) {
+      buffer(i) = columnTypes(i) match {
+        case VarIntType => row(i) match {
+          case bigDecimal: java.math.BigDecimal => bigDecimal.toBigInteger
+          case bigInteger: java.math.BigInteger => bigInteger
+        }
+        case other: ColumnType[_] => other.converterToCassandra.convert(row(i))
+      }
+    }
 
   }
 

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSQLRow.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSQLRow.scala
@@ -2,8 +2,10 @@ package org.apache.spark.sql.cassandra
 
 import java.sql.Timestamp
 import java.util.Date
+import java.math.BigInteger
 
 import org.apache.spark.sql.types.UTF8String
+import org.apache.spark.sql.types.Decimal
 
 import com.datastax.driver.core.{Row, ProtocolVersion}
 import com.datastax.spark.connector.{TupleValue, UDTValue, GettableData}
@@ -63,6 +65,7 @@ object CassandraSQLRow {
     value match {
       case date: Date => new Timestamp(date.getTime)
       case str: String => UTF8String(str)
+      case bigInteger: BigInteger => Decimal(bigInteger.toString)
       case set: Set[_] => set.map(toSparkSqlType).toSeq
       case list: List[_] => list.map(toSparkSqlType)
       case map: Map[_, _] => map map { case(k, v) => (toSparkSqlType(k), toSparkSqlType(v))}

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSourceRelation.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSourceRelation.scala
@@ -146,14 +146,12 @@ private[cassandra] class CassandraSourceRelation(
 
   /** If column is VarInt column, convert data to BigInteger */
   private def toCqlValue(columnName: String, value: Any): Any = {
-    val isVarIntColumn = tableDef.columnByName(columnName).columnType == VarIntType
-    if (isVarIntColumn) {
-      value match {
-        case decimal: org.apache.spark.sql.types.Decimal =>
-          return decimal.toJavaBigDecimal.toBigInteger
-      }
+    value match {
+      case decimal: Decimal =>
+        val isVarIntColumn = tableDef.columnByName(columnName).columnType == VarIntType
+        if (isVarIntColumn) decimal.toJavaBigDecimal.toBigInteger else value
+      case other => value
     }
-    value
   }
 
   /** Construct where clause from pushdown filters */

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSourceRelation.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSourceRelation.scala
@@ -4,7 +4,7 @@ import java.io.IOException
 
 import com.datastax.driver.core.Metadata
 import com.datastax.spark.connector.rdd.partitioner.DataSizeEstimates
-import com.datastax.spark.connector.rdd.partitioner.dht.TokenFactory
+import com.datastax.spark.connector.types.VarIntType
 import com.datastax.spark.connector.util.NameTools
 import org.apache.spark.{SparkConf, Logging}
 
@@ -15,7 +15,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.{sources, DataFrame, Row, SQLContext}
 
 import com.datastax.spark.connector._
-import com.datastax.spark.connector.cql.{CassandraConnectorConf, CassandraConnector, Schema, ColumnDef}
+import com.datastax.spark.connector.cql.{CassandraConnectorConf, CassandraConnector, Schema}
 import com.datastax.spark.connector.rdd.{CassandraRDD, ReadConf}
 import com.datastax.spark.connector.writer.{WriteConf, SqlRowWriter}
 import com.datastax.spark.connector.util.Quote._
@@ -127,17 +127,33 @@ private[cassandra] class CassandraSourceRelation(
   /** Construct Cql clause and retrieve the values from filter */
   private def filterToCqlAndValue(filter: Any): (String, Seq[Any]) = {
     filter match {
-      case sources.EqualTo(attribute, value)            => (s"${quote(attribute)} = ?", Seq(value))
-      case sources.LessThan(attribute, value)           => (s"${quote(attribute)} < ?", Seq(value))
-      case sources.LessThanOrEqual(attribute, value)    => (s"${quote(attribute)} <= ?", Seq(value))
-      case sources.GreaterThan(attribute, value)        => (s"${quote(attribute)} > ?", Seq(value))
-      case sources.GreaterThanOrEqual(attribute, value) => (s"${quote(attribute)} >= ?", Seq(value))
+      case sources.EqualTo(attribute, value)            => (s"${quote(attribute)} = ?", Seq(toCqlValue(attribute, value)))
+      case sources.LessThan(attribute, value)           => (s"${quote(attribute)} < ?", Seq(toCqlValue(attribute, value)))
+      case sources.LessThanOrEqual(attribute, value)    => (s"${quote(attribute)} <= ?", Seq(toCqlValue(attribute, value)))
+      case sources.GreaterThan(attribute, value)        => (s"${quote(attribute)} > ?", Seq(toCqlValue(attribute, value)))
+      case sources.GreaterThanOrEqual(attribute, value) => (s"${quote(attribute)} >= ?", Seq(toCqlValue(attribute, value)))
       case sources.In(attribute, values)                 =>
-        (quote(attribute) + " IN " + values.map(_ => "?").mkString("(", ", ", ")"), values.toSeq)
+        (quote(attribute) + " IN " + values.map(_ => "?").mkString("(", ", ", ")"), toCqlValues(attribute, values))
       case _ =>
         throw new UnsupportedOperationException(
           s"It's not a valid filter $filter to be pushed down, only >, <, >=, <= and In are allowed.")
     }
+  }
+
+  private def toCqlValues(columnName: String, values: Array[Any]): Seq[Any] = {
+    values.map(toCqlValue(columnName, _)).toSeq
+  }
+
+  /** If column is VarInt column, convert data to BigInteger */
+  private def toCqlValue(columnName: String, value: Any): Any = {
+    val isVarIntColumn = tableDef.columnByName(columnName).columnType == VarIntType
+    if (isVarIntColumn) {
+      value match {
+        case decimal: org.apache.spark.sql.types.Decimal =>
+          return decimal.toJavaBigDecimal.toBigInteger
+      }
+    }
+    value
   }
 
   /** Construct where clause from pushdown filters */


### PR DESCRIPTION
VarInt column is mapped to Spark Sql Decimal type, the data needs
be converted to decimal to Catalyst. It also needs to be converted
back to BigInteger when push down the filters to Cassandra.