### PR TITLE
SPARKC-299 Support append data to collection column for Spark SQL

### DIFF
--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
@@ -179,7 +179,7 @@ class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase with Logging 
     sqlContext.sql("SELECT b FROM insertListTable WHERE a = 3").collect().head.getList[Int](0).get(3) shouldBe 2
     sqlContext.dropTempTable("insertListTable")
 
-    /*sqlContext.sql("SELECT a, b from listTable")
+    sqlContext.sql("SELECT a, b from listTable")
       .write
       .format("org.apache.spark.sql.cassandra")
       .mode(Append)
@@ -187,7 +187,7 @@ class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase with Logging 
       .save()
     createTempTable(ks, "test_insert_list", "insertListTable")
     sqlContext.sql("SELECT b FROM insertListTable WHERE a = 3").collect().head.getList[Int](0).get(0) shouldBe 1
-    sqlContext.dropTempTable("insertListTable")*/
+    sqlContext.dropTempTable("insertListTable")
     sqlContext.dropTempTable("listTable")
   }
 

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSourceRelation.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSourceRelation.scala
@@ -18,7 +18,7 @@ import org.apache.spark.sql.{sources, DataFrame, Row, SQLContext}
 import org.apache.spark.unsafe.types.UTF8String
 
 import com.datastax.spark.connector._
-import com.datastax.spark.connector.cql.{CassandraConnectorConf, CassandraConnector, Schema}
+import com.datastax.spark.connector.cql.{TableDef, CassandraConnectorConf, CassandraConnector, Schema}
 import com.datastax.spark.connector.rdd.{CassandraRDD, ReadConf}
 import com.datastax.spark.connector.writer.{WriteConf, SqlRowWriter}
 import com.datastax.spark.connector.util.Quote._
@@ -34,31 +34,19 @@ import com.datastax.spark.connector.rdd.partitioner.CassandraRDDPartitioner._
  *
  */
 private[cassandra] class CassandraSourceRelation(
-    tableRef: TableRef,
+    tableDef: TableDef,
     userSpecifiedSchema: Option[StructType],
     filterPushdown: Boolean,
     tableSizeInBytes: Option[Long],
     connector: CassandraConnector,
     readConf: ReadConf,
     writeConf: WriteConf,
+    preappendColumns: Set[String],
     override val sqlContext: SQLContext)
   extends BaseRelation
   with InsertableRelation
   with PrunedFilteredScan
   with Logging {
-
-  private[this] val tableDef = {
-    val tableName = tableRef.table
-    val keyspaceName = tableRef.keyspace
-    Schema.fromCassandra(connector, Some(keyspaceName), Some(tableName)).tables.headOption match {
-      case Some(t) => t
-      case None =>
-        val metadata: Metadata = connector.withClusterDo(_.getMetadata)
-        val suggestions = NameTools.getSuggestions(metadata, keyspaceName, tableName)
-        val errorMessage = NameTools.getErrorString(keyspaceName, tableName, suggestions)
-        throw new IOException(errorMessage)
-    }
-  }
 
   override def schema: StructType = {
     userSpecifiedSchema.getOrElse(StructType(tableDef.columns.map(toStructField)))
@@ -67,20 +55,24 @@ private[cassandra] class CassandraSourceRelation(
   override def insert(data: DataFrame, overwrite: Boolean): Unit = {
     if (overwrite) {
       connector.withSessionDo {
-        val keyspace = quote(tableRef.keyspace)
-        val table = quote(tableRef.table)
+        val keyspace = quote(tableDef.keyspaceName)
+        val table = quote(tableDef.tableName)
         session => session.execute(s"TRUNCATE $keyspace.$table")
       }
     }
 
     implicit val rwf = SqlRowWriter.Factory
     val columns = SomeColumns(data.columns.map(x => columnRef(x, overwrite)): _*)
-    data.rdd.saveToCassandra(tableRef.keyspace, tableRef.table, columns, writeConf)
+    data.rdd.saveToCassandra(tableDef.keyspaceName, tableDef.tableName, columns, writeConf)
   }
 
   private[this] def columnRef(columnName: String, overwrite: Boolean): ColumnRef = {
     if (!overwrite && tableDef.columnByName(columnName).isCollection) {
-      CollectionColumnName(columnName, alias = None, collectionBehavior = CollectionAppend)
+      if (preappendColumns.contains(columnName)) {
+        CollectionColumnName(columnName, alias = None, collectionBehavior = CollectionPrepend)
+      } else {
+        CollectionColumnName(columnName, alias = None, collectionBehavior = CollectionAppend)
+      }
     } else {
       ColumnName(columnName)
     }
@@ -94,7 +86,7 @@ private[cassandra] class CassandraSourceRelation(
   implicit val cassandraConnector = connector
   implicit val readconf = readConf
   private[this] val baseRdd =
-    sqlContext.sparkContext.cassandraTable[CassandraSQLRow](tableRef.keyspace, tableRef.table)
+    sqlContext.sparkContext.cassandraTable[CassandraSQLRow](tableDef.keyspaceName, tableDef.tableName)
 
   def buildScan() : RDD[Row] = baseRdd.asInstanceOf[RDD[Row]]
 
@@ -231,15 +223,29 @@ object CassandraSourceRelation {
     }
     val readConf = ReadConf.fromSparkConf(conf)
     val writeConf = WriteConf.fromSparkConf(conf)
+    val tableDef = {
+      val tableName = tableRef.table
+      val keyspaceName = tableRef.keyspace
+      Schema.fromCassandra(cassandraConnector, Some(keyspaceName), Some(tableName)).tables.headOption match {
+        case Some(t) => t
+        case None =>
+          val metadata: Metadata = cassandraConnector.withClusterDo(_.getMetadata)
+          val suggestions = NameTools.getSuggestions(metadata, keyspaceName, tableName)
+          val errorMessage = NameTools.getErrorString(keyspaceName, tableName, suggestions)
+          throw new IOException(errorMessage)
+      }
+    }
+    val preappendColumns = tableDef.columns.map(_.columnName).filter(preappendColumn(_, options.cassandraConfs)).toSet
 
     new CassandraSourceRelation(
-      tableRef = tableRef,
+      tableDef = tableDef,
       userSpecifiedSchema = schema,
       filterPushdown = options.pushdown,
       tableSizeInBytes = tableSizeInBytes,
       connector = cassandraConnector,
       readConf = readConf,
       writeConf = writeConf,
+      preappendColumns = preappendColumns,
       sqlContext = sqlContext)
   }
 
@@ -271,5 +277,10 @@ object CassandraSourceRelation {
         conf.set(prop, tableLevelValue.get)
     }
     conf
+  }
+
+  def preappendColumn(columnName: String, cassandraConfs: Map[String, String]): Boolean = {
+    val preappendSetting = cassandraConfs.get(s"$columnName.preappend")
+    preappendSetting.nonEmpty && preappendSetting.get.toLowerCase.equals("true")
   }
 }

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/DefaultSource.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/DefaultSource.scala
@@ -121,34 +121,14 @@ object DefaultSource {
     val keyspaceName = parameters(CassandraDataSourceKeyspaceNameProperty)
     val clusterName = parameters.get(CassandraDataSourceClusterNameProperty)
     val pushdown : Boolean = parameters.getOrElse(CassandraDataSourcePushdownEnableProperty, "true").toBoolean
-    val cassandraConfs = buildConfMap(parameters)
 
-    (TableRef(tableName, keyspaceName, clusterName), CassandraSourceOptions(pushdown, cassandraConfs))
+    (TableRef(tableName, keyspaceName, clusterName), CassandraSourceOptions(pushdown, parameters))
   }
 
   val confProperties = ReadConf.Properties.map(_.name) ++
     WriteConf.Properties.map(_.name) ++
     CassandraConnectorConf.Properties.map(_.name) ++
     CassandraSourceRelation.Properties.map(_.name)
-
-  // Dot is not allowed in Options key for Spark SQL parsers, so convert . to _
-  // Map converted property to origin property name
-  // TODO check SPARK 1.4 it may be fixed
-  private val propertiesMap : Map[String, String] = {
-    confProperties.map(prop => (prop.replace(".", "_"), prop)).toMap
-  }
-
-  /** Construct a map stores Cassandra Conf settings from options */
-  def buildConfMap(parameters: Map[String, String]) : Map[String, String] = {
-    val confMap = mutable.Map.empty[String, String]
-    for (convertedProp <- propertiesMap.keySet) {
-      val setting = parameters.get(convertedProp)
-      if (setting.nonEmpty) {
-        confMap += propertiesMap(convertedProp) -> setting.get
-      }
-    }
-    confMap.toMap
-  }
 
   /** Check whether the provider is Cassandra datasource or not */
   def cassandraSource(provider: String) : Boolean = {


### PR DESCRIPTION
Support appending data to collection. to set pre-append per column base, 
<column_nam>.preappred should be set to true in table options.