### PR TITLE
SPARKC-228: Warn in Streaming Applications with Small Keep_Alive

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -38,7 +38,7 @@ CassandraConnectionFactory providing connections to the Cassandra cluster</td>
 </tr>
 <tr>
   <td><code>connection.keep_alive_ms</code></td>
-  <td>250</td>
+  <td>5000</td>
   <td>Period of time to keep unused connections open</td>
 </tr>
 <tr>

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
@@ -144,8 +144,6 @@ class CassandraConnector(conf: CassandraConnectorConf)
 
 object CassandraConnector extends Logging {
 
-  val keepAliveMillis = System.getProperty("spark.cassandra.connection.keep_alive_ms", "250").toInt
-
   private[cql] val sessionCache = new RefCountedCache[CassandraConnectorConf, Session](
     createSession, destroySession, alternativeConnectionConfigs)
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -135,7 +135,7 @@ object CassandraConnectorConf extends Logging {
   val KeepAliveMillisParam = ConfigParameter[Int](
     name = "spark.cassandra.connection.keep_alive_ms",
     section = ReferenceSection,
-    default = 250,
+    default = 5000,
     description = """Period of time to keep unused connections open""")
 
   val MinReconnectionDelayParam = ConfigParameter[Int](


### PR DESCRIPTION
We've run into several end users who are running Streaming applications
with a keep_alive short enough that a new connection is made every
batch. This ends up causing a lot of stress on the C* cluster and an
unneccessary (and time consuming) slowdown every batch.

To avoid these issues, This patch increases the default keep_alive to
5 seconds. Also warn the user if they use a C* DStream option with a
lower frequency than the batch interval.