### PR TITLE
SPARKC-280: Added FunctionCallRef

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+ * Added FunctionCallRef extending ColumnRef whose goal is to allow UDF selects.
  * Bump Spark version to 1.6-SNAPSHOT and add Apache Snapshot repository to resolvers (SPARKC-272)
 
 ********************************************************************************


### PR DESCRIPTION
Added FunctionCallRef` class as subtype of `ColumnRef` whose goal is to represent functions selections.