### PR TITLE
SPARKC-326: Support for reading Materialized Views

### DIFF
--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -125,7 +125,26 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
         session.execute(s"""CREATE TABLE "MixedSpace"."MixedCASE"(key INT PRIMARY KEY, value INT)""")
         session.execute(s"""CREATE TABLE "MixedSpace"."MoxedCAs" (key INT PRIMARY KEY, value INT)""")
       },
+      Future {
+        session.execute(s""" CREATE TABLE $ks.user(
+          id int PRIMARY KEY,
+          login text,
+          firstname text,
+          lastname text,
+          country text
+        )""")
 
+        session.execute(s"""CREATE MATERIALIZED VIEW $ks.user_by_country
+          AS SELECT *  //denormalize ALL columns
+          FROM user
+          WHERE country IS NOT NULL AND id IS NOT NULL
+          PRIMARY KEY(country, id);""")
+
+        session.execute(s"INSERT INTO $ks.user(id,login,firstname,lastname,country) VALUES(1, 'jdoe', 'John', 'DOE', 'US')")
+        session.execute(s"INSERT INTO $ks.user(id,login,firstname,lastname,country) VALUES(2, 'hsue', 'Helen', 'SUE', 'US')")
+        session.execute(s"INSERT INTO $ks.user(id,login,firstname,lastname,country) VALUES(3, 'rsmith', 'Richard', 'SMITH', 'UK')")
+        session.execute(s"INSERT INTO $ks.user(id,login,firstname,lastname,country) VALUES(4, 'doanduyhai', 'DuyHai', 'DOAN', 'FR')")
+      },
       Future {
         session.execute( s"""CREATE TABLE $ks.big_table (key INT PRIMARY KEY, value INT)""")
         val insert = session.prepare( s"""INSERT INTO $ks.big_table(key, value) VALUES (?, ?)""")
@@ -883,6 +902,22 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
     result should contain ((1, 100))
     result should contain ((2, 200))
     result should contain ((3, 300))
-
   }
+
+  it should "be able to read a Materialized View" in  {
+    val result = sc.cassandraTable[(String, Int, String, String, String)](ks, "user_by_country")
+      .where("country='US'")
+      .collect
+    result should contain theSameElementsAs Seq(
+      ("US", 1, "John", "DOE", "jdoe"),
+      ("US", 2, "Helen", "SUE", "hsue")
+    )
+  }
+
+  it should "throw an exception when trying to write to a Materialized View" in {
+    intercept[IllegalArgumentException] {
+      sc.parallelize(Seq(("US",1,"John","DOE","jdoe"))).saveToCassandra(ks, "user_by_country")
+    }
+  }
+
 }

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -827,7 +827,7 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
   }
 
   it should "suggest similar tables or views if the table doesn't exist" in {
-    val ioe = the [IOException] thrownBy sc.cassandraTable(ks,"user_by_county").collect()
+    val ioe = the [IOException] thrownBy sc.cassandraTable(ks, "user_by_county").collect()
     val message = ioe.getMessage
     message should include (s"$ks.user_by_country")
   }
@@ -922,7 +922,7 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
 
   it should "throw an exception when trying to write to a Materialized View" in {
     intercept[IllegalArgumentException] {
-      sc.parallelize(Seq(("US",1,"John","DOE","jdoe"))).saveToCassandra(ks, "user_by_country")
+      sc.parallelize(Seq(("US", 1, "John", "DOE", "jdoe"))).saveToCassandra(ks, "user_by_country")
     }
   }
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -826,6 +826,12 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
     result should have length 0
   }
 
+  it should "suggest similar tables or views if the table doesn't exist" in {
+    val ioe = the [IOException] thrownBy sc.cassandraTable(ks,"user_by_county").collect()
+    val message = ioe.getMessage
+    message should include (s"$ks.user_by_country")
+  }
+
   it should "suggest similar tables if table doesn't exist but keyspace does" in {
     val ioe = the [IOException] thrownBy sc.cassandraTable("MixedSpace","mixedcase").collect()
     val message = ioe.getMessage

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
@@ -249,7 +249,10 @@ object Schema extends Logging {
           val partitionKey = fetchPartitionKey(table)
           val clusteringColumns = fetchClusteringColumns(table)
           val regularColumns = fetchRegularColumns(table)
-          val isView = table.isInstanceOf[MaterializedViewMetadata]
+          val isView = table match {
+            case x: MaterializedViewMetadata => true
+            case _ => false
+          }
           TableDef(
             keyspace.getName,
             table.getName,

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/NameTools.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/NameTools.scala
@@ -54,7 +54,7 @@ object NameTools {
       .map(ks =>
       (ks, StringUtils.getJaroWinklerDistance(ks.getName, keyspace)))
 
-    val ktScores = for ((ks, ksScore) <- keyspaceScores; t <- ks.getTables) yield {
+    val ktScores = for ((ks, ksScore) <- keyspaceScores; t <- (ks.getTables ++ ks.getMaterializedViews)) yield {
       val tScore = StringUtils.getJaroWinklerDistance(t.getName, table)
       (ks.getName, t.getName, ksScore, tScore)
     }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -26,6 +26,9 @@ class TableWriter[T] private (
     rowWriter: RowWriter[T],
     writeConf: WriteConf) extends Serializable with Logging {
 
+  require(tableDef.isView == false,
+    s"${tableDef.name} is a Materialized View and Views are not writable")
+
   val keyspaceName = tableDef.keyspaceName
   val tableName = tableDef.tableName
   val columnNames = rowWriter.columnNames diff writeConf.optionPlaceholders


### PR DESCRIPTION
A new member is added to TableDef isView:Boolean which allows us to
specify whether the shchema represented by the TableDef is a
MaterializedView. We could also refactor the TableDef into multiple
classes but I found this to take considerably more refactoring than just
adding the single element. This allows all 1.5 TableDef code to be
compatible and supports future View Development.

Added a small trap for those trying to write to a Materialized View to
avoid getting a Java Driver Exeception.