### PR TITLE
d2b1254 (Russell Spitzer, 3 minutes ago)    SPARKC-270: Updated C* Driver Version to 3.0.0-Alpha3

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -30,7 +30,7 @@ object Versions {
 
   val Akka            = "2.3.4"
   val Cassandra       = "2.1.9"
-  val CassandraDriver = "2.2.0-rc3"
+  val CassandraDriver = "3.0.0-alpha3"
   val CommonsIO       = "2.4"
   val CommonsLang3    = "3.3.2"
   val Config          = "1.2.1"


### PR DESCRIPTION
Updated to 3.0 version of the Java Driver. The getIndex call is no longer
    valid for ColumnMetdata objects because in 3.0 columns can have multiple
    indexes. To accomadate this we now use the list of all indexes in the table
    to determine if any have targeted the column in question.

e63d828 (Russell Spitzer, 5 minutes ago)
   SPARKC-270: Remove unneccessary merge from build files

    We moved this into an earlier branch of the code so i'm removing the
    duplicate here.