### PR TITLE
SPARKC-306: Remove Special Matching for Dataframe Writers

### DIFF
--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/typeTests/InetTypeTest.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/typeTests/InetTypeTest.scala
@@ -1,8 +1,11 @@
 package com.datastax.spark.connector.rdd.typeTests
 
 import java.net.InetAddress
+import org.apache.spark.sql.SaveMode
+
 import scala.collection.JavaConverters._
 
+case class InetStringRow(pkey: String, ckey1: String, ckey2: String, data1: String)
 class InetTypeTest extends AbstractTypeTest[InetAddress, InetAddress] {
   override val typeName = "inet"
 
@@ -11,6 +14,23 @@ class InetTypeTest extends AbstractTypeTest[InetAddress, InetAddress] {
 
   override def getDriverColumn(row: com.datastax.driver.core.Row, colName: String): InetAddress = {
     row.getInet(colName)
+  }
+
+  "A String DataFrame" should "write to C* Inets" in {
+    val InetString = "111.111.111.111"
+    val stringRDD = sc.parallelize(Seq(InetStringRow(InetString, InetString, InetString, InetString)))
+    val stringDf = sqlContext.createDataFrame(stringRDD)
+
+    val normOptions = Map("keyspace" -> keyspaceName, "table" -> typeNormalTable)
+    stringDf.write
+      .format("org.apache.spark.sql.cassandra")
+      .options(normOptions)
+      .mode(SaveMode.Append)
+      .save()
+
+    val row = conn.withSessionDo(session =>
+      session.execute(s"SELECT * FROM $keyspaceName.$typeNormalTable WHERE pkey = '$InetString' and ckey1 = '$InetString'").one)
+    row.getInet("data1") should be (InetAddress.getByName(InetString))
   }
 }
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/typeTests/VarintTypeTest.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/typeTests/VarintTypeTest.scala
@@ -1,7 +1,13 @@
 package com.datastax.spark.connector.rdd.typeTests
 
+import java.math.BigDecimal
 import java.math.BigInteger
 
+import org.apache.spark.sql.types.DecimalType
+import org.apache.spark.sql.SaveMode
+
+case class LongRow(pkey: Long, ckey1: Long, ckey2: Long, data1: Long)
+case class BigDecimalRow(pkey: BigDecimal, ckey1: BigDecimal, ckey2: BigDecimal, data1: BigDecimal)
 
 class VarintTypeTest extends AbstractTypeTest[BigInteger, BigInteger] {
   override val typeName = "varint"
@@ -11,6 +17,47 @@ class VarintTypeTest extends AbstractTypeTest[BigInteger, BigInteger] {
 
   override def getDriverColumn(row: com.datastax.driver.core.Row, colName: String): BigInteger = {
     row.getVarint(colName)
+  }
+
+  "A LongType DataFrame" should "write to VarInt C* tables" in {
+    val LongValue = 11111111
+    val longRDD = sc.parallelize(Seq(LongRow(LongValue, LongValue, LongValue, LongValue)))
+    val longDf = sqlContext.createDataFrame(longRDD)
+
+    val normOptions = Map("keyspace" -> keyspaceName, "table" -> typeNormalTable)
+    longDf.write
+      .format("org.apache.spark.sql.cassandra")
+      .options(normOptions)
+      .mode(SaveMode.Append)
+      .save()
+
+    val row = conn.withSessionDo(session =>
+      session.execute(s"SELECT * FROM $keyspaceName.$typeNormalTable WHERE pkey = $LongValue and ckey1 = $LongValue").one)
+    row.getVarint("data1").longValue() should be (LongValue)
+
+  }
+
+  "A DecimalType DataFrame with Scale 0" should "write to VarInt C* Tables" in {
+    val BigDecimalValue = new BigDecimal(22222)
+
+    val bigDecimalRDD = sc.parallelize(Seq(BigDecimalRow(BigDecimalValue, BigDecimalValue, BigDecimalValue, BigDecimalValue)))
+    val bigDecimalDf = sqlContext.createDataFrame(bigDecimalRDD)
+
+    val normOptions = Map("keyspace" -> keyspaceName, "table" -> typeNormalTable)
+    bigDecimalDf
+      .withColumn("pkey", bigDecimalDf("pkey").cast(DecimalType(12,0)))
+      .withColumn("ckey1", bigDecimalDf("ckey2").cast(DecimalType(12,0)))
+      .withColumn("ckey2", bigDecimalDf("ckey2").cast(DecimalType(12,0)))
+      .withColumn("data1", bigDecimalDf("data1").cast(DecimalType(12,0)))
+      .write
+      .format("org.apache.spark.sql.cassandra")
+      .options(normOptions)
+      .mode(SaveMode.Append)
+      .save()
+
+    val row = conn.withSessionDo(session =>
+      session.execute(s"SELECT * FROM $keyspaceName.$typeNormalTable WHERE pkey = $BigDecimalValue and ckey1 = $BigDecimalValue").one)
+    row.getVarint("data1").longValue() should be (BigDecimalValue.longValue())
   }
 }
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
@@ -377,6 +377,8 @@ object TypeConverter {
       case x: java.lang.Long => new java.math.BigInteger(x.toString)
       case x: String => new java.math.BigInteger(x)
       case x: java.math.BigDecimal if x.scale() <= 0 => x.toBigInteger
+      case x: java.math.BigDecimal if x.scale() > 0 => throw new TypeConversionException(
+        s"BigDecimal ($x) has scale greater than 0 (Scale: ${x.scale()}) and cannot be converted to BigInteger")
     }
   }
 


### PR DESCRIPTION
The type converters are fully capabible of handeling all of the
edge cases for DataFrame -> CassandraType conversions. We can use this
instead of the custom code previously in the SqlRowWriter class. In
addtiion, added test cases for the special matching previously done.