### PR TITLE
SPARKC-331: Include More Index Information in TableDef

### DIFF
--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/BasicCassandraPredicatePushDown.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/BasicCassandraPredicatePushDown.scala
@@ -33,7 +33,7 @@ class BasicCassandraPredicatePushDown[Predicate : PredicateOps](predicates: Set[
   private val clusteringColumns = table.clusteringColumns.map(_.columnName)
   private val regularColumns = table.regularColumns.map(_.columnName)
   private val allColumns = partitionKeyColumns ++ clusteringColumns ++ regularColumns
-  private val indexedColumns = table.columns.filter(_.isIndexedColumn).map(_.columnName)
+  private val indexedColumns = table.indexedColumns.map(_.columnName)
 
   private val singleColumnPredicates = predicates.filter(Predicates.isSingleColumnPredicate)
 

--- a/spark-cassandra-connector/src/test/scala/org/apache/spark/sql/cassandra/PredicatePushDownSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/org/apache/spark/sql/cassandra/PredicatePushDownSpec.scala
@@ -35,8 +35,8 @@ class PredicatePushDownSpec extends FlatSpec with Matchers {
   val c1 = ColumnDef("c1", ClusteringColumn(0), IntType)
   val c2 = ColumnDef("c2", ClusteringColumn(1), IntType)
   val c3 = ColumnDef("c3", ClusteringColumn(2), IntType)
-  val i1 = ColumnDef("i1", RegularColumn, IntType, indexClassName = Some("index"))
-  val i2 = ColumnDef("i2", RegularColumn, IntType, indexClassName = Some("index"))
+  val i1 = ColumnDef("i1", RegularColumn, IntType)
+  val i2 = ColumnDef("i2", RegularColumn, IntType)
   val r1 = ColumnDef("r1", RegularColumn, IntType)
   val r2 = ColumnDef("r2", RegularColumn, IntType)
 
@@ -45,7 +45,10 @@ class PredicatePushDownSpec extends FlatSpec with Matchers {
     tableName = "test",
     partitionKey = Seq(pk1, pk2),
     clusteringColumns = Seq(c1, c2, c3),
-    regularColumns = Seq(i1, i2, r1, r2)
+    regularColumns = Seq(i1, i2, r1, r2),
+    indexes = Seq(
+      IndexDef("DummyIndex", "i1", "IndexOne", Map.empty),
+      IndexDef("DummyIndex", "i2", "IndexTwo", Map.empty))
   )
 
   "BasicCassandraPredicatePushDown" should "push down all equality predicates restricting partition key columns" in {

--- a/spark-cassandra-connector/src/test/scala/org/apache/spark/sql/cassandra/PredicatePushDownSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/org/apache/spark/sql/cassandra/PredicatePushDownSpec.scala
@@ -35,8 +35,8 @@ class PredicatePushDownSpec extends FlatSpec with Matchers {
   val c1 = ColumnDef("c1", ClusteringColumn(0), IntType)
   val c2 = ColumnDef("c2", ClusteringColumn(1), IntType)
   val c3 = ColumnDef("c3", ClusteringColumn(2), IntType)
-  val i1 = ColumnDef("i1", RegularColumn, IntType, indexed = true)
-  val i2 = ColumnDef("i2", RegularColumn, IntType, indexed = true)
+  val i1 = ColumnDef("i1", RegularColumn, IntType, indexClassName = Some("index"))
+  val i2 = ColumnDef("i2", RegularColumn, IntType, indexClassName = Some("index"))
   val r1 = ColumnDef("r1", RegularColumn, IntType)
   val r2 = ColumnDef("r2", RegularColumn, IntType)
 


### PR DESCRIPTION
In this patch we add the IndexClassName to the TableDef inorder to use
this information in pushdowns. All though the current C* driver does not
expose indexOptions information at this time it will be needed for
dealing with SASI indexes in the future.