### PR TITLE
SPARKC-280: Added FunctionCallRef

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+ * Added ColumRef child class to represent functions calls
+
 1.5.0 M3 (unreleased)
  * Added support for tinyint and smallint types (SPARKC-269)
  * Updated Java driver version to 3.0.0-alpha3.

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ColumnSelector.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ColumnSelector.scala
@@ -28,7 +28,13 @@ case class SomeColumns(columns: ColumnRef*) extends ColumnSelector {
   }.toMap
 
   override def selectFrom(table: TableDef): IndexedSeq[ColumnRef] = {
-    val missing = table.missingColumns(columns).filterNot(_ == RowCountRef)
+    val missing = table.missingColumns {
+      columns flatMap {
+        case f: FunctionCallRef => f.requiredColumns //Replaces function calls by their required columns
+        case RowCountRef => Seq.empty //Filters RowCountRef from the column list
+        case other => Seq(other)
+      }
+    }
     if (missing.nonEmpty) throw new NoSuchElementException(
       s"Columns not found in table ${table.name}: ${missing.mkString(", ")}")
 

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/ColumnRefSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/ColumnRefSpec.scala
@@ -1,0 +1,51 @@
+package com.datastax.spark.connector
+import org.scalatest.{Matchers, WordSpec}
+
+
+class ColumnRefSpec extends WordSpec with Matchers {
+
+  "A FunctionCallRef should" should {
+
+    //Expectations: (generated cql, required columns)
+    val valuesAndExpectations: Seq[(FunctionCallRef, (String, Seq[ColumnRef]))] = Seq(
+      // 0-arguments function
+      FunctionCallRef("f") -> (("f()", Nil)),
+
+      // Literal argument functions
+      FunctionCallRef("f", Right("3")::Nil) -> (("f(3)", Nil)),
+
+      //Columns as functions arguments
+      FunctionCallRef("f", Left(ColumnName("col01"))::Nil) -> (("""f("col01")""", ColumnName("col01")::Nil)),
+
+      FunctionCallRef("f", Left(ColumnName("col01"))::Left(ColumnName("col02"))::Nil) ->
+        (("""f("col01","col02")""", ColumnName("col01")::ColumnName("col02")::Nil)),
+
+      //Mixed columns and literal values as function arguments
+      FunctionCallRef("f", Left(ColumnName("col01"))::Right("1")::Right(""""hello"""")::Nil) ->
+        (("""f("col01",1,"hello")""", ColumnName("col01")::Nil)),
+
+      //Nested functions
+      FunctionCallRef("g",
+        Left(ColumnName("col01"))::
+          Left(FunctionCallRef("f", Left(ColumnName("col02"))::Right("1")::Right(""""hello"""")::Nil)
+          )::Nil
+      ) -> (("""g("col01",f("col02",1,"hello"))""", ColumnName("col01")::ColumnName("col02")::Nil))
+    )
+
+    //Tests generated CQLs for different function calls
+    valuesAndExpectations foreach { case (functionRef, (expectedCql, _)) =>
+      s"generate its equivalent CQL code for: $expectedCql" in {
+        functionRef.cql shouldEqual expectedCql
+      }
+    }
+
+    //Tests required columns analysis for each function call
+    valuesAndExpectations foreach { case(functionRef, (expectedCql, requiredColumns)) =>
+      s"be able to provide a list of columns used as actual parameters by: $expectedCql" in {
+        functionRef.requiredColumns shouldEqual requiredColumns
+      }
+    }
+
+  }
+
+}

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/ColumnSelectorSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/ColumnSelectorSpec.scala
@@ -31,9 +31,23 @@ class ColumnSelectorSpec extends WordSpec with Matchers {
       columns.map(_.columnName) should be equals Seq("c1", "c3", "c5")
     }
 
+    "return selections with function calls" in {
+      val selection = SomeColumns(
+        ColumnName("c1"),
+        FunctionCallRef("f", Left(ColumnName("c2"))::Nil)).selectFrom(tableDef)
+
+      selection.map(_.cql) should be equals Seq(""""c1"""", """f("c2")""")
+    }
+
     "throw a NoSuchElementException when selected column name is invalid" in {
       a[NoSuchElementException] should be thrownBy {
         SomeColumns("c1", "c3", "unknown_column").selectFrom(tableDef)
+      }
+    }
+
+    "throw a NoSuchElementException when a function call has a missing column as an actual parameter" in {
+      a[NoSuchElementException] should be thrownBy {
+        SomeColumns("c1", FunctionCallRef("f", Left(ColumnName("unknown_column"))::Nil)).selectFrom(tableDef)
       }
     }
 


### PR DESCRIPTION
Added FunctionCallRefclass as subtype of `ColumnRef` whose goal is to represent functions selections.
https://datastax-oss.atlassian.net/browse/SPARKC-280