### PR TITLE
Fix to IT tests to match Updated Spark

### DIFF
--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraPrunedFilteredScanSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraPrunedFilteredScanSpec.scala
@@ -49,7 +49,7 @@ class CassandraPrunedFilteredScanSpec extends SparkCassandraITFlatSpecBase with 
   "CassandraPrunedFilteredScan" should "pushdown predicates for clustering keys" in {
     val colorDF = sqlContext.read.format(cassandraFormat).options(colorOptions ++ withPushdown).load()
     val executionPlan = colorDF.filter("priority > 5").queryExecution.executedPlan.toString
-    executionPlan should include ("PushedFilter: [GreaterThan(priority,5)]")
+    executionPlan should include ("PushedFilters: [GreaterThan(priority,5)]")
   }
 
   it should "not pushdown predicates for clustering keys if filterPushdown is disabled" in {
@@ -61,13 +61,13 @@ class CassandraPrunedFilteredScanSpec extends SparkCassandraITFlatSpecBase with 
   it should "prune data columns" in {
     val fieldsDF = sqlContext.read.format(cassandraFormat).options(fieldsOptions ++ withPushdown).load()
     val executionPlan = fieldsDF.select("b","c","d").queryExecution.executedPlan.toString
-    executionPlan should include regex """PushedFilter: \[\] \[b#\d+,c#\d+,d#\d+\]""".r
+    executionPlan should include regex """CassandraSourceRelation.*\[b#\d+,c#\d+,d#\d+\]""".r
   }
 
   it should "prune data columns if filterPushdown is disabled" in {
     val fieldsDF = sqlContext.read.format(cassandraFormat).options(fieldsOptions ++ withoutPushdown).load()
     val executionPlan = fieldsDF.select("b","c","d").queryExecution.executedPlan.toString
-    executionPlan should include regex """PushedFilter: \[\] \[b#\d+,c#\d+,d#\d+\]""".r
+    executionPlan should include regex """CassandraSourceRelation.*\[b#\d+,c#\d+,d#\d+\]""".r
   }
 
 }

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLSpec.scala
@@ -338,7 +338,7 @@ class CassandraSQLSpec extends SparkCassandraITFlatSpecBase {
 
   it should "allow to select rows with in clause pushed down" in {
     val query = cc.sql(s"SELECT * FROM test2 WHERE a in (1,2)")
-    query.queryExecution.sparkPlan.toString should include regex """PushedFilter: \[In\(a.*\)\]""".r
+    query.queryExecution.sparkPlan.toString should include regex """PushedFilters: \[In\(a.*\)\]""".r
     val result = query.collect()
     result should have length 6
   }


### PR DESCRIPTION
Also I missed a rename on defaultSparkConf
Spark output for pushdown filtering changed so we change our tests to
match the expected output.