### PR TITLE
SPARKC-289: Fixed accessing multiple Cassandra clusters from Spark SQL

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,8 @@
+ * Removed the ability to specify cluster alias directly and added some helper methods which make it easier to configure
+   Cassandra related data frames (SPARKC-289)
+
 1.6.0 M1
- * Adds the ability to add additional Predicate Pushdown Rules at Runtime (SPARKC-308) 
+ * Adds the ability to add additional Predicate Pushdown Rules at Runtime (SPARKC-308)
  * Added CassandraOption for Skipping Columns when Writing to C* (SPARKC-283)
  * Upgrade Spark to 1.6.0 and add Apache Snapshot repository to resolvers (SPARKC-272, SPARKC-298, SPARKC-305)
  * Includes all patches up to 1.5.0.
@@ -46,7 +49,7 @@
 1.4.2
  * SqlRowWriter not using Cached Converters (SPARKC-329)
  * Fix Violation of Partition Contract (SPARKC-323)
- * Use ScalaReflectionLock from Spark instead of TypeTag 
+ * Use ScalaReflectionLock from Spark instead of TypeTag
    to workaround Scala 2.10 reflection concurrency issues (SPARKC-333)
 
 1.4.1

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLClusterLevelSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLClusterLevelSpec.scala
@@ -2,10 +2,12 @@ package com.datastax.spark.connector.sql
 
 import scala.concurrent.Future
 
+import org.apache.spark.sql.cassandra._
+
 import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
 import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.cql.CassandraConnectorConf.{ConnectionHostParam, ConnectionPortParam}
 import com.datastax.spark.connector.embedded.EmbeddedCassandra._
-import org.apache.spark.sql.cassandra.CassandraSQLContext
 
 class CassandraSQLClusterLevelSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template", "cassandra-default.yaml.template"))
@@ -56,22 +58,31 @@ class CassandraSQLClusterLevelSpec extends SparkCassandraITFlatSpecBase {
 
   var cc: CassandraSQLContext = null
 
+  private val cluster1 = "cluster1"
+  private val cluster2 = "cluster2"
+
   override def beforeAll() {
     cc = new CassandraSQLContext(sc)
-    cc.setConf("cluster1/spark.cassandra.connection.host", getHost(0).getHostAddress)
-    cc.setConf("cluster1/spark.cassandra.connection.port", getPort(0).toString)
-    cc.setConf("cluster2/spark.cassandra.connection.host", getHost(1).getHostAddress)
-    cc.setConf("cluster2/spark.cassandra.connection.port", getPort(1).toString)
+    cc.setConf(cluster1,
+      ConnectionHostParam.option(getHost(0).getHostAddress) ++ ConnectionPortParam.option(getPort(0)))
+    cc.setConf(cluster2,
+      ConnectionHostParam.option(getHost(1).getHostAddress) ++ ConnectionPortParam.option(getPort(1)))
   }
 
-  ignore should "allow to join tables from different clusters" in {
-    val result = cc.sql(s"SELECT * FROM cluster1.$ks.test1 AS test1 Join cluster2.$ks.test2 AS test2 where test1.a=test2.a").collect()
+  it should "allow to join tables from different clusters" in {
+    cc.read.cassandraFormat("test1", ks, cluster1).load().registerTempTable("c1_test1")
+    cc.read.cassandraFormat("test2", ks, cluster2).load().registerTempTable("c2_test2")
+
+    val result = cc.sql(s"SELECT * FROM c1_test1 AS test1 JOIN c2_test2 AS test2 WHERE test1.a = test2.a").collect()
     result should have length 2
   }
 
-  ignore should "allow to write data to another cluster" in {
-    val insert = cc.sql(s"INSERT INTO TABLE cluster2.$ks.test3 SELECT * FROM cluster1.$ks.test1 AS t1").collect()
-    val result = cc.sql(s"SELECT * FROM cluster2.$ks.test3 AS test3").collect()
+  it should "allow to write data to another cluster" in {
+    cc.read.cassandraFormat("test1", ks, cluster1).load().registerTempTable("c1_test1")
+    cc.read.cassandraFormat("test3", ks, cluster2).load().registerTempTable("c2_test3")
+
+    val insert = cc.sql(s"INSERT INTO TABLE c2_test3 SELECT * FROM c1_test1 AS t1").collect()
+    val result = cc.sql(s"SELECT * FROM c2_test3 AS test3").collect()
     result should have length 5
   }
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/ConfigParameter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/ConfigParameter.scala
@@ -4,4 +4,13 @@ case class ConfigParameter[T](
   val name: String,
   val section: String,
   val default: T,
-  val description: String)
+  val description: String) extends DataFrameOption {
+
+  override val sqlOptionName = name.replaceAll("\\.", "\\_")
+
+  def option(value: Any): Map[String, String] = {
+    require(value != null)
+    Map(name -> value.toString)
+  }
+
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/DataFrameOption.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/DataFrameOption.scala
@@ -1,0 +1,10 @@
+package com.datastax.spark.connector.util
+
+trait DataFrameOption {
+  val sqlOptionName: String
+
+  def sqlOption(value: Any): Map[String, String] = {
+    require(value != null)
+    Map(sqlOptionName -> value.toString)
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSQLContext.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSQLContext.scala
@@ -76,6 +76,38 @@ class CassandraSQLContext(sc: SparkContext) extends SQLContext(sc) {
   @transient
   override protected[sql] lazy val catalog = new CassandraCatalog(this)
 
+  /** Set the Spark Cassandra Connector configuration parameters */
+  def setConf(options: Map[String, String]): CassandraSQLContext = {
+    setConf(SqlClusterParam.default, options)
+  }
+
+  /** Set the Spark Cassandra Connector configuration parameters which will be used when accessing
+    * a given cluster */
+  def setConf(
+      cluster: String,
+      options: Map[String, String]): CassandraSQLContext = {
+    checkOptions(options)
+    for ((k, v) <- options) setConf(s"$cluster/$k", v)
+    this
+  }
+
+  /** Set the Spark Cassandra Connector configuration parameters which will be used when accessing
+    * a given keyspace in a given cluster */
+  def setConf(
+      cluster: String,
+      keyspace: String,
+      options: Map[String, String]): CassandraSQLContext = {
+    checkOptions(options)
+    for ((k, v) <- options) setConf(s"$cluster:$keyspace/$k", v)
+    this
+  }
+
+  private def checkOptions(options: Map[String, String]): Unit = {
+    options.keySet.foreach { name =>
+      require(DefaultSource.confProperties.contains(name),
+        s"Unrelated parameter. You can only set the following parameters: ${DefaultSource.confProperties.mkString(", ")}")
+    }
+  }
 }
 
 object CassandraSQLContext {

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/DefaultSource.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/DefaultSource.scala
@@ -3,17 +3,15 @@ package org.apache.spark.sql.cassandra
 import scala.collection.mutable
 
 import org.apache.spark.Logging
-
-import org.apache.spark.sql.{DataFrame, SaveMode, SQLContext}
 import org.apache.spark.sql.SaveMode._
-import org.apache.spark.sql.sources.{CreatableRelationProvider, SchemaRelationProvider, BaseRelation, RelationProvider}
+import org.apache.spark.sql.cassandra.DefaultSource._
+import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, RelationProvider, SchemaRelationProvider}
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
 
-import com.datastax.spark.connector.cql.CassandraConnectorConf
+import com.datastax.spark.connector.cql.{AuthConfFactory, CassandraConnectorConf}
 import com.datastax.spark.connector.rdd.ReadConf
 import com.datastax.spark.connector.writer.WriteConf
-
-import DefaultSource._
 
 /**
  * Cassandra data source extends [[RelationProvider]], [[SchemaRelationProvider]] and [[CreatableRelationProvider]].
@@ -39,9 +37,9 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
    * The parameters map stores table level data. User can specify vale for following keys
    *
    *    table        -- table name, required
-   *    keyspace       -- keyspace name, required
-   *    cluster        -- cluster name, optional, default name is "default"
-   *    pushdown      -- true/false, optional, default is true
+   *    keyspace     -- keyspace name, required
+   *    cluster      -- cluster name, optional, default name is "default"
+   *    pushdown     -- true/false, optional, default is true
    *    Cassandra connection settings  -- optional, e.g. spark_cassandra_connection_timeout_ms
    *    Cassandra Read Settings        -- optional, e.g. spark_cassandra_input_page_row_size
    *    Cassandra Write settings       -- optional, e.g. spark_cassandra_output_consistency_level
@@ -129,7 +127,8 @@ object DefaultSource {
   val confProperties = ReadConf.Properties.map(_.name) ++
     WriteConf.Properties.map(_.name) ++
     CassandraConnectorConf.Properties.map(_.name) ++
-    CassandraSourceRelation.Properties.map(_.name)
+    CassandraSourceRelation.Properties.map(_.name) ++
+    AuthConfFactory.Properties.map(_.name)
 
   // Dot is not allowed in Options key for Spark SQL parsers, so convert . to _
   // Map converted property to origin property name

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/package.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/package.scala
@@ -2,4 +2,54 @@ package org.apache.spark.sql
 
 package object cassandra {
 
+  /** A data frame format used to access Cassandra through Connector */
+  val CassandraFormat = "org.apache.spark.sql.cassandra"
+
+  /** Returns a map of options which configure the path to Cassandra table as well as whether pushdown is enabled
+    * or not */
+  def cassandraOptions(
+      table: String,
+      keyspace: String,
+      cluster: String = CassandraSourceRelation.defaultClusterName,
+      pushdownEnable: Boolean = true): Map[String, String] =
+    Map(
+      DefaultSource.CassandraDataSourceClusterNameProperty -> cluster,
+      DefaultSource.CassandraDataSourceKeyspaceNameProperty -> keyspace,
+      DefaultSource.CassandraDataSourceTableNameProperty -> table,
+      DefaultSource.CassandraDataSourcePushdownEnableProperty -> pushdownEnable.toString)
+
+  implicit class DataFrameReaderWrapper(val dfReader: DataFrameReader) extends AnyVal {
+    /** Sets the format used to access Cassandra through Connector */
+    def cassandraFormat: DataFrameReader = {
+      dfReader.format("org.apache.spark.sql.cassandra")
+    }
+
+    /** Sets the format used to access Cassandra through Connector and configure a path to Cassandra table. */
+    def cassandraFormat(
+        table: String,
+        keyspace: String,
+        cluster: String = CassandraSourceRelation.defaultClusterName,
+        pushdownEnable: Boolean = true): DataFrameReader = {
+
+      cassandraFormat.options(cassandraOptions(table, keyspace, cluster, pushdownEnable))
+    }
+  }
+
+  implicit class DataFrameWriterWrapper(val dfWriter: DataFrameWriter) extends AnyVal {
+    /** Sets the format used to access Cassandra through Connector */
+    def cassandraFormat: DataFrameWriter = {
+      dfWriter.format("org.apache.spark.sql.cassandra")
+    }
+
+    /** Sets the format used to access Cassandra through Connector and configure a path to Cassandra table. */
+    def cassandraFormat(
+        table: String,
+        keyspace: String,
+        cluster: String = CassandraSourceRelation.defaultClusterName,
+        pushdownEnable: Boolean = true): DataFrameWriter = {
+
+      cassandraFormat.options(cassandraOptions(table, keyspace, cluster, pushdownEnable))
+    }
+  }
+
 }


### PR DESCRIPTION
SPARKC-289: Fixed accessing multiple Cassandra clusters from Spark SQL by adding the ability to define cluster/keyspace aliases