### PR TITLE
Open Visibility on RowReader

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
@@ -49,7 +49,7 @@ class CassandraJoinRDD[L, R] private[connector](
 
   override protected val classTag = rightClassTag
 
-  override protected[connector] lazy val rowReader: RowReader[R] = manualRowReader match {
+  override lazy val rowReader: RowReader[R] = manualRowReader match {
     case Some(rr) => rr
     case None => rowReaderFactory.rowReader (tableDef, columnNames.selectFrom (tableDef) )
   }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableRowReaderProvider.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableRowReaderProvider.scala
@@ -40,7 +40,7 @@ trait CassandraTableRowReaderProvider[R] {
   /** RowReaderFactory and ClassTag should be provided from implicit parameters in the constructor
     * of the class implementing this trait
     * @see CassandraTableScanRDD */
-  protected val rowReaderFactory: RowReaderFactory[R]
+  val rowReaderFactory: RowReaderFactory[R]
 
   protected val classTag: ClassTag[R]
 


### PR DESCRIPTION
Inorder to allow more extensibility to Spark Classes we will allow other
classes to access the RowReaders built by RowReaderProvider implementing
classes.