### PR TITLE
SPARKC-283: Adds CassandraOption for Skipping Empty Columns

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
  * Adds the ability to add additional Predicate Pushdown Rules at Runtime (SPARKC-308) 
+ * Added CassandraOption for Skipping Columns when Writing to C* (SPARKC-283)
  * Upgrade Spark to 1.6.0 and add Apache Snapshot repository to resolvers (SPARKC-272, SPARKC-298, SPARKC-305)
 
 ********************************************************************************

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -241,6 +241,13 @@ in each row</td>
   <td>Consistency level for writing</td>
 </tr>
 <tr>
+  <td><code>output.ignoreNulls</code></td>
+  <td>false</td>
+  <td> In Cassandra >= 2.2 null values can be left as unset in bound statements. Setting
+this to true will cause all null values to be left as unset rather than bound. For
+finer control see the CassandraOption class</td>
+</tr>
+<tr>
   <td><code>output.metrics</code></td>
   <td>true</td>
   <td>Sets whether to record connector specific metrics on write</td>

--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/RDDAndDStreamCommonJavaFunctions.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/RDDAndDStreamCommonJavaFunctions.java
@@ -176,8 +176,8 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
             if (!Objects.equals(writeConf.batchSize(), batchSize))
                 return withWriteConf(
                     new WriteConf(batchSize, writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
-                        writeConf.consistencyLevel(), writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
-                        writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
+                        writeConf.consistencyLevel(), writeConf.ignoreNulls(), writeConf.parallelismLevel(),
+                        writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
             else
                 return this;
         }
@@ -194,8 +194,8 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
             if (writeConf.batchGroupingBufferSize() != batchGroupingBufferSize)
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), batchGroupingBufferSize, writeConf.batchGroupingKey(),
-                        writeConf.consistencyLevel(), writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
-                        writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
+                        writeConf.consistencyLevel(), writeConf.ignoreNulls(), writeConf.parallelismLevel(),
+                        writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
             else
                 return this;
         }
@@ -212,8 +212,8 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
             if (!Objects.equals(writeConf.batchGroupingKey(), batchGroupingKey))
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), batchGroupingKey,
-                        writeConf.consistencyLevel(), writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
-                        writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
+                        writeConf.consistencyLevel(), writeConf.ignoreNulls(), writeConf.parallelismLevel(),
+                        writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
             else
                 return this;
         }
@@ -230,7 +230,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
             if (writeConf.consistencyLevel() != consistencyLevel)
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
-                        consistencyLevel, writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
+                        consistencyLevel, writeConf.ignoreNulls(), writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
                         writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
             else
                 return this;
@@ -248,7 +248,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
             if (writeConf.parallelismLevel() != parallelismLevel)
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
-                        writeConf.consistencyLevel(), parallelismLevel, writeConf.throughputMiBPS(),
+                        writeConf.consistencyLevel(), writeConf.ignoreNulls(), parallelismLevel, writeConf.throughputMiBPS(),
                         writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
             else
                 return this;
@@ -266,7 +266,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
             if (writeConf.throughputMiBPS() != throughputMBPS)
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
-                        writeConf.consistencyLevel(), writeConf.parallelismLevel(), throughputMBPS,
+                        writeConf.consistencyLevel(), writeConf.ignoreNulls(), writeConf.parallelismLevel(), throughputMBPS,
                         writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
             else
               return this;
@@ -284,8 +284,25 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
             if (writeConf.taskMetricsEnabled() != taskMetricsEnabled)
                 return withWriteConf(
                         new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
-                                writeConf.consistencyLevel(), writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
+                                writeConf.consistencyLevel(), writeConf.ignoreNulls(), writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
                                 writeConf.ttl(), writeConf.timestamp(), taskMetricsEnabled));
+            else
+                return this;
+        }
+
+        /**
+         * Return a copy of this builder with the new write configuration which has ignoreNulls set to enabled or disabled as specified.
+         *
+         * <p>If the same instance is passed as the one which is currently set, no copy of this builder is created.</p>
+         *
+         * @return this instance or copy to allow method invocation chaining
+         */
+        public WriterBuilder withIgnoreNulls(boolean ignoreNulls) {
+            if (writeConf.ignoreNulls() != ignoreNulls)
+                return withWriteConf(
+                        new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
+                                writeConf.consistencyLevel(), ignoreNulls, writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
+                                writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
             else
                 return this;
         }
@@ -298,6 +315,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                     writeConf.batchGroupingBufferSize(),
                     writeConf.batchGroupingKey(),
                     writeConf.consistencyLevel(),
+                    writeConf.ignoreNulls(),
                     writeConf.parallelismLevel(),
                     writeConf.throughputMiBPS(),
                     writeConf.ttl(),
@@ -377,6 +395,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                     writeConf.batchGroupingBufferSize(),
                     writeConf.batchGroupingKey(),
                     writeConf.consistencyLevel(),
+                    writeConf.ignoreNulls(),
                     writeConf.parallelismLevel(),
                     writeConf.throughputMiBPS(),
                     ttl,

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/doc/DocExamples.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/doc/DocExamples.scala
@@ -1,0 +1,115 @@
+package com.datastax.spark.connector.doc
+
+import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
+import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.types.CassandraOption
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.writer.WriteConf
+
+import scala.concurrent.Future
+
+class DocExamples extends SparkCassandraITFlatSpecBase {
+
+  useCassandraConfig(Seq("cassandra-default.yaml.template"))
+  useSparkConf(defaultConf)
+
+  val conn = CassandraConnector(defaultConf)
+  override val ks = "doc_example"
+
+  conn.withSessionDo { session =>
+    createKeyspace(session)
+
+    awaitAll(
+      Future {
+        session.execute(
+          s"""CREATE TABLE doc_example.tab1 (key INT, col_1 INT, col_2 INT,
+             |PRIMARY KEY (key))""".stripMargin)
+        session.execute(
+          s"""INSERT INTO doc_example.tab1 (key, col_1, col_2) VALUES (1, null, 1)
+             |
+           """.stripMargin)
+      },
+      Future {
+        session.execute(
+          s"""CREATE TABLE doc_example.tab2 (key INT, col_1 INT, col_2 INT,
+             |PRIMARY KEY (key))""".stripMargin)
+        session.execute(
+          s"""INSERT INTO doc_example.tab2 (key, col_1, col_2) VALUES (1, 5, null)
+             |
+           """.stripMargin)
+      })
+  }
+
+  "Docs" should "demonstrate copying a table without deletes" in {
+    sc.cassandraTable[(Int, CassandraOption[Int], CassandraOption[Int])](ks, "tab1")
+      .saveToCassandra(ks, "tab2")
+    sc.cassandraTable[(Int, Int, Int)](ks, "tab2").collect should contain((1, 5, 1))
+  }
+
+  it should "demonstrate only deleting some records" in {
+    sc.parallelize(1 to 6).map(x => (x, x, x)).saveToCassandra(ks, "tab1")
+    sc.parallelize(1 to 6).map(x => x match {
+      case x if (x >= 5) => (x, CassandraOption.Null, CassandraOption.Unset)
+      case x if (x <= 2) => (x, CassandraOption.Unset, CassandraOption.Null)
+      case x => (x, CassandraOption(-1), CassandraOption(-1))
+    }).saveToCassandra(ks, "tab1")
+
+
+    val results = sc.cassandraTable[(Int, Option[Int], Option[Int])](ks, "tab1").collect
+    results should contain theSameElementsAs Seq(
+      (1, Some(1), None),
+      (2, Some(2), None),
+      (3, Some(-1), Some(-1)),
+      (4, Some(-1), Some(-1)),
+      (5, None, Some(5)),
+      (6, None, Some(6)))
+  }
+
+  it should "demonstrate converting Options to CassandraOptions" in {
+    import com.datastax.spark.connector.types.CassandraOption
+    //Setup original data (1, 1, 1) --> (6, 6, 6)
+    sc.parallelize(1 to 6).map(x => (x, x, x)).saveToCassandra(ks, "tab1")
+
+    //Setup options Rdd (1, -1, None) (2, -1, None) (3, -1, None)
+    val optRdd = sc.parallelize(1 to 6)
+      .map(x => (x, None, None))
+      .map { case (x: Int, y: Option[Int], z: Option[Int]) =>
+        (x, CassandraOption.deleteIfNone(y), CassandraOption.unsetIfNone(z))
+      }.saveToCassandra(ks, "tab1")
+
+    val results = sc.cassandraTable[(Int, Option[Int], Option[Int])](ks, "tab1").collect
+
+    results should contain theSameElementsAs Seq(
+      (1, None, Some(1)),
+      (2, None, Some(2)),
+      (3, None, Some(3)),
+      (4, None, Some(4)),
+      (5, None, Some(5)),
+      (6, None, Some(6))
+    )
+
+  }
+
+  it should "show using a write conf to ignore nulls" in {
+    //Setup original data (1, 1, 1) --> (6, 6, 6)
+    sc.parallelize(1 to 6).map(x => (x, x, x)).saveToCassandra(ks, "tab1")
+
+    val ignoreNullsWriteConf = WriteConf.fromSparkConf(sc.getConf).copy(ignoreNulls = true)
+    //These writes will do not delete because we are ignoring nulls
+    val optRdd = sc.parallelize(1 to 6)
+      .map(x => (x, None, None))
+      .saveToCassandra(ks, "tab1", writeConf = ignoreNullsWriteConf)
+
+    val results = sc.cassandraTable[(Int, Int, Int)](ks, "tab1").collect
+
+    results should contain theSameElementsAs Seq(
+      (1, 1, 1),
+      (2, 2, 2),
+      (3, 3, 3),
+      (4, 4, 4),
+      (5, 5, 5),
+      (6, 6, 6)
+    )
+
+  }
+}

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/BoundStatementBuilderSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/BoundStatementBuilderSpec.scala
@@ -1,0 +1,72 @@
+package com.datastax.spark.connector.writer
+
+import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
+import com.datastax.spark.connector.cql.{Schema, CassandraConnector}
+
+import com.datastax.driver.core.ProtocolVersion
+import com.datastax.spark.connector.types.{CassandraOption, Unset}
+
+class BoundStatementBuilderSpec extends SparkCassandraITFlatSpecBase {
+  useCassandraConfig(Seq("cassandra-default.yaml.template"))
+  val conn = CassandraConnector(defaultConf)
+
+  conn.withSessionDo { session =>
+    createKeyspace(session, ks)
+    session.execute( s"""CREATE TABLE IF NOT EXISTS "$ks".tab (id INT PRIMARY KEY, value TEXT)""")
+  }
+  val cluster = conn.withClusterDo(c => c)
+
+  val schema = Schema.fromCassandra(conn, Some(ks), Some("tab"))
+  val rowWriter = RowWriterFactory.defaultRowWriterFactory[(Int, CassandraOption[String])]
+    .rowWriter(schema.tables.head, IndexedSeq("id", "value"))
+  val rkg = new RoutingKeyGenerator(schema.tables.head, Seq("id", "value"))
+  val ps = conn.withSessionDo(session =>
+    session.prepare( s"""INSERT INTO "$ks".tab (id, value) VALUES (?, ?) """))
+
+  "BoundStatementBuilder" should "ignore Unset values if ProtocolVersion >= 4" in {
+    val testProtocols = (ProtocolVersion.V4.toInt to ProtocolVersion.NEWEST_SUPPORTED.toInt)
+      .map(ProtocolVersion.fromInt(_))
+
+    for (testProtocol <- testProtocols) {
+      val bsb = new BoundStatementBuilder(rowWriter, ps, protocolVersion = testProtocol)
+      val x = bsb.bind((1, CassandraOption.Unset))
+      withClue(s"$testProtocol should ignore unset values :")(x.isSet("value") should be(false))
+    }
+  }
+
+  it should "set Unset values to null if ProtocolVersion <= 3" in {
+    for (testProtocol <- Seq(ProtocolVersion.V1, ProtocolVersion.V2, ProtocolVersion.V3)) {
+      val bsb = new BoundStatementBuilder(rowWriter, ps, protocolVersion = testProtocol)
+      val x = bsb.bind((1, CassandraOption.Unset))
+      withClue(s"$testProtocol should set to null :")(x.isNull("value") should be(true))
+    }
+  }
+
+  it should "ignore null values if ignoreNulls is set and protocol version >= 4" in {
+    val testProtocols = (ProtocolVersion.V4.toInt to ProtocolVersion.NEWEST_SUPPORTED.toInt)
+      .map(ProtocolVersion.fromInt(_))
+
+    for (testProtocol <- testProtocols) {
+      val bsb = new BoundStatementBuilder(
+        rowWriter,
+        ps,
+        protocolVersion = testProtocol,
+        ignoreNulls = true)
+
+      val x = bsb.bind((1, null))
+      withClue(s"$testProtocol should ignore unset values :")(x.isSet("value") should be(false))
+    }
+  }
+
+  it should "throw an exception if ignoreNulls is set and protocol version <= 3" in {
+    for (testProtocol <- Seq(ProtocolVersion.V1, ProtocolVersion.V2, ProtocolVersion.V3)) {
+      intercept[IllegalArgumentException] {
+        val bsb = new BoundStatementBuilder(
+          rowWriter,
+          ps,
+          protocolVersion = testProtocol,
+          ignoreNulls = true)
+      }
+    }
+  }
+}

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/GroupingBatchBuilderSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/GroupingBatchBuilderSpec.scala
@@ -25,10 +25,20 @@ class GroupingBatchBuilderSpec extends SparkCassandraITFlatSpecBase {
   val rkg = new RoutingKeyGenerator(schema.tables.head, Seq("id", "value"))
 
   def makeBatchBuilder(session: Session): (BoundStatement => Any, BatchSize, Int, Iterator[(Int, String)]) => GroupingBatchBuilder[(Int, String)] = {
-    val stmt = session.prepare(s"""INSERT INTO $ks.tab (id, value) VALUES (:id, :value)""")
-    val boundStmtBuilder = new BoundStatementBuilder(rowWriter, stmt)
+    val protocolVersion = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersion
+    val stmt = session.prepare( s"""INSERT INTO $ks.tab (id, value) VALUES (:id, :value)""")
+    val boundStmtBuilder = new BoundStatementBuilder(
+      rowWriter,
+      stmt,
+      protocolVersion = protocolVersion)
     val batchStmtBuilder = new BatchStatementBuilder(Type.UNLOGGED, rkg, ConsistencyLevel.LOCAL_ONE)
-    new GroupingBatchBuilder[(Int, String)](boundStmtBuilder, batchStmtBuilder, _: BoundStatement => Any, _: BatchSize, _: Int, _: Iterator[(Int, String)])
+    new GroupingBatchBuilder[(Int, String)](
+      boundStmtBuilder,
+      batchStmtBuilder,
+      _: BoundStatement => Any,
+      _: BatchSize,
+      _: Int,
+      _: Iterator[(Int, String)])
   }
 
   def staticBatchKeyGen(bs: BoundStatement): Int = 0

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
@@ -2,6 +2,8 @@ package com.datastax.spark.connector.writer
 
 import java.io.IOException
 
+import com.datastax.driver.core.ProtocolVersion
+
 import scala.collection.JavaConversions._
 import scala.concurrent.Future
 
@@ -11,7 +13,7 @@ import com.datastax.spark.connector.embedded.SparkTemplate._
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.SomeColumns
-import com.datastax.spark.connector.types.{BigIntType, TextType, IntType, TypeConverter}
+import com.datastax.spark.connector.types._
 
 case class KeyValue(key: Int, group: Long, value: String)
 case class KeyValueWithTransient(key: Int, group: Long, value: String, @transient transientField: String)
@@ -32,6 +34,7 @@ object CustomerIdConverter extends TypeConverter[String] {
 }
 
 class TableWriterSpec extends SparkCassandraITFlatSpecBase {
+
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultConf)
@@ -73,6 +76,9 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase {
         session.execute( s"""CREATE TABLE $ks.map_tuple (a TEXT, b TEXT, c TEXT, PRIMARY KEY (a))""")
       },
       Future {
+        session.execute( s"""CREATE TABLE $ks.unset_test (a TEXT, b TEXT, c TEXT, PRIMARY KEY (a))""")
+      },
+      Future {
         session.execute( s"""CREATE TYPE $ks.address (street text, city text, zip int)""")
         session.execute( s"""CREATE TABLE $ks.udts(key INT PRIMARY KEY, name text, addr frozen<address>)""")
       },
@@ -87,6 +93,9 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase {
         session.execute( s"""CREATE TABLE $ks.nested_tuples (key INT PRIMARY KEY, addr frozen<address2>)""")
       })
   }
+
+  def protocolVersion = conn.withClusterDo(cluster =>
+    cluster.getConfiguration.getProtocolOptions.getProtocolVersion)
 
   private def verifyKeyValueTable(tableName: String) {
     conn.withSessionDo { session =>
@@ -168,6 +177,51 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase {
     )
     sc.parallelize(col).saveToCassandra(ks, "key_value")
     verifyKeyValueTable("key_value")
+  }
+
+  it should "ignore unset inserts" in {
+    conn.withSessionDo {
+      _.execute(
+        s"""INSERT into $ks.unset_test (A, B, C) VALUES ('Original', 'Original', 'Original')""")
+    }
+
+    sc.parallelize(Seq(("Original", Unset, "New"))).saveToCassandra(ks, "unset_test")
+    val result = sc.cassandraTable[(String, Option[String], Option[String])](ks, "unset_test")
+      .collect
+    if (protocolVersion.toInt >= ProtocolVersion.V4.toInt) {
+      result(0) should be(("Original", Some("Original"), Some("New")))
+    } else {
+      result(0) should be(("Original", None, Some("New")))
+    }
+  }
+
+  it should "ignore CassandraOptions set to UNSET" in {
+    conn.withSessionDo {
+      _.execute(
+        s"""INSERT into $ks.unset_test (A, B, C) VALUES ('Original', 'Original','Original')"""
+      )
+    }
+    sc.parallelize(Seq(("Original", CassandraOption.Unset, "New")))
+      .saveToCassandra(ks, "unset_test")
+    val result = sc.cassandraTable[(String, Option[String], Option[String])](ks, "unset_test")
+      .collect
+    if (protocolVersion.toInt >= ProtocolVersion.V4.toInt) {
+      result(0) should be(("Original", Some("Original"), Some("New")))
+    } else {
+      result(0) should be(("Original", None, Some("New")))
+    }
+  }
+
+  it should "delete with Cassandra Options set to Null" in {
+    conn.withSessionDo {
+      _.execute(
+        s"""INSERT into $ks.unset_test (A, B, C) VALUES ('Original', 'Original', 'Original')"""
+      )
+    }
+    sc.parallelize(Seq(("Original", CassandraOption.Null, "New"))).saveToCassandra(ks, "unset_test")
+    val result = sc.cassandraTable[(String, Option[String], Option[String])](ks, "unset_test")
+      .collect
+    result(0) should be(("Original", None, Some("New")))
   }
 
   it should "write RDD of tuples to a table with camel case column names" in {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
@@ -212,8 +212,9 @@ class CassandraJoinRDD[L, R] private[connector](
    */
   override def compute(split: Partition, context: TaskContext): Iterator[(L, R)] = {
     val session = connector.openSession()
+    val protocolVersion = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersion
     val stmt = session.prepare(singleKeyCqlQuery).setConsistencyLevel(consistencyLevel)
-    val bsb = new BoundStatementBuilder[L](rowWriter, stmt, where.values)
+    val bsb = new BoundStatementBuilder[L](rowWriter, stmt, where.values, protocolVersion = protocolVersion)
     val metricsUpdater = InputMetricsUpdater(context, readConf)
     val rowIterator = fetchIterator(session, bsb, left.iterator(split, context))
     val countingIterator = new CountingIterator(rowIterator, limit)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/CassandraOption.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/CassandraOption.scala
@@ -1,0 +1,43 @@
+package com.datastax.spark.connector.types
+
+/**
+  * An object representing a column which will be skipped on insert.
+  */
+protected[connector] object Unset extends Serializable
+
+/**
+  * An Optional value with Cassandra in mind. There are three options
+  * Value(value): Representing a value to be inserted from C*
+  * Unset: Representing a value which should be skipped when writing to C*
+  * Null: Representing a java `null`, treated as a delete in C* (or empty collection)
+  */
+sealed trait CassandraOption[+A] extends Product with Serializable
+
+object CassandraOption {
+
+  case class Value[+A](value: A) extends CassandraOption[A]
+  case object Unset extends CassandraOption[Nothing]
+  case object Null extends CassandraOption[Nothing]
+
+  def apply[A](x: A): CassandraOption[A] = x match {
+    case x: AnyRef if (x == null) => CassandraOption.Null
+    case Unset => CassandraOption.Unset
+    case x => CassandraOption.Value[A](x)
+  }
+
+  implicit def toScalaOption[A](cOption: CassandraOption[A]): Option[A] = cOption match {
+    case CassandraOption.Unset | CassandraOption.Null => None
+    case CassandraOption.Value(x) => Some(x)
+  }
+
+  def deleteIfNone[A](op: Option[A]): CassandraOption[A] = op match {
+    case None => CassandraOption.Null
+    case Some(x) => CassandraOption.Value(x)
+  }
+
+  def unsetIfNone[A](op: Option[A]): CassandraOption[A] = op match {
+    case None => CassandraOption.Unset
+    case Some(x) => CassandraOption.Value(x)
+  }
+
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/Symbols.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/Symbols.scala
@@ -5,7 +5,10 @@ import scala.reflect.runtime.universe._
 
 import org.apache.commons.lang3.tuple
 
+import com.datastax.spark.connector.types.CassandraOption
+
 object Symbols {
+  val CassandraOptionSymbol = typeOf[CassandraOption[Any]].asInstanceOf[TypeRef].sym
   val OptionSymbol = typeOf[Option[Any]].asInstanceOf[TypeRef].sym
   val ListSymbol = typeOf[List[Any]].asInstanceOf[TypeRef].sym
   val VectorSymbol = typeOf[Vector[Any]].asInstanceOf[TypeRef].sym

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/BoundStatementBuilder.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/BoundStatementBuilder.scala
@@ -1,7 +1,7 @@
 package com.datastax.spark.connector.writer
 
 import com.datastax.driver.core._
-import com.datastax.spark.connector.types.ColumnType
+import com.datastax.spark.connector.types.{Unset, ColumnType}
 import com.datastax.spark.connector.util.CodecRegistryUtil
 import org.apache.spark.Logging
 
@@ -13,12 +13,77 @@ import org.apache.spark.Logging
 private[connector] class BoundStatementBuilder[T](
     val rowWriter: RowWriter[T],
     val preparedStmt: PreparedStatement,
-    val prefixVals: Seq[Any] = Seq.empty) extends Logging {
+    val prefixVals: Seq[Any] = Seq.empty,
+    val ignoreNulls: Boolean = false,
+    val protocolVersion: ProtocolVersion) extends Logging {
 
   private val columnNames = rowWriter.columnNames.toIndexedSeq
   private val columnTypes = columnNames.map(preparedStmt.getVariables.getType)
   private val converters = columnTypes.map(ColumnType.converterToCassandra(_))
   private val buffer = Array.ofDim[Any](columnNames.size)
+
+  require(ignoreNulls == false || protocolVersion.toInt >= ProtocolVersion.V4.toInt,
+    s"""
+       |Protocol Version $protocolVersion does not support ignoring null values and leaving
+       |parameters unset. This is only supported in ${ProtocolVersion.V4} and greater.
+    """.stripMargin)
+
+  var logUnsetToNullWarning = false
+  val UnsetToNullWarning =
+    s"""Unset values can only be used with C* >= 2.2. They have been replaced
+        |with nulls. Found protocol version ${protocolVersion}.
+        |${ProtocolVersion.V4} or greater required"
+    """.stripMargin
+
+
+  private def maybeLeaveUnset(
+    boundStatement: BoundStatement,
+    columnName: String): Unit = protocolVersion match {
+      case pv if pv.toInt <= ProtocolVersion.V3.toInt => {
+        boundStatement.setToNull(columnName)
+        logUnsetToNullWarning = true
+      }
+      case _ =>
+  }
+
+  private def bindColumnNull(
+    boundStatement: BoundStatement,
+    columnName: String,
+    columnType: DataType,
+    columnValue: AnyRef): Unit = {
+
+    if (columnValue == Unset || (ignoreNulls && columnValue == null)) {
+      boundStatement.setToNull(columnName)
+      logUnsetToNullWarning = true
+    } else {
+      val codec = CodecRegistryUtil.codecFor(columnType, columnValue)
+      boundStatement.set(columnName, columnValue, codec)
+    }
+  }
+
+  private def bindColumnUnset(
+    boundStatement: BoundStatement,
+    columnName: String,
+    columnType: DataType,
+    columnValue: AnyRef): Unit = {
+
+    if (columnValue == Unset || (ignoreNulls && columnValue == null)) {
+      //Do not bind
+    } else {
+      val codec = CodecRegistryUtil.codecFor(columnType, columnValue)
+      boundStatement.set(columnName, columnValue, codec)
+    }
+  }
+
+  /**
+  * If the protocol version is greater than V3 (C* 2.2 and Greater) then
+  * we can leave values in the prepared statement unset. If the version is
+  * less than V3 then we need to place a `null` in the bound statement.
+  */
+  val bindColumn: (BoundStatement, String, DataType, AnyRef) => Unit = protocolVersion match {
+    case pv if pv.toInt <= ProtocolVersion.V3.toInt => bindColumnNull
+    case _ => bindColumnUnset
+  }
 
   private val prefixConverted = for {
     prefixIndex: Int <- 0 until prefixVals.length
@@ -37,18 +102,15 @@ private[connector] class BoundStatementBuilder[T](
     for (i <- 0 until columnNames.size) {
       val converter = converters(i)
       val columnName = columnNames(i)
+      val columnType = columnTypes(i)
       val columnValue = converter.convert(buffer(i))
-      boundStatement.set(columnName, columnValue, CodecRegistryUtil.codecFor(columnTypes(i), columnValue))
+      bindColumn(boundStatement, columnName, columnType, columnValue)
       val serializedValue = boundStatement.getBytesUnsafe(i)
-
-      if (serializedValue != null)
-        bytesCount += serializedValue.remaining()
-
+      if (serializedValue != null) bytesCount += serializedValue.remaining()
     }
     boundStatement.bytesCount = bytesCount
     boundStatement
   }
-
 }
 
 private[connector] object BoundStatementBuilder {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/ReplicaLocator.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/ReplicaLocator.scala
@@ -56,9 +56,10 @@ class ReplicaLocator[T] private(
    */
   def keyByReplicas(data: Iterator[T]): Iterator[(scala.collection.immutable.Set[InetAddress], T)] = {
       connector.withSessionDo { session =>
+        val protocolVersion = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersion
         val stmt = prepareDummyStatement(session)
         val routingKeyGenerator = new RoutingKeyGenerator(tableDef, columnNames)
-        val boundStmtBuilder = new BoundStatementBuilder(rowWriter, stmt)
+        val boundStmtBuilder = new BoundStatementBuilder(rowWriter, stmt, protocolVersion = protocolVersion)
         val clusterMetadata = session.getCluster.getMetadata
         data.map { row =>
           val hosts = clusterMetadata

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -137,13 +137,20 @@ class TableWriter[T] private (
   def write(taskContext: TaskContext, data: Iterator[T]) {
     val updater = OutputMetricsUpdater(taskContext, writeConf)
     connector.withSessionDo { session =>
+      val protocolVersion = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersion
       val rowIterator = new CountingIterator(data)
       val stmt = prepareStatement(session).setConsistencyLevel(writeConf.consistencyLevel)
       val queryExecutor = new QueryExecutor(session, writeConf.parallelismLevel,
         Some(updater.batchFinished(success = true, _, _, _)), Some(updater.batchFinished(success = false, _, _, _)))
       val routingKeyGenerator = new RoutingKeyGenerator(tableDef, columnNames)
       val batchType = if (isCounterUpdate) Type.COUNTER else Type.UNLOGGED
-      val boundStmtBuilder = new BoundStatementBuilder(rowWriter, stmt)
+
+      val boundStmtBuilder = new BoundStatementBuilder(
+        rowWriter,
+        stmt,
+        protocolVersion = protocolVersion,
+        ignoreNulls = writeConf.ignoreNulls)
+
       val batchStmtBuilder = new BatchStatementBuilder(batchType, routingKeyGenerator, writeConf.consistencyLevel)
       val batchKeyGenerator = batchRoutingKey(session, routingKeyGenerator) _
       val batchBuilder = new GroupingBatchBuilder(boundStmtBuilder, batchStmtBuilder, batchKeyGenerator,
@@ -165,6 +172,7 @@ class TableWriter[T] private (
 
       val duration = updater.finish() / 1000000000d
       logInfo(f"Wrote ${rowIterator.count} rows to $keyspaceName.$tableName in $duration%.3f s.")
+      if (boundStmtBuilder.logUnsetToNullWarning){ logWarning(boundStmtBuilder.UnsetToNullWarning) }
     }
   }
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
@@ -26,6 +26,7 @@ case class WriteConf(batchSize: BatchSize = BatchSize.Automatic,
                      batchGroupingBufferSize: Int = WriteConf.BatchBufferSizeParam.default,
                      batchGroupingKey: BatchGroupingKey = WriteConf.BatchLevelParam.default,
                      consistencyLevel: ConsistencyLevel = WriteConf.ConsistencyLevelParam.default,
+                     ignoreNulls: Boolean = WriteConf.IgnoreNullsParam.default,
                      parallelismLevel: Int = WriteConf.ParallelismLevelParam.default,
                      throughputMiBPS: Double = WriteConf.ThroughputMiBPSParam.default,
                      ttl: TTLOption = TTLOption.defaultValue,
@@ -97,6 +98,15 @@ object WriteConf {
     |</ul>
     |""".stripMargin)
 
+  val IgnoreNullsParam = ConfigParameter[Boolean](
+    name = "spark.cassandra.output.ignoreNulls",
+    section = ReferenceSection,
+    default = false,
+    description =
+      """ In Cassandra >= 2.2 null values can be left as unset in bound statements. Setting
+        |this to true will cause all null values to be left as unset rather than bound. For
+        |finer control see the CassandraOption class""".stripMargin)
+
   val ParallelismLevelParam = ConfigParameter[Int] (
     name = "spark.cassandra.output.concurrent.writes",
     section = ReferenceSection,
@@ -127,6 +137,7 @@ object WriteConf {
     BatchSizeRowsParam,
     BatchBufferSizeParam,
     BatchLevelParam,
+    IgnoreNullsParam,
     ParallelismLevelParam,
     ThroughputMiBPSParam,
     TaskMetricsParam
@@ -142,6 +153,8 @@ object WriteConf {
       conf.get(ConsistencyLevelParam.name, ConsistencyLevelParam.default.name()))
 
     val batchSizeInRowsStr = conf.get(BatchSizeRowsParam.name, "auto")
+
+    val ignoreNulls = conf.getBoolean(IgnoreNullsParam.name, IgnoreNullsParam.default)
 
     val batchSize = {
       val Number = "([0-9]+)".r
@@ -173,7 +186,8 @@ object WriteConf {
       consistencyLevel = consistencyLevel,
       parallelismLevel = parallelismLevel,
       throughputMiBPS = throughputMiBPS,
-      taskMetricsEnabled = metricsEnabled)
+      taskMetricsEnabled = metricsEnabled,
+      ignoreNulls = ignoreNulls)
   }
 
 }

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/TypeConverterTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/TypeConverterTest.scala
@@ -243,6 +243,15 @@ class TypeConverterTest {
   }
 
   @Test
+  def testCassandraOption() {
+    val c = TypeConverter.forType[CassandraOption[String]]
+    val unset = CassandraOption.Unset
+    val set = CassandraOption.Value("not-null")
+    assertEquals(unset, c.convert(null))
+    assertEquals(set, c.convert("not-null"))
+  }
+
+  @Test
   def testList() {
     val c = TypeConverter.forType[Vector[Option[Int]]]
     val arrayList = new java.util.ArrayList[String]()
@@ -384,6 +393,14 @@ class TypeConverterTest {
     assertEquals(1.asInstanceOf[AnyRef], c.convert("1"))
     assertEquals(null, c.convert(None))
     assertEquals(null, c.convert(null))
+  }
+
+  @Test
+  def testCassandraOptionToNull() {
+    val c = new TypeConverter.OptionToNullConverter(TypeConverter.IntConverter)
+    assertEquals(Unset, c.convert(CassandraOption.Unset))
+    assertEquals(null, c.convert(CassandraOption.Null))
+    assertEquals(1.asInstanceOf[AnyRef], c.convert(CassandraOption.Value(1)))
   }
 
   @Test(expected = classOf[IllegalArgumentException])


### PR DESCRIPTION
Previously unset columns had to be set to null since the Cassandra
Protocol <= V3 did not support unbound parameters in bound statements.
The newere version of the protocol allows for this, and this patch
enables the connector to take advtange of that behavior.

This is done through use of a new option container, CassandraOption.
This class holds an Option and the behavior that a None should have upon
being written. With this class a row can have varying behavior from
column to column and row to row.

If an Unset is used on a C* version prior to Protcol Version 3 a warning
will be logged that the Unset functionality cannot be used and the value
will be treated as a Delete instead.