### PR TITLE
SPARK-294: JWCT should inherit Spark Conf from Spark Context

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+ * Fixed Default ReadConf for JoinWithCassandra Table (SPARKC-294)
  * Added refresh cassandra schema cache to CassandraSQLContext (SPARKC-234)
 
 1.2.5

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
@@ -25,7 +25,7 @@ case class DataCol(pk1: Int, pk2: Int, pk3: Int, d1: Int)
 class RDDSpec extends SparkCassandraITFlatSpecBase {
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
-  useSparkConf(defaultSparkConf)
+  useSparkConf(defaultSparkConf.set("spark.cassandra.input.consistency.level", "ONE"))
 
   val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
   implicit val protocolVersion = conn.withClusterDo(_.getConfiguration.getProtocolOptions.getProtocolVersionEnum)
@@ -243,6 +243,12 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
     }
     val result = someCass.collect
     checkArrayCassandraRow(result)
+  }
+
+  it should "use the ReadConf from the SparkContext by default" in {
+    val source = sc.parallelize(keys).map(x => (x, x * 100: Long))
+    val someCass = source.joinWithCassandraTable[FullRow](ks, tableName)
+    someCass.readConf.consistencyLevel should be (com.datastax.driver.core.ConsistencyLevel.ONE)
   }
 
   it should "be joinable on both partitioning key and clustering key" in {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
@@ -7,7 +7,7 @@ import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.mapper.ColumnMapper
 import com.datastax.spark.connector.rdd.partitioner.{CassandraPartitionedRDD, ReplicaPartitioner}
 import com.datastax.spark.connector.rdd.reader._
-import com.datastax.spark.connector.rdd.{CassandraJoinRDD, SpannedRDD, ValidRDDType}
+import com.datastax.spark.connector.rdd.{ReadConf, CassandraJoinRDD, SpannedRDD, ValidRDDType}
 import com.datastax.spark.connector.writer.{ReplicaMapper, _}
 import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext._
@@ -127,7 +127,15 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
                                (implicit connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
                                 newType: ClassTag[R], rrf: RowReaderFactory[R], ev: ValidRDDType[R],
                                 currentType: ClassTag[T], rwf: RowWriterFactory[T]): CassandraJoinRDD[T, R] = {
-    new CassandraJoinRDD[T, R](rdd, keyspaceName, tableName, connector, columnNames = selectedColumns, joinColumns = joinColumns)
+    new CassandraJoinRDD[T, R](
+      rdd,
+      keyspaceName,
+      tableName,
+      connector,
+      columnNames = selectedColumns,
+      joinColumns = joinColumns,
+      readConf = ReadConf.fromSparkConf(rdd.sparkContext.getConf)
+    )
   }
 
 


### PR DESCRIPTION
The joinWithCassandraTable method was incorrectly making a ReadConf from
default rather than using the SparkConf. The jWCT method now pulls the
sparkConf from the left hand side RDD and uses this for the jWCT
readConf.