### PR TITLE
Assembly fix for 1.5 2.11

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -325,14 +325,22 @@ object Settings extends Build {
 
   lazy val sbtAssemblySettings = assemblySettings ++ Seq(
     parallelExecution in assembly := false,
-    jarName in assembly <<= (baseDirectory, version) map { (dir, version) => s"${dir.name}-assembly-$version.jar" },
+    assemblyJarName in assembly <<= (baseDirectory, version) map { (dir, version) => s"${dir.name}-assembly-$version.jar" },
     run in Compile <<= Defaults.runTask(fullClasspath in Compile, mainClass in (Compile, run), runner in (Compile, run)),
     assemblyOption in assembly ~= { _.copy(includeScala = false) },
     assemblyMergeStrategy in assembly <<= (assemblyMergeStrategy in assembly) {
       (old) => {
-        case PathList("META-INF", "io.netty.versions.properties", xs @ _*) => MergeStrategy.last
+        case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
+        case PathList("META-INF", xs @ _*) => MergeStrategy.last
         case PathList("com", "google", xs @ _*) => MergeStrategy.last
-        case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.last
+        case PathList("com", "esotericsoftware", "minlog", xs @ _ *) => MergeStrategy.last
+        case PathList("io", "netty", xs @ _*) => MergeStrategy.last
+        case PathList("org", "jboss", xs @ _*) => MergeStrategy.last
+        case PathList("javax", "xml", xs @ _*) => MergeStrategy.last
+        case PathList("org", "apache", "commons", xs @ _ *) => MergeStrategy.last
+        case PathList("org", "apache", "hadoop", "yarn", xs @ _ *) => MergeStrategy.last
+        case PathList("org", "apache", "spark", xs @ _ *) => MergeStrategy.last
+        case PathList("org", "fusesource", xs @ _ *) => MergeStrategy.last
         case x => old(x)
       }
     }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
@@ -7,6 +7,7 @@ import org.apache.spark.sql.DataFrame
 
 import scala.collection.JavaConversions._
 import scala.language.existentials
+import scala.util.Properties
 import com.datastax.driver.core._
 import com.datastax.spark.connector.types.{CounterType, ColumnType}
 import com.datastax.spark.connector.util.Quote._
@@ -145,8 +146,8 @@ case class TableDef(
   override lazy val columnByName: Map[String, ColumnDef] =
     super.columnByName
 
-  def cql = {    
-    val columnList = columns.map(_.cql).mkString(",\n  ")
+  def cql = {
+    val columnList = columns.map(_.cql).mkString(s",${Properties.lineSeparator}  ")
     val partitionKeyClause = partitionKey.map(_.columnName).map(quote).mkString("(", ", ", ")")
     val clusteringColumnNames = clusteringColumns.map(_.columnName).map(quote)
     val primaryKeyClause = (partitionKeyClause +: clusteringColumnNames).mkString(", ")


### PR DESCRIPTION
Prior to this commit, the 1.5 branch could not successfully complete an assembly task for Scala 2.11 due to:

- 4 Failed unit tests
- Unsuccessful merge strategy for assembly

These changes were derived from previous pull requests to the master branch; they are simply making their way into the 1.5 branch. 

There was an additional merge strategy addition that I made which I did not find in prior commits (line 338 in Settings.scala). Deduplication errors were thrown without this. I have successfully tested a 2.11 assembly with these changes. 