### PR TITLE
SPARKC-321

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/RoutingKeyGenerator.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/RoutingKeyGenerator.scala
@@ -1,4 +1,4 @@
-package com.datastax.spark.connector.writer
+﻿package com.datastax.spark.connector.writer
 
 import java.nio.ByteBuffer
 
@@ -44,10 +44,11 @@ class RoutingKeyGenerator(table: TableDef, columnNames: Seq[String])
 
   private def fillRoutingKey(stmt: BoundStatement): Array[ByteBuffer] = {
     val rk = routingKey.get
-    for (i ← partitionKeyIdxs.indices) {
-      if (stmt.isNull(partitionKeyIdxs(i)))
-        throw NullKeyColumnException(columnNames(partitionKeyIdxs(i)))
-      rk(i) = stmt.getBytesUnsafe(partitionKeyIdxs(i))
+    val newKey = table.partitionKey
+    for (i <- newKey.indices) {
+      if (stmt.isNull(newKey(i).columnName))
+        throw NullKeyColumnException(newKey(i).columnName)
+      rk(i) = stmt.getBytesUnsafe(table.partitionKey(i).columnName)
     }
     rk
   }


### PR DESCRIPTION
The routingKey is determined based on the column index in the first batch of rows sent during the save operation. Spark Cassandra connector shuffles the data around while saving the data resulting in column orders to be altered. This causes the job to fail when it's unable to find the routingKey column by that index. Instead of indexes, using columnNames should solve this issue.