### PR TITLE
SPARKC-287: Upgrade CassandraSqlContext and Catalog to compile v 1.6

### DIFF
--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLClusterLevelSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLClusterLevelSpec.scala
@@ -50,12 +50,13 @@ class CassandraSQLClusterLevelSpec extends SparkCassandraITFlatSpecBase {
     cc.setConf("cluster2/spark.cassandra.connection.port", getPort(1).toString)
   }
 
-  it should "allow to join tables from different clusters" in {
+  //These tests require us to fix the csc dialect and possibly get a fix in the TableIdentifier code
+  ignore should "allow to join tables from different clusters" in {
     val result = cc.sql("SELECT * FROM cluster1.sql_test1.test1 AS test1 Join cluster2.sql_test2.test2 AS test2 where test1.a=test2.a").collect()
     result should have length 2
   }
 
-  it should "allow to write data to another cluster" in {
+  ignore should "allow to write data to another cluster" in {
     val insert = cc.sql("INSERT INTO TABLE cluster2.sql_test2.test3 SELECT * FROM cluster1.sql_test1.test1 AS t1").collect()
     val result = cc.sql("SELECT * FROM cluster2.sql_test2.test3 AS test3").collect()
     result should have length 5

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSQLContext.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSQLContext.scala
@@ -2,12 +2,12 @@ package org.apache.spark.sql.cassandra
 
 import java.util.NoSuchElementException
 
-import com.datastax.spark.connector.util.ConfigParameter
-import org.apache.spark.sql.execution.datasources.DataSourceStrategy
-
-
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.cassandra.CassandraSourceRelation._
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.QueryExecution
+import org.apache.spark.sql.{execution => sparkexecution}
+import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 import org.apache.spark.sql.{DataFrame, SQLContext, Strategy}
 
 /** Allows to execute SQL queries against Cassandra and access results as
@@ -36,8 +36,8 @@ import org.apache.spark.sql.{DataFrame, SQLContext, Strategy}
 class CassandraSQLContext(sc: SparkContext) extends SQLContext(sc) {
   import org.apache.spark.sql.cassandra.CassandraSQLContext._
 
-  override protected[sql] def executePlan(plan: LogicalPlan): this.QueryExecution =
-    new this.QueryExecution(plan)
+  override protected[sql] def executePlan(plan: LogicalPlan) =
+    new sparkexecution.QueryExecution(this, plan)
 
   /** Set default Cassandra keyspace to be used when accessing tables with unqualified names. */
   def setKeyspace(ks: String) = {
@@ -78,24 +78,6 @@ class CassandraSQLContext(sc: SparkContext) extends SQLContext(sc) {
   @transient
   override protected[sql] lazy val catalog = new CassandraCatalog(this)
 
-  /** Modified Catalyst planner that does Cassandra-specific predicate pushdown */
-  @transient
-  override protected[sql] val planner = new SparkPlanner {
-    val cassandraContext = CassandraSQLContext.this
-    override val strategies: Seq[Strategy] = Seq(
-      DataSourceStrategy,
-      DDLStrategy,
-      TakeOrderedAndProject,
-      InMemoryScans,
-      HashAggregation,
-      Aggregation,
-      LeftSemiJoin,
-      EquiJoinSelection,
-      BasicOperators,
-      CartesianProduct,
-      BroadcastNestedLoopJoin
-    )
-  }
 }
 
 object CassandraSQLContext {

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSQLContext.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSQLContext.scala
@@ -3,12 +3,10 @@ package org.apache.spark.sql.cassandra
 import java.util.NoSuchElementException
 
 import org.apache.spark.SparkContext
-import org.apache.spark.sql.cassandra.CassandraSourceRelation._
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.execution.QueryExecution
-import org.apache.spark.sql.{execution => sparkexecution}
-import org.apache.spark.sql.execution.datasources.DataSourceStrategy
-import org.apache.spark.sql.{DataFrame, SQLContext, Strategy}
+import org.apache.spark.sql.{DataFrame, SQLContext, execution => sparkexecution}
+
+import com.datastax.spark.connector.util.ConfigParameter
 
 /** Allows to execute SQL queries against Cassandra and access results as
   * `SchemaRDD` collections. Predicate pushdown to Cassandra is supported.


### PR DESCRIPTION
I've had to disable some of the functionality around having a seperate
cluster identifier in TableIdentifier. SPARK-10104 changed Table
Identifier from a Seq[String] to a case class with two members Table and
Database. We've raised an issue and will find a workaround in
SPARKC-289. This commit is designed to have Master back up and running.