### PR TITLE
SPARKC-322: bulkLoadToCassandra() RDD Function

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
- * Adds the ability to add additional Predicate Pushdown Rules at Runtime (SPARKC-308) 
+ * Add new RDD function 'bulkLoadToCassandra()'; writes SSTables and streams them to Cassandra cluster (SPARKC-322)
+ * Adds the ability to add additional Predicate Pushdown Rules at Runtime (SPARKC-308)
  * Added CassandraOption for Skipping Columns when Writing to C* (SPARKC-283)
  * Upgrade Spark to 1.6.0 and add Apache Snapshot repository to resolvers (SPARKC-272, SPARKC-298, SPARKC-305)
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+ * Add new RDD function 'bulkLoadToCassandra()'; writes SSTables and streams them to Cassandra cluster (SPARKC-322)
  * Upgrade Spark to 1.6.0 and add Apache Snapshot repository to resolvers (SPARKC-272, SPARKC-298, SPARKC-305)
 
 ********************************************************************************

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -2,6 +2,84 @@
 
 
     
+## Bulk Loading Parameters
+**All parameters should be prefixed with <code> spark.cassandra. </code>**
+
+<table class="table">
+<tr><th>Property Name</th><th>Default</th><th>Description</th></tr>
+<tr>
+  <td><code>bulk.partitioner</code></td>
+  <td>org.apache.cassandra.dht.Murmur3Partitioner</td>
+  <td>The 'partitioner' defined in cassandra.yaml.</td>
+</tr>
+<tr>
+  <td><code>bulk.server.algorithm</code></td>
+  <td>SunX509</td>
+  <td>The 'server_encryption_options:algorithm' defined in cassandra.yaml.</td>
+</tr>
+<tr>
+  <td><code>bulk.server.cipherSuites</code></td>
+  <td>Set(TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_256_CBC_SHA)</td>
+  <td>The 'server_encryption_options:cipher_suites' defined in cassandra.yaml.</td>
+</tr>
+<tr>
+  <td><code>bulk.server.internode.encryption</code></td>
+  <td>none</td>
+  <td>The 'server_encryption_options:internode_encryption' defined in cassandra.yaml.</td>
+</tr>
+<tr>
+  <td><code>bulk.server.keyStore.password</code></td>
+  <td>cassandra</td>
+  <td>The 'server_encryption_options:keystore_password' defined in cassandra.yaml.</td>
+</tr>
+<tr>
+  <td><code>bulk.server.keyStore.path</code></td>
+  <td>conf/.keystore</td>
+  <td>The 'server_encryption_options:keystore' defined in cassandra.yaml.</td>
+</tr>
+<tr>
+  <td><code>bulk.server.protocol</code></td>
+  <td>TLS</td>
+  <td>The 'server_encryption_options:protocol' defined in cassandra.yaml.</td>
+</tr>
+<tr>
+  <td><code>bulk.server.requireClientAuth</code></td>
+  <td>false</td>
+  <td>The 'server_encryption_options:require_client_auth' defined in cassandra.yaml.</td>
+</tr>
+<tr>
+  <td><code>bulk.server.sslStorage.port</code></td>
+  <td>7001</td>
+  <td>The 'ssl_storage_port' defined in cassandra.yaml.</td>
+</tr>
+<tr>
+  <td><code>bulk.server.storage.port</code></td>
+  <td>7000</td>
+  <td>The 'storage_port' defined in cassandra.yaml.</td>
+</tr>
+<tr>
+  <td><code>bulk.server.store.type</code></td>
+  <td>JKS</td>
+  <td>The 'server_encryption_options:store_type' defined in cassandra.yaml.</td>
+</tr>
+<tr>
+  <td><code>bulk.server.trustStore.password</code></td>
+  <td>cassandra</td>
+  <td>The 'server_encryption_options:truststore_password' defined in cassandra.yaml.</td>
+</tr>
+<tr>
+  <td><code>bulk.server.trustStore.path</code></td>
+  <td>conf/.truststore</td>
+  <td>The 'server_encryption_options:truststore' defined in cassandra.yaml.</td>
+</tr>
+<tr>
+  <td><code>bulk.throughput_mb_per_sec</code></td>
+  <td>2147483647</td>
+  <td>Maximum write throughput allowed per single core in MB/s.</td>
+</tr>
+</table>
+
+
 ## Cassandra Authentication Parameters
 **All parameters should be prefixed with <code> spark.cassandra. </code>**
 

--- a/project/CassandraSparkBuild.scala
+++ b/project/CassandraSparkBuild.scala
@@ -42,7 +42,7 @@ object CassandraSparkBuild extends Build {
     id = "cassandra-server",
     base = file("cassandra-server"),
     settings = defaultSettings ++ Seq(
-      libraryDependencies ++= Seq(Artifacts.cassandraServer % "it", Artifacts.airlift),
+      libraryDependencies ++= Seq(Artifacts.cassandraServerTest % "it", Artifacts.airlift),
       cassandraServerClasspath := {
         (fullClasspath in IntegrationTest).value.map(_.data.getAbsoluteFile).mkString(File.pathSeparator)
       }
@@ -160,13 +160,14 @@ object Artifacts {
       .exclude("net.sf.jopt-simple", "jopt-simple")
   }
 
-  val akkaActor           = "com.typesafe.akka"       %% "akka-actor"            % Akka           % "provided"  // ApacheV2
-  val akkaRemote          = "com.typesafe.akka"       %% "akka-remote"           % Akka           % "provided"  // ApacheV2
-  val akkaSlf4j           = "com.typesafe.akka"       %% "akka-slf4j"            % Akka           % "provided"  // ApacheV2
-  val cassandraClient     = "org.apache.cassandra"    % "cassandra-clientutil"   % Cassandra       guavaExclude // ApacheV2
-  val cassandraDriver     = "com.datastax.cassandra"  % "cassandra-driver-core"  % CassandraDriver guavaExclude // ApacheV2
-  val commonsLang3        = "org.apache.commons"      % "commons-lang3"          % CommonsLang3                 // ApacheV2
-  val config              = "com.typesafe"            % "config"                 % Config         % "provided"  // ApacheV2
+  val akkaActor           = "com.typesafe.akka"       %% "akka-actor"            % Akka           % "provided"    // ApacheV2
+  val akkaRemote          = "com.typesafe.akka"       %% "akka-remote"           % Akka           % "provided"    // ApacheV2
+  val akkaSlf4j           = "com.typesafe.akka"       %% "akka-slf4j"            % Akka           % "provided"    // ApacheV2
+  val cassandraAll        = "org.apache.cassandra"    % "cassandra-all"          % Cassandra       logbackExclude // ApacheV2
+  val cassandraClient     = "org.apache.cassandra"    % "cassandra-clientutil"   % Cassandra       guavaExclude   // ApacheV2
+  val cassandraDriver     = "com.datastax.cassandra"  % "cassandra-driver-core"  % CassandraDriver guavaExclude   // ApacheV2
+  val commonsLang3        = "org.apache.commons"      % "commons-lang3"          % CommonsLang3                   // ApacheV2
+  val config              = "com.typesafe"            % "config"                 % Config         % "provided"    // ApacheV2
   val guava               = "com.google.guava"        % "guava"                  % Guava
   val jodaC               = "org.joda"                % "joda-convert"           % JodaC
   val jodaT               = "joda-time"               % "joda-time"              % JodaT
@@ -184,7 +185,7 @@ object Artifacts {
   val sparkCatalyst       = "org.apache.spark"        %% "spark-catalyst"        % Spark sparkExclusions        // ApacheV2
   val sparkHive           = "org.apache.spark"        %% "spark-hive"            % Spark sparkExclusions        // ApacheV2
 
-  val cassandraServer     = "org.apache.cassandra"    % "cassandra-all"          % Settings.cassandraTestVersion      logbackExclude    // ApacheV2
+  val cassandraServerTest = "org.apache.cassandra"    % "cassandra-all"          % Settings.cassandraTestVersion logbackExclude    // ApacheV2
 
   object Metrics {
     val metricsCore       = "com.codahale.metrics"    % "metrics-core"           % CodaHaleMetrics % "provided"
@@ -256,15 +257,15 @@ object Dependencies {
 
   val akka = Seq(akkaActor, akkaRemote, akkaSlf4j)
 
-  val cassandra = Seq(cassandraClient, cassandraDriver)
+  val cassandra = Seq(cassandraAll, cassandraClient, cassandraDriver)
 
   val spark = Seq(sparkCore, sparkStreaming, sparkSql, sparkCatalyst, sparkHive, sparkUnsafe)
 
   val connector = testKit ++ metrics ++ jetty ++ logging ++ akka ++ cassandra ++ spark.map(_ % "provided") ++ Seq(
-    commonsLang3, config, guava, jodaC, jodaT, lzf, jsr166e, cassandraServer)
+    commonsLang3, config, guava, jodaC, jodaT, lzf, jsr166e)
 
   val embedded = logging ++ spark ++ cassandra ++ Seq(
-    cassandraServer % "it,test", Embedded.jopt, Embedded.sparkRepl, Embedded.kafka, Embedded.snappy, guava)
+    cassandraServerTest % "it,test", Embedded.jopt, Embedded.sparkRepl, Embedded.kafka, Embedded.snappy, guava)
 
   val kafka = Seq(Demos.kafka, Demos.kafkaStreaming)
 

--- a/project/CassandraSparkBuild.scala
+++ b/project/CassandraSparkBuild.scala
@@ -261,7 +261,7 @@ object Dependencies {
   val spark = Seq(sparkCore, sparkStreaming, sparkSql, sparkCatalyst, sparkHive, sparkUnsafe)
 
   val connector = testKit ++ metrics ++ jetty ++ logging ++ akka ++ cassandra ++ spark.map(_ % "provided") ++ Seq(
-    commonsLang3, config, guava, jodaC, jodaT, lzf, jsr166e)
+    commonsLang3, config, guava, jodaC, jodaT, lzf, jsr166e, cassandraServer)
 
   val embedded = logging ++ spark ++ cassandra ++ Seq(
     cassandraServer % "it,test", Embedded.jopt, Embedded.sparkRepl, Embedded.kafka, Embedded.snappy, guava)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/bulk/BulkConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/bulk/BulkConf.scala
@@ -1,0 +1,293 @@
+package com.datastax.spark.connector.bulk
+
+import com.datastax.driver.core.DataType
+import com.datastax.spark.connector.bulk.BulkConf._
+import com.datastax.spark.connector.cql.{RegularColumn, ColumnDef}
+import com.datastax.spark.connector.types.ColumnType
+import com.datastax.spark.connector.util.{ConfigCheck, ConfigParameter}
+import com.datastax.spark.connector.writer.{PerRowWriteOptionValue, WriteOption, TimestampOption, TTLOption}
+import org.apache.cassandra.config.EncryptionOptions.ServerEncryptionOptions
+import org.apache.cassandra.config.EncryptionOptions.ServerEncryptionOptions.InternodeEncryption
+import org.apache.cassandra.dht.{Murmur3Partitioner, RandomPartitioner, ByteOrderedPartitioner, IPartitioner}
+import org.apache.spark.SparkConf
+
+/**
+ * Bulk loading settings.
+ *
+ * @param partitioner the 'partitioner' defined in cassandra.yaml.
+ * @param serverConf the server side encryption configurations defined in cassandra.yaml.
+ * @param throughputMiBPS the maximum throughput to throttle.
+ * @param ttl the default TTL value which is used when it is defined (in seconds)
+ * @param timestamp the default timestamp value which is used when it is defined (in microseconds)
+ */
+case class BulkConf
+(
+  partitioner: String = BulkConf.PartitionerParam.default,
+  serverConf: BulkServerConf = BulkConf.DefaultBulkServerConf,
+  throughputMiBPS: Int = BulkConf.ThroughputMiBPSParam.default,
+  ttl: TTLOption = TTLOption.defaultValue,
+  timestamp: TimestampOption = TimestampOption.defaultValue
+) {
+  require(BulkConf.AllowedPartitioners.contains(partitioner),
+    s"Invalid value of spark.cassandra.bulk.partitioner: $partitioner. Expected any of ${BulkConf.AllowedPartitioners.mkString(", ")}."
+  )
+
+  private[bulk] def getPartitioner: IPartitioner = {
+    partitioner match {
+      case "org.apache.cassandra.dht.Murmur3Partitioner" => Murmur3Partitioner.instance
+      case "org.apache.cassandra.dht.RandomPartitioner" => RandomPartitioner.instance
+      case "org.apache.cassandra.dht.ByteOrderedPartitioner" => ByteOrderedPartitioner.instance
+    }
+  }
+
+  private[bulk] val optionPlaceholders: Seq[String] = Seq(ttl, timestamp).collect {
+    case WriteOption(PerRowWriteOptionValue(placeholder)) => placeholder
+  }
+
+  private[bulk] val optionsAsColumns: (String, String) => Seq[ColumnDef] = { (keyspace, table) =>
+    def toRegularColDef(opt: WriteOption[_], dataType: DataType) = opt match {
+      case WriteOption(PerRowWriteOptionValue(placeholder)) =>
+        Some(ColumnDef(placeholder, RegularColumn, ColumnType.fromDriverType(dataType)))
+      case _ => None
+    }
+
+    Seq(toRegularColDef(ttl, DataType.cint()), toRegularColDef(timestamp, DataType.bigint())).flatten
+  }
+
+  val throttlingEnabled = throughputMiBPS < BulkConf.ThroughputMiBPSParam.default
+}
+
+object BulkConf {
+
+  /**
+   * Bulk load server encryption settings.
+   *
+   * @param storagePort the 'storage_port' defined in cassandra.yaml.
+   * @param sslStoragePort the 'ssl_storage_port' defined in cassandra.yaml.
+   * @param internodeEncryption the 'server_encryption_options:internode_encryption' defined in cassandra.yaml.
+   * @param keyStorePath the 'server_encryption_options:keystore' defined in cassandra.yaml.
+   * @param keyStorePassword the 'server_encryption_options:keystore_password' defined in cassandra.yaml.
+   * @param trustStorePath the 'server_encryption_options:truststore' defined in cassandra.yaml.
+   * @param trustStorePassword the 'server_encryption_options:truststore_password' defined in cassandra.yaml.
+   * @param protocol the 'server_encryption_options:protocol' defined in cassandra.yaml.
+   * @param algorithm the 'server_encryption_options:algorithm' defined in cassandra.yaml.
+   * @param storeType the 'server_encryption_options:store_type' defined in cassandra.yaml.
+   * @param cipherSuites the 'server_encryption_options:cipher_suites' defined in cassandra.yaml.
+   * @param requireClientAuth the 'server_encryption_options:require_client_auth' defined in cassandra.yaml.
+   */
+  case class BulkServerConf
+  (
+    storagePort: Int = BulkConf.StoragePortParam.default,
+    sslStoragePort: Int = BulkConf.SSLStoragePortParam.default,
+    internodeEncryption: String = BulkConf.InternodeEncryptionParam.default,
+    keyStorePath: String = BulkConf.KeystorePathParam.default,
+    keyStorePassword: String = BulkConf.KeystorePasswordParam.default,
+    trustStorePath: String = BulkConf.TrustStorePathParam.default,
+    trustStorePassword: String = BulkConf.TrustStorePasswordParam.default,
+    protocol: String = BulkConf.ProtocolParam.default,
+    algorithm: String = BulkConf.AlgorithmParam.default,
+    storeType: String = BulkConf.StoreTypeParam.default,
+    cipherSuites: Set[String] = BulkConf.CipherSuitesParam.default,
+    requireClientAuth: Boolean = BulkConf.RequireClientAuthParam.default
+  ) {
+    require(BulkConf.AllowedInternodeEncryptions.contains(internodeEncryption),
+      s"Invalid value of spark.cassandra.bulk.server.internode.encryption: ${internodeEncryption}. Expected any of ${BulkConf.AllowedInternodeEncryptions.mkString(", ")}."
+    )
+
+    private[bulk] def getServerEncryptionOptions: ServerEncryptionOptions = {
+      val actualInternodeEncryption = internodeEncryption match {
+        case "all" => InternodeEncryption.all
+        case "none" => InternodeEncryption.none
+        case "dc" => InternodeEncryption.dc
+        case "rack" => InternodeEncryption.rack
+      }
+
+      val encryptionOptions = new ServerEncryptionOptions()
+      encryptionOptions.internode_encryption = actualInternodeEncryption
+      encryptionOptions.keystore = keyStorePath
+      encryptionOptions.keystore_password = keyStorePassword
+      encryptionOptions.truststore = trustStorePath
+      encryptionOptions.truststore_password = trustStorePassword
+      encryptionOptions.cipher_suites = cipherSuites.toArray
+      encryptionOptions.protocol = protocol
+      encryptionOptions.algorithm = algorithm
+      encryptionOptions.store_type = storeType
+      encryptionOptions.require_client_auth = requireClientAuth
+
+      encryptionOptions
+    }
+  }
+
+  val AllowedPartitioners = Set(
+    "org.apache.cassandra.dht.Murmur3Partitioner",
+    "org.apache.cassandra.dht.RandomPartitioner",
+    "org.apache.cassandra.dht.ByteOrderedPartitioner"
+  )
+
+  val AllowedInternodeEncryptions = Set(
+    "all",
+    "none",
+    "dc",
+    "other"
+  )
+
+  val ReferenceSection = "Bulk Loading Parameters"
+
+  val PartitionerParam = ConfigParameter[String](
+    name = "spark.cassandra.bulk.partitioner",
+    section = ReferenceSection,
+    default = "org.apache.cassandra.dht.Murmur3Partitioner",
+    description = """The 'partitioner' defined in cassandra.yaml."""
+  )
+
+  val ThroughputMiBPSParam = ConfigParameter[Int] (
+    name = "spark.cassandra.bulk.throughput_mb_per_sec",
+    section = ReferenceSection,
+    default = Int.MaxValue,
+    description = """Maximum write throughput allowed per single core in MB/s.""".stripMargin
+  )
+
+  val StoragePortParam = ConfigParameter[Int](
+    name = "spark.cassandra.bulk.server.storage.port",
+    section = ReferenceSection,
+    default = 7000,
+    description = """The 'storage_port' defined in cassandra.yaml."""
+  )
+
+  val SSLStoragePortParam = ConfigParameter[Int](
+    name = "spark.cassandra.bulk.server.sslStorage.port",
+    section = ReferenceSection,
+    default = 7001,
+    description = """The 'ssl_storage_port' defined in cassandra.yaml."""
+  )
+
+  val InternodeEncryptionParam = ConfigParameter[String](
+    name = "spark.cassandra.bulk.server.internode.encryption",
+    section = ReferenceSection,
+    default = "none",
+    description = """The 'server_encryption_options:internode_encryption' defined in cassandra.yaml."""
+  )
+
+  val KeystorePathParam = ConfigParameter[String](
+    name = "spark.cassandra.bulk.server.keyStore.path",
+    section = ReferenceSection,
+    default = "conf/.keystore",
+    description = """The 'server_encryption_options:keystore' defined in cassandra.yaml."""
+  )
+
+  val KeystorePasswordParam = ConfigParameter[String](
+    name = "spark.cassandra.bulk.server.keyStore.password",
+    section = ReferenceSection,
+    default = "cassandra",
+    description = """The 'server_encryption_options:keystore_password' defined in cassandra.yaml."""
+  )
+
+  val TrustStorePathParam = ConfigParameter[String](
+    name = "spark.cassandra.bulk.server.trustStore.path",
+    section = ReferenceSection,
+    default = "conf/.truststore",
+    description = """The 'server_encryption_options:truststore' defined in cassandra.yaml."""
+  )
+
+  val TrustStorePasswordParam = ConfigParameter[String](
+    name = "spark.cassandra.bulk.server.trustStore.password",
+    section = ReferenceSection,
+    default = "cassandra",
+    description = """The 'server_encryption_options:truststore_password' defined in cassandra.yaml."""
+  )
+
+  val ProtocolParam = ConfigParameter[String](
+    name = "spark.cassandra.bulk.server.protocol",
+    section = ReferenceSection,
+    default = "TLS",
+    description = """The 'server_encryption_options:protocol' defined in cassandra.yaml."""
+  )
+
+  val AlgorithmParam = ConfigParameter[String](
+    name = "spark.cassandra.bulk.server.algorithm",
+    section = ReferenceSection,
+    default = "SunX509",
+    description = """The 'server_encryption_options:algorithm' defined in cassandra.yaml."""
+  )
+
+  val StoreTypeParam = ConfigParameter[String](
+    name = "spark.cassandra.bulk.server.store.type",
+    section = ReferenceSection,
+    default = "JKS",
+    description = """The 'server_encryption_options:store_type' defined in cassandra.yaml."""
+  )
+
+  val CipherSuitesParam = ConfigParameter[Set[String]](
+    name = "spark.cassandra.bulk.server.cipherSuites",
+    section = ReferenceSection,
+    default = Set("TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA"),
+    description = """The 'server_encryption_options:cipher_suites' defined in cassandra.yaml."""
+  )
+
+  val RequireClientAuthParam = ConfigParameter[Boolean](
+    name = "spark.cassandra.bulk.server.requireClientAuth",
+    section = ReferenceSection,
+    default = false,
+    description = """The 'server_encryption_options:require_client_auth' defined in cassandra.yaml."""
+  )
+
+  val Properties: Set[ConfigParameter[_]] = Set(
+    PartitionerParam,
+    ThroughputMiBPSParam,
+    StoragePortParam,
+    SSLStoragePortParam,
+    InternodeEncryptionParam,
+    KeystorePathParam,
+    KeystorePasswordParam,
+    TrustStorePathParam,
+    TrustStorePasswordParam,
+    ProtocolParam,
+    AlgorithmParam,
+    StoreTypeParam,
+    CipherSuitesParam,
+    RequireClientAuthParam
+  )
+
+  val DefaultBulkServerConf = BulkServerConf()
+
+  def fromSparkConf(conf: SparkConf): BulkConf = {
+    ConfigCheck.checkConfig(conf)
+
+    val partitioner = conf.get(PartitionerParam.name, PartitionerParam.default)
+    val throughputMiBPS = conf.getInt(ThroughputMiBPSParam.name, ThroughputMiBPSParam.default)
+    val storagePort = conf.getInt(StoragePortParam.name, StoragePortParam.default)
+    val sslStoragePort = conf.getInt(SSLStoragePortParam.name, SSLStoragePortParam.default)
+    val internodeEncryption = conf.get(InternodeEncryptionParam.name, InternodeEncryptionParam.default)
+    val keyStorePath = conf.get(KeystorePathParam.name, KeystorePathParam.default)
+    val keyStorePassword = conf.get(KeystorePasswordParam.name, KeystorePasswordParam.default)
+    val trustStorePath = conf.get(TrustStorePathParam.name, TrustStorePathParam.default)
+    val trustStorePassword = conf.get(TrustStorePasswordParam.name, TrustStorePasswordParam.default)
+    val protocol = conf.get(ProtocolParam.name, ProtocolParam.default)
+    val algorithm = conf.get(AlgorithmParam.name, AlgorithmParam.default)
+    val storeType = conf.get(StoreTypeParam.name, StoreTypeParam.default)
+    val cipherSuites = conf.getOption(CipherSuitesParam.name)
+      .map(_.split(",").map(_.trim).toSet).getOrElse(CipherSuitesParam.default)
+    val requireClientAuth = conf.getBoolean(RequireClientAuthParam.name, RequireClientAuthParam.default)
+
+    val bulkServerConf = BulkServerConf(
+      storagePort = storagePort,
+      sslStoragePort = sslStoragePort,
+      internodeEncryption = internodeEncryption,
+      keyStorePath = keyStorePath,
+      keyStorePassword = keyStorePassword,
+      trustStorePath = trustStorePath,
+      trustStorePassword = trustStorePassword,
+      protocol = protocol,
+      algorithm = algorithm,
+      storeType = storeType,
+      cipherSuites = cipherSuites,
+      requireClientAuth = requireClientAuth
+    )
+
+    BulkConf(
+      partitioner = partitioner,
+      serverConf = bulkServerConf,
+      throughputMiBPS = throughputMiBPS
+    )
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/bulk/BulkOutputHandler.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/bulk/BulkOutputHandler.scala
@@ -1,0 +1,14 @@
+package com.datastax.spark.connector.bulk
+
+import org.apache.cassandra.utils.OutputHandler
+import org.slf4j.Logger
+
+class BulkOutputHandler(log: Logger) extends OutputHandler {
+  override def warn(msg: String): Unit = log.warn(msg)
+
+  override def warn(msg: String, th: Throwable): Unit = log.warn(msg, th)
+
+  override def debug(msg: String): Unit = log.debug(msg)
+
+  override def output(msg: String): Unit = log.info(msg)
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/bulk/BulkProgressIndicator.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/bulk/BulkProgressIndicator.scala
@@ -1,0 +1,89 @@
+package com.datastax.spark.connector.bulk
+
+import java.net.InetAddress
+
+import org.apache.cassandra.streaming._
+import org.slf4j.Logger
+
+import scala.collection.mutable.{HashMap, MultiMap, Set, StringBuilder}
+
+import scala.collection.JavaConverters._
+
+class BulkProgressIndicator(log: Logger) extends StreamEventHandler {
+  private val startTime: Long = System.nanoTime()
+  private var lastTime: Long = System.nanoTime()
+
+  private var totalFiles = 0L
+
+  private val sessionsByHost = new HashMap[InetAddress, Set[SessionInfo]] with MultiMap[InetAddress, SessionInfo]
+
+  override def onSuccess(result: StreamState): Unit = {
+    // Do Nothing.
+  }
+
+  override def onFailure(t: Throwable): Unit = {
+    // Do Nothing.
+  }
+
+  override def handleStreamEvent(event: StreamEvent): Unit = {
+    event.eventType match {
+      case StreamEvent.Type.STREAM_PREPARED =>
+        val currentSessionInfo = event.asInstanceOf[StreamEvent.SessionPreparedEvent].session
+        sessionsByHost.addBinding(currentSessionInfo.peer, currentSessionInfo)
+
+        log.info(s"Session to ${currentSessionInfo.connecting.getHostAddress}.")
+      case StreamEvent.Type.STREAM_COMPLETE =>
+        val currentCompletionEvent = event.asInstanceOf[StreamEvent.SessionCompleteEvent]
+
+        if (currentCompletionEvent.success) {
+          log.info(s"Stream to ${currentCompletionEvent.peer.getHostAddress} successful.")
+        } else {
+          log.info(s"Stream to ${currentCompletionEvent.peer.getHostAddress} failed.")
+        }
+      case StreamEvent.Type.FILE_PROGRESS =>
+        val currentProgressInfo = event.asInstanceOf[StreamEvent.ProgressEvent].progress
+
+        val currentTime = System.nanoTime()
+        val deltaTime = currentTime - lastTime
+
+        val currentProgressBuilder = new StringBuilder()
+        currentProgressBuilder.append("Stream Progress: ")
+
+        var totalProgress = 0L
+        var totalSize = 0L
+
+        var updateTotalFiles = totalFiles == 0
+        for (currentPeer <- sessionsByHost.keys) {
+          currentProgressBuilder.append(s"[${currentPeer.toString}]")
+          for (currentSession <- sessionsByHost.getOrElse(currentPeer, Set.empty[SessionInfo])) {
+            val currentSize = currentSession.getTotalSizeToSend
+            var currentProgress = 0L
+            var completitionStatus = 0
+
+            if (
+              currentSession.peer == currentProgressInfo.peer &&
+              currentSession.sessionIndex == currentProgressInfo.sessionIndex) {
+              currentSession.updateProgress(currentProgressInfo)
+            }
+            for (existingProgressInfo <- currentSession.getSendingFiles.asScala) {
+              if (existingProgressInfo.isCompleted)
+                completitionStatus += 1
+
+              currentProgress += existingProgressInfo.currentBytes
+            }
+            totalProgress += currentProgress
+            totalSize += currentSize
+
+            currentProgressBuilder.append(s"-${currentSession.sessionIndex}:$completitionStatus/${currentSession.getTotalFilesToSend} ")
+
+            if (updateTotalFiles) {
+              totalFiles += currentSession.getTotalFilesToSend
+            }
+          }
+        }
+
+        log.info(currentProgressBuilder.toString().trim)
+      case _ => // Do Nothing.
+    }
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/bulk/BulkSSTableLoaderClient.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/bulk/BulkSSTableLoaderClient.scala
@@ -1,0 +1,84 @@
+package com.datastax.spark.connector.bulk
+
+import com.datastax.driver.core._
+import com.datastax.spark.connector.bulk.BulkConf.BulkServerConf
+import org.apache.cassandra.config.CFMetaData
+import org.apache.cassandra.db.composites.CellNames
+import org.apache.cassandra.db.marshal.TypeParser
+import org.apache.cassandra.db.{ColumnFamilyType, SystemKeyspace}
+import org.apache.cassandra.dht.{Token, Range}
+import org.apache.cassandra.io.sstable.SSTableLoader.Client
+import org.apache.cassandra.schema.LegacySchemaTables
+import org.apache.cassandra.streaming.StreamConnectionFactory
+import org.apache.cassandra.tools.BulkLoadConnectionFactory
+
+import scala.collection.JavaConverters._
+
+class BulkSSTableLoaderClient(session: Session, bulkServerConf: BulkServerConf) extends Client {
+  var tables: Map[String, CFMetaData] = Map.empty[String, CFMetaData]
+
+  override def init(keyspace: String): Unit = {
+    val cluster = session.getCluster
+
+    val metaData = cluster.getMetadata
+
+    setPartitioner(metaData.getPartitioner)
+
+    val tokenRanges = metaData.getTokenRanges.asScala
+    val tokenFactory = getPartitioner.getTokenFactory
+
+    for (tokenRange <- tokenRanges) {
+      val endpoints = metaData.getReplicas(Metadata.quote(keyspace), tokenRange).asScala
+
+      val range = new Range[Token](
+        tokenFactory.fromString(tokenRange.getStart.getValue.toString),
+        tokenFactory.fromString(tokenRange.getEnd.getValue.toString)
+      )
+
+      for (endpoint <- endpoints) {
+        addRangeForEndpoint(range, endpoint.getAddress)
+      }
+    }
+
+    tables = fetchTablesMetadata(keyspace)
+  }
+
+  override def getTableMetadata(tableName: String): CFMetaData = {
+    tables(tableName)
+  }
+
+  override def setTableMetadata(cfm: CFMetaData): Unit = {
+    tables = tables + (cfm.cfName -> cfm)
+  }
+
+
+  override def getConnectionFactory: StreamConnectionFactory = {
+    new BulkLoadConnectionFactory(
+      bulkServerConf.storagePort,
+      bulkServerConf.sslStoragePort,
+      bulkServerConf.getServerEncryptionOptions,
+      false
+    )
+  }
+
+  private def fetchTablesMetadata(keyspace: String): Map[String, CFMetaData] = {
+    var tempTables = Map.empty[String, CFMetaData]
+
+    val queryString = s"""SELECT columnfamily_name, cf_id, type, comparator, subcomparator, is_dense FROM ${SystemKeyspace.NAME}.${LegacySchemaTables.COLUMNFAMILIES} WHERE keyspace_name = '$keyspace'"""
+
+    val rowIterator = session.execute(queryString).iterator.asScala
+    for (row <- rowIterator) {
+      val rowName = row.getString("columnfamily_name")
+      val rowId = row.getUUID("cf_id")
+      val rowType = ColumnFamilyType.valueOf(row.getString("type"))
+      val rowRawComparator = TypeParser.parse(row.getString("comparator"))
+      val rowSubComparator = if (row.isNull("subcomparator")) null else TypeParser.parse(row.getString("subcomparator"))
+      val rowIsDense = row.getBool("is_dense")
+      val rowComparator = CellNames.fromAbstractType(CFMetaData.makeRawAbstractType(rowRawComparator, rowSubComparator), rowIsDense)
+
+      tempTables = tempTables + (rowName -> new CFMetaData(keyspace, rowName, rowType, rowComparator, rowId))
+    }
+
+    tempTables
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/bulk/BulkSSTableLoaderClient.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/bulk/BulkSSTableLoaderClient.scala
@@ -4,7 +4,7 @@ import com.datastax.driver.core._
 import com.datastax.spark.connector.bulk.BulkConf.BulkServerConf
 import org.apache.cassandra.config.{ColumnDefinition, CFMetaData}
 import org.apache.cassandra.cql3.ColumnIdentifier
-import org.apache.cassandra.db.marshal.{ReversedType, TypeParser}
+import org.apache.cassandra.db.marshal.ReversedType
 import org.apache.cassandra.dht.{IPartitioner, Token, Range}
 import org.apache.cassandra.io.sstable.SSTableLoader.Client
 import org.apache.cassandra.schema.{CQLTypeParser, Types, SchemaKeyspace}
@@ -124,7 +124,7 @@ class BulkSSTableLoaderClient(session: Session, bulkServerConf: BulkServerConf) 
 
     val colRowIterator = session.execute(columnsQueryString, keyspace).iterator.asScala
     for (colRow <- colRowIterator) {
-      columnDefinitions = columnDefinitions + createDefinitionFromRow(colRow, keyspace, tableName, types)
+      columnDefinitions = columnDefinitions :+ createDefinitionFromRow(colRow, keyspace, tableName, types)
     }
 
     CFMetaData.create(

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/bulk/BulkSSTableLoaderClient.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/bulk/BulkSSTableLoaderClient.scala
@@ -2,15 +2,15 @@ package com.datastax.spark.connector.bulk
 
 import com.datastax.driver.core._
 import com.datastax.spark.connector.bulk.BulkConf.BulkServerConf
-import org.apache.cassandra.config.CFMetaData
-import org.apache.cassandra.db.composites.CellNames
-import org.apache.cassandra.db.marshal.TypeParser
-import org.apache.cassandra.db.{ColumnFamilyType, SystemKeyspace}
-import org.apache.cassandra.dht.{Token, Range}
+import org.apache.cassandra.config.{ColumnDefinition, CFMetaData}
+import org.apache.cassandra.cql3.ColumnIdentifier
+import org.apache.cassandra.db.marshal.{ReversedType, TypeParser}
+import org.apache.cassandra.dht.{IPartitioner, Token, Range}
 import org.apache.cassandra.io.sstable.SSTableLoader.Client
-import org.apache.cassandra.schema.LegacySchemaTables
+import org.apache.cassandra.schema.{CQLTypeParser, Types, SchemaKeyspace}
 import org.apache.cassandra.streaming.StreamConnectionFactory
 import org.apache.cassandra.tools.BulkLoadConnectionFactory
+import org.apache.cassandra.utils.FBUtilities
 
 import scala.collection.JavaConverters._
 
@@ -22,10 +22,9 @@ class BulkSSTableLoaderClient(session: Session, bulkServerConf: BulkServerConf) 
 
     val metaData = cluster.getMetadata
 
-    setPartitioner(metaData.getPartitioner)
-
+    val partitioner = FBUtilities.newPartitioner(metaData.getPartitioner)
     val tokenRanges = metaData.getTokenRanges.asScala
-    val tokenFactory = getPartitioner.getTokenFactory
+    val tokenFactory = partitioner.getTokenFactory
 
     for (tokenRange <- tokenRanges) {
       val endpoints = metaData.getReplicas(Metadata.quote(keyspace), tokenRange).asScala
@@ -40,7 +39,10 @@ class BulkSSTableLoaderClient(session: Session, bulkServerConf: BulkServerConf) 
       }
     }
 
-    tables = fetchTablesMetadata(keyspace)
+    val types = fetchTypes(keyspace)
+
+    tables = tables ++ fetchTables(keyspace, partitioner, types)
+    tables = tables ++ fetchViews(keyspace, partitioner, types)
   }
 
   override def getTableMetadata(tableName: String): CFMetaData = {
@@ -61,24 +63,95 @@ class BulkSSTableLoaderClient(session: Session, bulkServerConf: BulkServerConf) 
     )
   }
 
-  private def fetchTablesMetadata(keyspace: String): Map[String, CFMetaData] = {
+  private def fetchTypes(keyspace: String): Types = {
+    val queryString = s"""SELECT * FROM ${SchemaKeyspace.NAME}.${SchemaKeyspace.TYPES} WHERE keyspace_name = ?"""
+
+    val typeBuilder = Types.rawBuilder(keyspace)
+    val rowIterator = session.execute(queryString, keyspace).iterator.asScala
+    for (row <- rowIterator) {
+      val rowTypeName = row.getString("type_name")
+      val rowFieldNames = row.getList("field_names", classOf[String])
+      val rowFieldTypes = row.getList("field_types", classOf[String])
+
+      typeBuilder.add(rowTypeName, rowFieldNames, rowFieldTypes)
+    }
+
+    typeBuilder.build()
+  }
+
+  private def fetchTables(keyspace: String, partitioner: IPartitioner, types: Types): Map[String, CFMetaData] = {
     var tempTables = Map.empty[String, CFMetaData]
 
-    val queryString = s"""SELECT columnfamily_name, cf_id, type, comparator, subcomparator, is_dense FROM ${SystemKeyspace.NAME}.${LegacySchemaTables.COLUMNFAMILIES} WHERE keyspace_name = '$keyspace'"""
+    val queryString = s"""SELECT * FROM ${SchemaKeyspace.NAME}.${SchemaKeyspace.TABLES} WHERE keyspace_name = ?"""
 
-    val rowIterator = session.execute(queryString).iterator.asScala
+    val rowIterator = session.execute(queryString, keyspace).iterator.asScala
     for (row <- rowIterator) {
-      val rowName = row.getString("columnfamily_name")
-      val rowId = row.getUUID("cf_id")
-      val rowType = ColumnFamilyType.valueOf(row.getString("type"))
-      val rowRawComparator = TypeParser.parse(row.getString("comparator"))
-      val rowSubComparator = if (row.isNull("subcomparator")) null else TypeParser.parse(row.getString("subcomparator"))
-      val rowIsDense = row.getBool("is_dense")
-      val rowComparator = CellNames.fromAbstractType(CFMetaData.makeRawAbstractType(rowRawComparator, rowSubComparator), rowIsDense)
+      val rowTableName = row.getString("table_name")
 
-      tempTables = tempTables + (rowName -> new CFMetaData(keyspace, rowName, rowType, rowComparator, rowId))
+      tempTables = tempTables + (rowTableName -> createTableMetadata(keyspace, partitioner, false, row, rowTableName, types))
     }
 
     tempTables
+  }
+
+  private def fetchViews(keyspace: String, partitioner: IPartitioner, types: Types): Map[String, CFMetaData] = {
+    var tempTables = Map.empty[String, CFMetaData]
+
+    val queryString = s"""SELECT * FROM ${SchemaKeyspace.NAME}.${SchemaKeyspace.VIEWS} WHERE keyspace_name = ?"""
+
+    val rowIterator = session.execute(queryString, keyspace).iterator.asScala
+    for (row <- rowIterator) {
+      val rowViewName = row.getString("view_name")
+
+      tempTables = tempTables + (rowViewName -> createTableMetadata(keyspace, partitioner, true, row, rowViewName, types))
+    }
+
+    tempTables
+  }
+
+  private def createTableMetadata(keyspace: String, partitioner: IPartitioner, tableIsView: Boolean, tableRow: Row, tableName: String, types: Types): CFMetaData = {
+    val tableId = tableRow.getUUID("id")
+    val tableFlags = CFMetaData.flagsFromStrings(tableRow.getSet("flags", classOf[String]))
+
+    val tableIsSuper = tableFlags.contains(CFMetaData.Flag.SUPER)
+    val tableIsCounter = tableFlags.contains(CFMetaData.Flag.COUNTER)
+    val tableIsDense  = tableFlags.contains(CFMetaData.Flag.DENSE)
+    val tableIsCompound = tableFlags.contains(CFMetaData.Flag.COMPOUND)
+
+    val columnsQueryString = s"""SELECT * FROM ${SchemaKeyspace.NAME}.${SchemaKeyspace.COLUMNS} WHERE keyspace_name = ?"""
+
+    var columnDefinitions = Vector.empty[ColumnDefinition]
+
+    val colRowIterator = session.execute(columnsQueryString, keyspace).iterator.asScala
+    for (colRow <- colRowIterator) {
+      columnDefinitions = columnDefinitions + createDefinitionFromRow(colRow, keyspace, tableName, types)
+    }
+
+    CFMetaData.create(
+      keyspace,
+      tableName,
+      tableId,
+      tableIsDense,
+      tableIsCompound,
+      tableIsSuper,
+      tableIsCounter,
+      tableIsView,
+      columnDefinitions.toList.asJava,
+      partitioner
+    )
+  }
+
+  private def createDefinitionFromRow(colRow: Row, keyspace: String, table: String, types: Types): ColumnDefinition = {
+    val columnName = ColumnIdentifier.getInterned(colRow.getBytes("column_name_bytes"), colRow.getString("column_name"))
+    val columnOrder = ClusteringOrder.valueOf(colRow.getString("clustering_order").toUpperCase())
+
+    var columnType = CQLTypeParser.parse(keyspace, colRow.getString("type"), types)
+    if (columnOrder == ClusteringOrder.DESC)
+      columnType = ReversedType.getInstance(columnType)
+
+    val columnPositition = colRow.getInt("position")
+    val columnKind = ColumnDefinition.Kind.valueOf(colRow.getString("kind"))
+
+    new ColumnDefinition(keyspace, table, columnName, columnType, columnPositition, columnKind)
   }
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/bulk/BulkSSTableWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/bulk/BulkSSTableWriter.scala
@@ -1,0 +1,245 @@
+package com.datastax.spark.connector.bulk
+
+import java.io.{File, IOException}
+import java.net.InetAddress
+import java.util.UUID
+
+import com.datastax.driver.core.{Session, PreparedStatement}
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.cql._
+import com.datastax.spark.connector.types.ColumnType
+import com.datastax.spark.connector.util._
+import com.datastax.spark.connector.writer._
+import com.datastax.spark.connector.util.Quote._
+import org.apache.cassandra.config.DatabaseDescriptor
+import org.apache.cassandra.io.sstable.{SSTableLoader, CQLSSTableWriter}
+import org.apache.commons.io.FileUtils
+import org.apache.spark.{TaskContext, Logging}
+
+import scala.collection.JavaConverters._
+
+class BulkSSTableWriter[T]
+(
+  cassandraConnector: CassandraConnector,
+  tableDef: TableDef,
+  columnSelector: IndexedSeq[ColumnRef],
+  rowWriter: RowWriter[T],
+  bulkConf: BulkConf
+) extends Serializable with Logging {
+  val keyspaceName = tableDef.keyspaceName
+  val tableName = tableDef.tableName
+  val columnNames = rowWriter.columnNames diff bulkConf.optionPlaceholders
+  val columns = columnNames.map(tableDef.columnByName)
+
+  val defaultTTL = bulkConf.ttl match {
+    case TTLOption(StaticWriteOptionValue(value)) => Some(value)
+    case _ => None
+  }
+
+  val defaultTimestamp = bulkConf.timestamp match {
+    case TimestampOption(StaticWriteOptionValue(value)) => Some(value)
+    case _ => None
+  }
+
+  private val schemaTemplate: String = tableDef.cql
+
+  private val insertTemplate: String = {
+    val quotedColumnNames: Seq[String] = columnNames.map(quote)
+    val columnSpec = quotedColumnNames.mkString(", ")
+    val valueSpec = quotedColumnNames.map(":" + _).mkString(", ")
+
+    val ttlSpec = bulkConf.ttl match {
+      case TTLOption(PerRowWriteOptionValue(placeholder)) => Some(s"TTL :$placeholder")
+      case TTLOption(StaticWriteOptionValue(value)) => Some(s"TTL $value")
+      case _ => None
+    }
+
+    val timestampSpec = bulkConf.timestamp match {
+      case TimestampOption(PerRowWriteOptionValue(placeholder)) => Some(s"TIMESTAMP :$placeholder")
+      case TimestampOption(StaticWriteOptionValue(value)) => Some(s"TIMESTAMP $value")
+      case _ => None
+    }
+
+    val options = List(ttlSpec, timestampSpec).flatten
+    val optionsSpec = if (options.nonEmpty) s"USING ${options.mkString(" AND ")}" else ""
+
+    s"INSERT INTO ${quote(keyspaceName)}.${quote(tableName)} ($columnSpec) VALUES ($valueSpec) $optionsSpec".trim
+  }
+
+  private def prepareDataStatement(session: Session): PreparedStatement = {
+    try {
+      session.prepare(insertTemplate)
+    }
+    catch {
+      case t: Throwable =>
+        throw new IOException(s"Failed to prepare insert statement $insertTemplate: " + t.getMessage, t)
+    }
+  }
+
+  private def prepareSSTableDirectory(): File = {
+    val temporaryRoot = System.getProperty("java.io.tmpdir")
+
+    val maxAttempts = 10
+    var currentAttempts = 0
+
+    var ssTableDirectory: Option[File] = None
+    while (ssTableDirectory.isEmpty) {
+      currentAttempts += 1
+      if (currentAttempts > maxAttempts) {
+        throw new IOException(
+          s"Failed to create a SSTable directory of $keyspaceName.$tableName after $maxAttempts attempts!"
+        )
+      }
+
+      try {
+        ssTableDirectory = Some {
+          val newSSTablePath = "spark" + "-" + UUID.randomUUID.toString +
+            File.separator + keyspaceName + File.separator + tableName
+
+          new File(temporaryRoot, newSSTablePath)
+        }
+        if (ssTableDirectory.get.exists() || !ssTableDirectory.get.mkdirs()) {
+          ssTableDirectory = None
+        }
+      } catch {
+        case e: SecurityException => ssTableDirectory = None
+      }
+    }
+
+    ssTableDirectory.get.getCanonicalFile
+  }
+
+  private def writeRowsToSSTables(
+    ssTableDirectory: File,
+    dataStatement: PreparedStatement,
+    data: Iterator[T]
+  ): Unit = {
+    val ssTableBuilder = CQLSSTableWriter.builder()
+      .inDirectory(ssTableDirectory)
+      .forTable(schemaTemplate)
+      .using(insertTemplate)
+      .withPartitioner(bulkConf.getPartitioner)
+    val ssTableWriter = ssTableBuilder.build()
+
+    logInfo(s"Writing rows to temporary SSTables in ${ssTableDirectory.getAbsolutePath}.")
+
+    val startTime = System.nanoTime()
+
+    val rowIterator = new CountingIterator(data)
+    val rowColumnNames = rowWriter.columnNames.toIndexedSeq
+    val rowColumnTypes = rowColumnNames.map(dataStatement.getVariables.getType)
+    val rowConverters = rowColumnTypes.map(ColumnType.converterToCassandra(_))
+    val rowBuffer = Array.ofDim[Any](columnNames.size)
+    for (currentData <- rowIterator) {
+      rowWriter.readColumnValues(currentData, rowBuffer)
+
+      val rowValues = for (index <- columnNames.indices) yield {
+        val currentConverter = rowConverters(index)
+        val currentValue = currentConverter.convert(rowBuffer(index))
+
+        currentValue
+      }
+
+      ssTableWriter.addRow(rowValues: _*)
+    }
+
+    ssTableWriter.close()
+
+    val endTime = System.nanoTime()
+
+    val duration = (endTime - startTime) / 1000000000d
+
+    logInfo(s"Wrote rows to temporary SSTables in ${ssTableDirectory.getAbsolutePath} in $duration%.3f s.")
+  }
+
+  def write(taskContext: TaskContext, data: Iterator[T]): Unit = {
+    val tempSSTableDirectory = prepareSSTableDirectory()
+
+    logInfo(s"Created temporary file directory for SSTables at ${tempSSTableDirectory.getAbsolutePath}.")
+
+    try {
+      cassandraConnector.withSessionDo { session =>
+        val dataStatement = prepareDataStatement(session)
+
+        writeRowsToSSTables(tempSSTableDirectory, dataStatement, data)
+
+        val bulkSSTableLoaderClient = new BulkSSTableLoaderClient(session, bulkConf.serverConf)
+        val bulkSSTableOutputHandler = new BulkOutputHandler(log)
+        val bulkSSTableLoader = new SSTableLoader(
+          tempSSTableDirectory,
+          bulkSSTableLoaderClient,
+          bulkSSTableOutputHandler
+        )
+
+        DatabaseDescriptor.setStreamThroughputOutboundMegabitsPerSec(bulkConf.throughputMiBPS)
+
+        val bulkProgressIndicator = new BulkProgressIndicator(log)
+        try {
+          val bulkLoadFuture = bulkSSTableLoader.stream(Set.empty[InetAddress].asJava, bulkProgressIndicator)
+
+          bulkLoadFuture.get()
+        } catch  {
+          case e: Exception =>
+            throw new IOException(s"Failed to write statements to $keyspaceName.$tableName.", e)
+        }
+
+        logInfo(s"Finished stream of SSTables from ${tempSSTableDirectory.getAbsolutePath}.")
+      }
+    } finally {
+      if (tempSSTableDirectory.exists()) {
+        FileUtils.deleteDirectory(tempSSTableDirectory)
+      }
+    }
+  }
+}
+
+object BulkSSTableWriter {
+  private def checkMissingColumns(table: TableDef, columnNames: Seq[String]) {
+    val allColumnNames = table.columns.map(_.columnName)
+    val missingColumns = columnNames.toSet -- allColumnNames
+    if (missingColumns.nonEmpty)
+      throw new IllegalArgumentException(
+        s"Column(s) not found: ${missingColumns.mkString(", ")}")
+  }
+
+  private def checkMissingPrimaryKeyColumns(table: TableDef, columnNames: Seq[String]) {
+    val primaryKeyColumnNames = table.primaryKey.map(_.columnName)
+    val missingPrimaryKeyColumns = primaryKeyColumnNames.toSet -- columnNames
+    if (missingPrimaryKeyColumns.nonEmpty)
+      throw new IllegalArgumentException(
+        s"Some primary key columns are missing in RDD or have not been selected: ${missingPrimaryKeyColumns.mkString(", ")}")
+  }
+
+  private def checkNoCollectionBehaviors(table: TableDef, columnRefs: IndexedSeq[ColumnRef]) {
+    if (columnRefs.exists(_.isInstanceOf[CollectionColumnName]))
+      throw new IllegalArgumentException(
+        s"Collection behaviors (add/remove/append/prepend) are not allowed on collection columns")
+  }
+
+  private def checkColumns(table: TableDef, columnRefs: IndexedSeq[ColumnRef]) = {
+    val columnNames = columnRefs.map(_.columnName)
+    checkMissingColumns(table, columnNames)
+    checkMissingPrimaryKeyColumns(table, columnNames)
+    checkNoCollectionBehaviors(table, columnRefs)
+  }
+
+  def apply[T : RowWriterFactory](
+    connector: CassandraConnector,
+    keyspaceName: String,
+    tableName: String,
+    columnNames: ColumnSelector,
+    bulkConf: BulkConf
+  ): BulkSSTableWriter[T] = {
+    val schema = Schema.fromCassandra(connector, Some(keyspaceName), Some(tableName))
+    val tableDef = schema.tables.headOption
+      .getOrElse(throw new IOException(s"Table not found: $keyspaceName.$tableName"))
+    val selectedColumns = columnNames.selectFrom(tableDef)
+    val optionColumns = bulkConf.optionsAsColumns(keyspaceName, tableName)
+    val rowWriter = implicitly[RowWriterFactory[T]].rowWriter(
+      tableDef.copy(regularColumns = tableDef.regularColumns ++ optionColumns),
+      selectedColumns ++ optionColumns.map(_.ref))
+
+    checkColumns(tableDef, selectedColumns)
+    new BulkSSTableWriter[T](connector, tableDef, selectedColumns, rowWriter, bulkConf)
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/ConfigCheck.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/ConfigCheck.scala
@@ -1,5 +1,6 @@
 package com.datastax.spark.connector.util
 
+import com.datastax.spark.connector.bulk.BulkConf
 import com.datastax.spark.connector.cql.{CassandraConnectionFactory, AuthConfFactory, CassandraConnectorConf}
 import com.datastax.spark.connector.rdd.ReadConf
 import com.datastax.spark.connector.writer.WriteConf
@@ -20,6 +21,7 @@ object ConfigCheck {
   /** Set of valid static properties hardcoded in the connector.
     * Custom CassandraConnectionFactory and AuthConf properties are not listed here. */
   val validStaticProperties: Set[ConfigParameter[_]] =
+    BulkConf.Properties ++
     WriteConf.Properties ++
     ReadConf.Properties ++
     CassandraConnectorConf.Properties ++


### PR DESCRIPTION
https://datastax-oss.atlassian.net/browse/SPARKC-322

Currently, the bulkLoadToCassandra() RDD function writes SSTables to a temporary directory and then stream the SSTables to Cassandra minimizing the write path latency of using a driver.

I have used a prototype branch internally, so I know that it works. I am now making a pull request to contribute a cleaned version. I still have to write the various tests. 

Please do not merge until I push tests and squash a final commit. Nonetheless, I am making this pull request early to allow ample time for review.