### PR TITLE
Rename variable throughputMiBPS as throughputMBPS

### DIFF
--- a/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/RDDAndDStreamCommonJavaFunctions.java
+++ b/spark-cassandra-connector-java/src/main/java/com/datastax/spark/connector/japi/RDDAndDStreamCommonJavaFunctions.java
@@ -177,7 +177,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                     new WriteConf(batchSize, writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                         writeConf.consistencyLevel(), writeConf.ignoreNulls(), writeConf.parallelismLevel(),
-                        writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
+                        writeConf.throughputMBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
             else
                 return this;
         }
@@ -195,7 +195,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), batchGroupingBufferSize, writeConf.batchGroupingKey(),
                         writeConf.consistencyLevel(), writeConf.ignoreNulls(), writeConf.parallelismLevel(),
-                        writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
+                        writeConf.throughputMBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
             else
                 return this;
         }
@@ -213,7 +213,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), batchGroupingKey,
                         writeConf.consistencyLevel(), writeConf.ignoreNulls(), writeConf.parallelismLevel(),
-                        writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
+                        writeConf.throughputMBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
             else
                 return this;
         }
@@ -230,7 +230,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
             if (writeConf.consistencyLevel() != consistencyLevel)
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
-                        consistencyLevel, writeConf.ignoreNulls(), writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
+                        consistencyLevel, writeConf.ignoreNulls(), writeConf.parallelismLevel(), writeConf.throughputMBPS(),
                         writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
             else
                 return this;
@@ -248,7 +248,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
             if (writeConf.parallelismLevel() != parallelismLevel)
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
-                        writeConf.consistencyLevel(), writeConf.ignoreNulls(), parallelismLevel, writeConf.throughputMiBPS(),
+                        writeConf.consistencyLevel(), writeConf.ignoreNulls(), parallelismLevel, writeConf.throughputMBPS(),
                         writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
             else
                 return this;
@@ -263,7 +263,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
          * @return this instance or copy to allow method invocation chaining
          */
         public WriterBuilder withThroughputMBPS(int throughputMBPS) {
-            if (writeConf.throughputMiBPS() != throughputMBPS)
+            if (writeConf.throughputMBPS() != throughputMBPS)
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                         writeConf.consistencyLevel(), writeConf.ignoreNulls(), writeConf.parallelismLevel(), throughputMBPS,
@@ -284,7 +284,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
             if (writeConf.taskMetricsEnabled() != taskMetricsEnabled)
                 return withWriteConf(
                         new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
-                                writeConf.consistencyLevel(), writeConf.ignoreNulls(), writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
+                                writeConf.consistencyLevel(), writeConf.ignoreNulls(), writeConf.parallelismLevel(), writeConf.throughputMBPS(),
                                 writeConf.ttl(), writeConf.timestamp(), taskMetricsEnabled));
             else
                 return this;
@@ -301,7 +301,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
             if (writeConf.ignoreNulls() != ignoreNulls)
                 return withWriteConf(
                         new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
-                                writeConf.consistencyLevel(), ignoreNulls, writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
+                                writeConf.consistencyLevel(), ignoreNulls, writeConf.parallelismLevel(), writeConf.throughputMBPS(),
                                 writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
             else
                 return this;
@@ -317,7 +317,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                     writeConf.consistencyLevel(),
                     writeConf.ignoreNulls(),
                     writeConf.parallelismLevel(),
-                    writeConf.throughputMiBPS(),
+                    writeConf.throughputMBPS(),
                     writeConf.ttl(),
                     timestamp,
                     writeConf.taskMetricsEnabled()));
@@ -397,7 +397,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                     writeConf.consistencyLevel(),
                     writeConf.ignoreNulls(),
                     writeConf.parallelismLevel(),
-                    writeConf.throughputMiBPS(),
+                    writeConf.throughputMBPS(),
                     ttl,
                     writeConf.timestamp(),
                     writeConf.taskMetricsEnabled()));

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -158,7 +158,7 @@ class TableWriter[T] private (
       val batchKeyGenerator = batchRoutingKey(session, routingKeyGenerator) _
       val batchBuilder = new GroupingBatchBuilder(boundStmtBuilder, batchStmtBuilder, batchKeyGenerator,
         writeConf.batchSize, writeConf.batchGroupingBufferSize, rowIterator)
-      val rateLimiter = new RateLimiter((writeConf.throughputMiBPS * 1024 * 1024).toLong, 1024 * 1024)
+      val rateLimiter = new RateLimiter((writeConf.throughputMBPS * 1024 * 1024).toLong, 1024 * 1024)
 
       logDebug(s"Writing data partition to $keyspaceName.$tableName in batches of ${writeConf.batchSize}.")
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
@@ -28,7 +28,7 @@ case class WriteConf(batchSize: BatchSize = BatchSize.Automatic,
                      consistencyLevel: ConsistencyLevel = WriteConf.ConsistencyLevelParam.default,
                      ignoreNulls: Boolean = WriteConf.IgnoreNullsParam.default,
                      parallelismLevel: Int = WriteConf.ParallelismLevelParam.default,
-                     throughputMiBPS: Double = WriteConf.ThroughputMiBPSParam.default,
+                     throughputMBPS: Double = WriteConf.ThroughputMBPSParam.default,
                      ttl: TTLOption = TTLOption.defaultValue,
                      timestamp: TimestampOption = TimestampOption.defaultValue,
                      taskMetricsEnabled: Boolean = WriteConf.TaskMetricsParam.default) {
@@ -47,7 +47,7 @@ case class WriteConf(batchSize: BatchSize = BatchSize.Automatic,
     Seq(toRegularColDef(ttl, DataType.cint()), toRegularColDef(timestamp, DataType.bigint())).flatten
   }
 
-  val throttlingEnabled = throughputMiBPS < WriteConf.ThroughputMiBPSParam.default
+  val throttlingEnabled = throughputMBPS < WriteConf.ThroughputMBPSParam.default
 }
 
 
@@ -114,7 +114,7 @@ object WriteConf {
     description = """Maximum number of batches executed in parallel by a
       | single Spark task""".stripMargin)
   
-  val ThroughputMiBPSParam = ConfigParameter[Double] (
+  val ThroughputMBPSParam = ConfigParameter[Double] (
     name = "spark.cassandra.output.throughput_mb_per_sec",
     section = ReferenceSection,
     default = Int.MaxValue,
@@ -139,7 +139,7 @@ object WriteConf {
     BatchLevelParam,
     IgnoreNullsParam,
     ParallelismLevelParam,
-    ThroughputMiBPSParam,
+    ThroughputMBPSParam,
     TaskMetricsParam
   )
 
@@ -175,7 +175,7 @@ object WriteConf {
 
     val parallelismLevel = conf.getInt(ParallelismLevelParam.name, ParallelismLevelParam.default)
 
-    val throughputMiBPS = conf.getDouble(ThroughputMiBPSParam.name, ThroughputMiBPSParam.default)
+    val throughputMBPS = conf.getDouble(ThroughputMBPSParam.name, ThroughputMBPSParam.default)
 
     val metricsEnabled = conf.getBoolean(TaskMetricsParam.name, TaskMetricsParam.default)
 
@@ -185,7 +185,7 @@ object WriteConf {
       batchGroupingKey = batchGroupingKey,
       consistencyLevel = consistencyLevel,
       parallelismLevel = parallelismLevel,
-      throughputMiBPS = throughputMiBPS,
+      throughputMBPS = throughputMBPS,
       taskMetricsEnabled = metricsEnabled,
       ignoreNulls = ignoreNulls)
   }

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/RateLimiterSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/RateLimiterSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class RateLimiterSpec extends FlatSpec with Matchers with MockFactory with Eventually{
 
- val TestRates = Seq(1L, 2L, 4L, 6L, 8L, 16L, 32L, WriteConf.ThroughputMiBPSParam.default.toLong)
+ val TestRates = Seq(1L, 2L, 4L, 6L, 8L, 16L, 32L, WriteConf.ThroughputMBPSParam.default.toLong)
 
   "RateLimiter" should "not cause delays if rate is not exceeded" in {
     var now: Long = 0

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/WriteConfTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/WriteConfTest.scala
@@ -20,7 +20,7 @@ class WriteConfTest extends FlatSpec with Matchers {
     val conf = new SparkConf(false)
       .set("spark.cassandra.output.throughput_mb_per_sec", "0.5")
     val writeConf = WriteConf.fromSparkConf(conf)
-      writeConf.throughputMiBPS should equal ( 0.5 +- 0.02 )
+      writeConf.throughputMBPS should equal ( 0.5 +- 0.02 )
   }
 
   it should "allow to set consistency level" in {


### PR DESCRIPTION
This will make it clear that we are dealing with Mega Bytes per second.