### PR TITLE
SPARKC-325: Provide an extension for New Driver Types

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -164,6 +164,22 @@ retrieve size from C*. Can be set manually now</td>
 </table>
 
 
+## Custom Cassandra Type Parameters (Expert Use Only)
+**All parameters should be prefixed with <code> spark.cassandra. </code>**
+
+<table class="table">
+<tr><th>Property Name</th><th>Default</th><th>Description</th></tr>
+<tr>
+  <td><code>dev.customFromDriver</code></td>
+  <td>None</td>
+  <td>Provides an additional class implementing CustomDriverConverter for those
+clients that need to read non-standard primitive Cassandra types. If your C* implementation
+uses a Java Driver which can read DataType.custom() you may need it this. If you are using
+OSS Cassandra this should never be used.</td>
+</tr>
+</table>
+
+
 ## Read Tuning Parameters
 **All parameters should be prefixed with <code> spark.cassandra. </code>**
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -263,11 +263,14 @@ object Settings extends Build {
     // if we have a single C* create as little groups as possible to avoid restarting C*
     // the minimum - we need to run REPL and streaming tests in separate processes
     // additional groups for auth and ssl is just an optimisation
+    // A new group is made for CustomFromDriverSpec because the ColumnType needs to be
+    // Initilized afresh
     def singleCInstanceGroupingFunction(test: TestDefinition): String = {
       val pkgName = test.name.reverse.dropWhile(_ != '.').reverse
       if (test.name.toLowerCase.contains("authenticate")) "auth"
       else if (test.name.toLowerCase.contains("ssl")) "ssl"
       else if (pkgName.contains(".repl")) "repl"
+      else if (test.name.contains("CustomFromDriverSpec")) "customdriverspec"
       else if (pkgName.contains(".streaming")) "streaming"
       else "other"
     }

--- a/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/SparkTemplate.scala
+++ b/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/SparkTemplate.scala
@@ -61,7 +61,7 @@ object SparkTemplate {
     }
 
     System.err.println("Starting SparkContext with the following configuration:\n" +
-      defaultConf.toDebugString.lines.map(line => "\t" + line).mkString("\n"))
+      conf.toDebugString.lines.map(line => "\t" + line).mkString("\n"))
     _conf = conf.clone()
     for (cp <- sys.env.get("SPARK_SUBMIT_CLASSPATH"))
       conf.setJars(

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CustomFromDriverSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CustomFromDriverSpec.scala
@@ -3,13 +3,17 @@ package com.datastax.spark.connector.rdd
 import com.datastax.driver.core.DataType
 import com.datastax.driver.core.DataType.Name
 import com.datastax.spark.connector.{types, SparkCassandraITFlatSpecBase}
-import com.datastax.spark.connector.types.{IntType, CustomDriverConverter, ColumnType}
+import com.datastax.spark.connector.types.{
+  ColumnTypeConf,
+  IntType,
+  CustomDriverConverter,
+  ColumnType}
 
 class CustomFromDriverSpec extends SparkCassandraITFlatSpecBase {
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultConf
-    .set(ColumnType.CustomDriverTypeParam.name, "com.datastax.spark.connector.rdd.DumbConverter"))
+    .set(ColumnTypeConf.CustomDriverTypeParam.name, "com.datastax.spark.connector.rdd.DumbConverter"))
 
   "Custom fromDrivers converters " should "be loadable" in {
     ColumnType.fromDriverType(DataType.custom("Dummy")) should be(types.IntType)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CustomFromDriverSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CustomFromDriverSpec.scala
@@ -1,0 +1,29 @@
+package com.datastax.spark.connector.rdd
+
+import com.datastax.driver.core.DataType
+import com.datastax.driver.core.DataType.Name
+import com.datastax.spark.connector.{types, SparkCassandraITFlatSpecBase}
+import com.datastax.spark.connector.types.{IntType, CustomDriverConverter, ColumnType}
+
+class CustomFromDriverSpec extends SparkCassandraITFlatSpecBase {
+
+  useCassandraConfig(Seq("cassandra-default.yaml.template"))
+  useSparkConf(defaultConf
+    .set(ColumnType.CustomDriverTypeParam.name, "com.datastax.spark.connector.rdd.DumbConverter"))
+
+  "Custom fromDrivers converters " should "be loadable" in {
+    ColumnType.fromDriverType(DataType.custom("Dummy")) should be(types.IntType)
+    for ((driverType, expectedType) <- ColumnType.primitiveTypeMap) {
+      ColumnType.fromDriverType(driverType) should be(expectedType)
+    }
+  }
+}
+
+object DumbConverter extends CustomDriverConverter {
+  val asciiType = DataType.ascii()
+  override val fromDriverRowExtension: PartialFunction[(DataType, Name), ColumnType[_]] = {
+    case (x: DataType.CustomType, _) => {
+      IntType
+    }
+  }
+}

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CustomFromDriverSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CustomFromDriverSpec.scala
@@ -25,8 +25,8 @@ class CustomFromDriverSpec extends SparkCassandraITFlatSpecBase {
 
 object DumbConverter extends CustomDriverConverter {
   val asciiType = DataType.ascii()
-  override val fromDriverRowExtension: PartialFunction[(DataType, Name), ColumnType[_]] = {
-    case (x: DataType.CustomType, _) => {
+  override val fromDriverRowExtension: PartialFunction[DataType, ColumnType[_]] = {
+    case (x: DataType.CustomType) => {
       IntType
     }
   }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/ColumnType.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/ColumnType.scala
@@ -86,7 +86,8 @@ object ColumnType {
   )
 
   private lazy val customFromDriverRow: PartialFunction[(DataType, DataType.Name), ColumnType[_]] = {
-    SparkEnv.get.conf.getOption(CustomDriverTypeParam.name)
+    Option(SparkEnv.get)
+      .flatMap(env => env.conf.getOption(CustomDriverTypeParam.name))
       .flatMap(className => Some(ReflectionUtil.findGlobalObject[CustomDriverConverter](className)))
       .flatMap(clazz => Some(clazz.fromDriverRowExtension))
       .getOrElse(PartialFunction.empty)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/CustomDriverConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/CustomDriverConverter.scala
@@ -4,6 +4,6 @@ import com.datastax.driver.core.DataType
 
 trait CustomDriverConverter {
 
-  val fromDriverRowExtension:PartialFunction[(DataType, DataType.Name), ColumnType[_]]
+  val fromDriverRowExtension: PartialFunction[(DataType, DataType.Name), ColumnType[_]]
 
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/CustomDriverConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/CustomDriverConverter.scala
@@ -4,6 +4,6 @@ import com.datastax.driver.core.DataType
 
 trait CustomDriverConverter {
 
-  val fromDriverRowExtension: PartialFunction[(DataType, DataType.Name), ColumnType[_]]
+  val fromDriverRowExtension: PartialFunction[DataType, ColumnType[_]]
 
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/CustomDriverConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/CustomDriverConverter.scala
@@ -1,0 +1,9 @@
+package com.datastax.spark.connector.types
+
+import com.datastax.driver.core.DataType
+
+trait CustomDriverConverter {
+
+  val fromDriverRowExtension:PartialFunction[(DataType, DataType.Name), ColumnType[_]]
+
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/ConfigCheck.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/ConfigCheck.scala
@@ -2,6 +2,7 @@ package com.datastax.spark.connector.util
 
 import com.datastax.spark.connector.cql.{CassandraConnectionFactory, AuthConfFactory, CassandraConnectorConf}
 import com.datastax.spark.connector.rdd.ReadConf
+import com.datastax.spark.connector.types.ColumnTypeConf
 import com.datastax.spark.connector.writer.WriteConf
 import org.apache.commons.configuration.ConfigurationException
 import org.apache.commons.lang3.StringUtils
@@ -26,7 +27,8 @@ object ConfigCheck {
     AuthConfFactory.Properties ++
     CassandraConnectionFactory.Properties ++
     CassandraSQLContext.Properties ++
-    CassandraSourceRelation.Properties
+    CassandraSourceRelation.Properties ++
+    ColumnTypeConf.Properties
 
   val validStaticPropertyNames = validStaticProperties.map(_.name)
 


### PR DESCRIPTION
Allow for extending the `fromDriverRow` method of columnType. This
extension point should allow for custom cassandra types known by the
driver to be read.