### PR TITLE
SPARKC-269 Support smallint

### DIFF
--- a/doc/2_loading.md
+++ b/doc/2_loading.md
@@ -181,10 +181,12 @@ The following table shows recommended Scala types corresponding to Cassandra col
 | `list`            | `Vector`, `List`, `Iterable`, `Seq`, `IndexedSeq`, `java.util.List` 
 | `map`             | `Map`, `TreeMap`, `java.util.HashMap` 
 | `set`             | `Set`, `TreeSet`, `java.util.HashSet` 
+| `smallint`        | `Short`
 | `text`            | `String` 
 | `timestamp`       | `Long`, `java.util.Date`, `java.sql.Date`, `org.joda.time.DateTime` 
-| `uuid`            | `java.util.UUID` 
 | `timeuuid`        | `java.util.UUID` 
+| `tinyint`         | `Byte`
+| `uuid`            | `java.util.UUID` 
 | `varchar`         | `String` 
 | `varint`          | `BigInt`, `java.math.BigInteger`
 | `frozen<tuple<>>` | `TupleValue`, `scala.Product`, `org.apache.commons.lang3.tuple.Pair`, `org.apache.commons.lang3.tuple.Triple`  

--- a/doc/6_advanced_mapper.md
+++ b/doc/6_advanced_mapper.md
@@ -110,10 +110,12 @@ Cassandra column type | Object type to convert from / to
  `float`              | `java.lang.Float`    
  `inet`               | `java.net.InetAddress` 
  `int`                | `java.lang.Integer`  
+ `smallint`           | `java.lang.Short`
  `text`               | `java.lang.String` 
  `timestamp`          | `java.util.Date` 
- `uuid`               | `java.util.UUID` 
  `timeuuid`           | `java.util.UUID` 
+ `tinyint`            | `java.lang.Byte`
+ `uuid`               | `java.util.UUID` 
  `varchar`            | `java.lang.String` 
  `varint`             | `java.math.BigInteger`
  user defined         | `com.datastax.spark.connector.UDTValue`

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -29,7 +29,7 @@ object Versions {
   lazy val scalaBinary = scalaVersion.dropRight(2)
 
   val Akka            = "2.3.4"
-  val Cassandra       = "2.1.9"
+  val Cassandra       = "2.2.2"
   val CassandraDriver = "3.0.0-alpha3"
   val CommonsIO       = "2.4"
   val CommonsLang3    = "3.3.2"

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLSpec.scala
@@ -57,12 +57,12 @@ class CassandraSQLSpec extends SparkCassandraITFlatSpecBase {
     session.execute("INSERT INTO sql_test2.test2 (a, b, c) VALUES (3, 3, 3)")
 
     session.execute("CREATE TABLE IF NOT EXISTS sql_test.test_data_type (a ASCII, b INT, c FLOAT, d DOUBLE, e BIGINT, f BOOLEAN, g DECIMAL, " +
-      " h INET, i TEXT, j TIMESTAMP, k UUID, l VARINT, m SMALLINT, PRIMARY KEY ((a), b, c))")
-    session.execute("INSERT INTO sql_test.test_data_type (a, b, c, d, e, f, g, h, i, j, k, l) VALUES (" +
-      "'ascii', 10, 12.34, 12.3456789, 123344556, true, 12.36, '74.125.239.135', 'text', '2011-02-03 04:05+0000', 123e4567-e89b-12d3-a456-426655440000 ,123456)")
+      " h INET, i TEXT, j TIMESTAMP, k UUID, l VARINT, m SMALLINT, n TINYINT,  PRIMARY KEY ((a), b, c))")
+    session.execute("INSERT INTO sql_test.test_data_type (a, b, c, d, e, f, g, h, i, j, k, l, m, n) VALUES (" +
+      "'ascii', 10, 12.34, 12.3456789, 123344556, true, 12.36, '74.125.239.135', 'text', '2011-02-03 04:05+0000', 123e4567-e89b-12d3-a456-426655440000 ,123456, 22, 4)")
 
     session.execute("CREATE TABLE IF NOT EXISTS sql_test.test_data_type1 (a ASCII, b INT, c FLOAT, d DOUBLE, e BIGINT, f BOOLEAN, g DECIMAL, " +
-      " h INET, i TEXT, j TIMESTAMP, k UUID, l VARINT, m SMALLINT, PRIMARY KEY ((a), b, c))")
+      " h INET, i TEXT, j TIMESTAMP, k UUID, l VARINT, m SMALLINT, n TINYINT, PRIMARY KEY ((a), b, c))")
 
     session.execute("CREATE TABLE IF NOT EXISTS sql_test.test_collection (a INT, b SET<INT>, c MAP<INT, INT>, PRIMARY KEY (a))")
     session.execute("INSERT INTO sql_test.test_collection (a, b, c) VALUES (1, {1,2,3}, {1:2, 2:3})")

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLSpec.scala
@@ -57,12 +57,12 @@ class CassandraSQLSpec extends SparkCassandraITFlatSpecBase {
     session.execute("INSERT INTO sql_test2.test2 (a, b, c) VALUES (3, 3, 3)")
 
     session.execute("CREATE TABLE IF NOT EXISTS sql_test.test_data_type (a ASCII, b INT, c FLOAT, d DOUBLE, e BIGINT, f BOOLEAN, g DECIMAL, " +
-      " h INET, i TEXT, j TIMESTAMP, k UUID, l VARINT, PRIMARY KEY ((a), b, c))")
+      " h INET, i TEXT, j TIMESTAMP, k UUID, l VARINT, m SMALLINT, PRIMARY KEY ((a), b, c))")
     session.execute("INSERT INTO sql_test.test_data_type (a, b, c, d, e, f, g, h, i, j, k, l) VALUES (" +
       "'ascii', 10, 12.34, 12.3456789, 123344556, true, 12.36, '74.125.239.135', 'text', '2011-02-03 04:05+0000', 123e4567-e89b-12d3-a456-426655440000 ,123456)")
 
     session.execute("CREATE TABLE IF NOT EXISTS sql_test.test_data_type1 (a ASCII, b INT, c FLOAT, d DOUBLE, e BIGINT, f BOOLEAN, g DECIMAL, " +
-      " h INET, i TEXT, j TIMESTAMP, k UUID, l VARINT, PRIMARY KEY ((a), b, c))")
+      " h INET, i TEXT, j TIMESTAMP, k UUID, l VARINT, m SMALLINT, PRIMARY KEY ((a), b, c))")
 
     session.execute("CREATE TABLE IF NOT EXISTS sql_test.test_collection (a INT, b SET<INT>, c MAP<INT, INT>, PRIMARY KEY (a))")
     session.execute("INSERT INTO sql_test.test_collection (a, b, c) VALUES (1, {1,2,3}, {1:2, 2:3})")
@@ -275,12 +275,12 @@ class CassandraSQLSpec extends SparkCassandraITFlatSpecBase {
     result should have length 1
   }
 
-  it should "allow to select rows for data types of ASCII, INT, FLOAT, DOUBLE, BIGINT, BOOLEAN, DECIMAL, INET, TEXT, TIMESTAMP, UUID, VARINT" in {
+  it should "allow to select rows for data types of ASCII, INT, FLOAT, DOUBLE, BIGINT, BOOLEAN, DECIMAL, INET, TEXT, TIMESTAMP, UUID, VARINT, SMALLINT" in {
     val result = cc.sql("SELECT * FROM test_data_type").collect()
     result should have length 1
   }
 
-  it should "allow to insert rows for data types of ASCII, INT, FLOAT, DOUBLE, BIGINT, BOOLEAN, DECIMAL, INET, TEXT, TIMESTAMP, UUID, VARINT" in {
+  it should "allow to insert rows for data types of ASCII, INT, FLOAT, DOUBLE, BIGINT, BOOLEAN, DECIMAL, INET, TEXT, TIMESTAMP, UUID, VARINT, SMALLINT" in {
     val result = cc.sql("INSERT INTO TABLE test_data_type1 SELECT * FROM test_data_type").collect()
     val result1 = cc.sql("SELECT * FROM test_data_type1").collect()
     result1 should have length 1

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/ColumnType.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/ColumnType.scala
@@ -41,6 +41,7 @@ object ColumnType {
     DataType.varchar() -> VarCharType,
     DataType.cint() -> IntType,
     DataType.bigint() -> BigIntType,
+    DataType.smallint() -> SmallIntType,
     DataType.cfloat() -> FloatType,
     DataType.cdouble() -> DoubleType,
     DataType.cboolean() -> BooleanType,
@@ -90,6 +91,7 @@ object ColumnType {
     else if (dataType =:= typeOf[java.lang.Integer]) IntType
     else if (dataType =:= typeOf[Long]) BigIntType
     else if (dataType =:= typeOf[java.lang.Long]) BigIntType
+    else if (dataType =:= typeOf[java.lang.Short]) SmallIntType
     else if (dataType =:= typeOf[Float]) FloatType
     else if (dataType =:= typeOf[java.lang.Float]) FloatType
     else if (dataType =:= typeOf[Double]) DoubleType

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/ColumnType.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/ColumnType.scala
@@ -42,6 +42,7 @@ object ColumnType {
     DataType.cint() -> IntType,
     DataType.bigint() -> BigIntType,
     DataType.smallint() -> SmallIntType,
+    DataType.tinyint() -> TinyIntType,
     DataType.cfloat() -> FloatType,
     DataType.cdouble() -> DoubleType,
     DataType.cboolean() -> BooleanType,
@@ -93,6 +94,8 @@ object ColumnType {
     else if (dataType =:= typeOf[java.lang.Long]) BigIntType
     else if (dataType =:= typeOf[Short]) SmallIntType
     else if (dataType =:= typeOf[java.lang.Short]) SmallIntType
+    else if (dataType =:= typeOf[Byte]) TinyIntType
+    else if (dataType =:= typeOf[java.lang.Byte]) TinyIntType
     else if (dataType =:= typeOf[Float]) FloatType
     else if (dataType =:= typeOf[java.lang.Float]) FloatType
     else if (dataType =:= typeOf[Double]) DoubleType

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/ColumnType.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/ColumnType.scala
@@ -91,6 +91,7 @@ object ColumnType {
     else if (dataType =:= typeOf[java.lang.Integer]) IntType
     else if (dataType =:= typeOf[Long]) BigIntType
     else if (dataType =:= typeOf[java.lang.Long]) BigIntType
+    else if (dataType =:= typeOf[Short]) SmallIntType
     else if (dataType =:= typeOf[java.lang.Short]) SmallIntType
     else if (dataType =:= typeOf[Float]) FloatType
     else if (dataType =:= typeOf[java.lang.Float]) FloatType

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/PrimitiveColumnType.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/PrimitiveColumnType.scala
@@ -53,6 +53,13 @@ case object SmallIntType extends PrimitiveColumnType[Short] {
     new TypeConverter.OptionToNullConverter(TypeConverter.forType[java.lang.Short])
 }
 
+case object TinyIntType extends PrimitiveColumnType[Byte] {
+  def scalaTypeTag = TypeTag.synchronized { implicitly[TypeTag[Byte]]}
+  def cqlTypeName = "tinyint"
+  def converterToCassandra =
+    new TypeConverter.OptionToNullConverter(TypeConverter.forType[java.lang.Byte])
+}
+
 case object FloatType extends PrimitiveColumnType[Float] {
   def scalaTypeTag = TypeTag.synchronized { implicitly[TypeTag[Float]] }
   def cqlTypeName = "float"

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/PrimitiveColumnType.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/PrimitiveColumnType.scala
@@ -46,6 +46,13 @@ case object BigIntType extends PrimitiveColumnType[Long] {
     new TypeConverter.OptionToNullConverter(TypeConverter.forType[java.lang.Long])
 }
 
+case object SmallIntType extends PrimitiveColumnType[Short] {
+  def scalaTypeTag = TypeTag.synchronized { implicitly[TypeTag[Short]] }
+  def cqlTypeName = "smallint"
+  def converterToCassandra =
+    new TypeConverter.OptionToNullConverter(TypeConverter.forType[java.lang.Short])
+}
+
 case object FloatType extends PrimitiveColumnType[Float] {
   def scalaTypeTag = TypeTag.synchronized { implicitly[TypeTag[Float]] }
   def cqlTypeName = "float"

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/DataTypeConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/DataTypeConverter.scala
@@ -25,6 +25,7 @@ object DataTypeConverter extends Logging {
     connector.types.FloatType      -> catalystTypes.FloatType,
     connector.types.DoubleType     -> catalystTypes.DoubleType,
     connector.types.SmallIntType   -> catalystTypes.ShortType,
+    connector.types.TinyIntType    -> catalystTypes.ByteType,
 
     connector.types.VarIntType     -> catalystTypes.DecimalType(38, 0), // no native arbitrary-size integer type
     connector.types.DecimalType    -> catalystTypes.DecimalType(38, 18),

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/DataTypeConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/DataTypeConverter.scala
@@ -24,6 +24,7 @@ object DataTypeConverter extends Logging {
     connector.types.CounterType    -> catalystTypes.LongType,
     connector.types.FloatType      -> catalystTypes.FloatType,
     connector.types.DoubleType     -> catalystTypes.DoubleType,
+    connector.types.SmallIntType   -> catalystTypes.ShortType,
 
     connector.types.VarIntType     -> catalystTypes.DecimalType(38, 0), // no native arbitrary-size integer type
     connector.types.DecimalType    -> catalystTypes.DecimalType(38, 18),

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/ColumnTypeSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/ColumnTypeSpec.scala
@@ -56,6 +56,12 @@ class ColumnTypeSpec extends WordSpec with Matchers with GivenWhenThen {
       "given a Short should return a SmallIntType" in {
         assert (ColumnType.fromScalaType(typeOf[Short]) === SmallIntType)
       }
+      "given a Byte should return a TinyIntType" in {
+        assert (ColumnType.fromScalaType(typeOf[Byte]) === TinyIntType)
+      }
+      "given a java.lang.Byte should return a TinyIntType" in {
+        assert (ColumnType.fromScalaType(typeOf[java.lang.Byte]) === TinyIntType)
+      }
       "given a java.util.Date should return TimestampType" in {
         assert (ColumnType.fromScalaType(typeOf[java.util.Date]) === TimestampType)
       }

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/ColumnTypeSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/ColumnTypeSpec.scala
@@ -50,6 +50,12 @@ class ColumnTypeSpec extends WordSpec with Matchers with GivenWhenThen {
       "given a String should return VarcharType" in {
         assert (ColumnType.fromScalaType(typeOf[String]) === VarCharType)
       }
+      "given a java.lang.Short should return a SmallIntType" in {
+        assert (ColumnType.fromScalaType(typeOf[java.lang.Short]) === SmallIntType)
+      }
+      "given a Short should return a SmallIntType" in {
+        assert (ColumnType.fromScalaType(typeOf[Short]) === SmallIntType)
+      }
       "given a java.util.Date should return TimestampType" in {
         assert (ColumnType.fromScalaType(typeOf[java.util.Date]) === TimestampType)
       }

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/TypeSerializationTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/TypeSerializationTest.scala
@@ -27,6 +27,7 @@ class TypeSerializationTest {
     testSerialization(InetType)
     testSerialization(CounterType)
     testSerialization(SmallIntType)
+    testSerialization(TinyIntType)
   }
 
   @Test

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/TypeSerializationTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/TypeSerializationTest.scala
@@ -26,6 +26,7 @@ class TypeSerializationTest {
     testSerialization(BigIntType)
     testSerialization(InetType)
     testSerialization(CounterType)
+    testSerialization(SmallIntType)
   }
 
   @Test


### PR DESCRIPTION
Add SmallIntType case class mapped to java.lang.Short and CQL's "smallint" type

Does this need test coverage?  If there's a basic datatype spec/test somewhere that I should extend, let me know.