### PR TITLE
SPARKC-338-b1.4: Change DF ErrorIfExists Message

### DIFF
--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
@@ -113,8 +113,8 @@ class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase with Logging 
     }.getMessage
 
     assert(
-      message.contains("Writing to a non-empty Cassandra Table is not allowed."),
-      "We should complain that 'Writing to a non-empty Cassandra table is not allowed.'")
+      message.contains("SaveMode is set to ErrorIfExists and Table"),
+      "We should complain if attempting to write to a table with data if save mode is ErrorIfExists.'")
   }
 
   it should "allow to overwrite a cassandra table" in {

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/DefaultSource.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/DefaultSource.scala
@@ -90,7 +90,11 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
         if (table.buildScan().isEmpty()) {
           table.insert(data, overwrite = false)
         } else {
-          throw new UnsupportedOperationException("'Writing to a non-empty Cassandra Table is not allowed.'")
+          throw new UnsupportedOperationException(
+            s"""'SaveMode is set to ErrorIfExists and Table
+               |${tableRef.keyspace + "." + tableRef.table} already exists and contains data.
+               |Perhaps you meant to set the DataFrame write mode to Append?
+               |Example: df.write.format.options.mode(SaveMode.Append).save()" '""".stripMargin)
         }
       case Ignore =>
         if (table.buildScan().isEmpty()) {


### PR DESCRIPTION
The current message makes it seem as if there is no way to insert to a
C* table if there is data within it. This patch changes the message so
it is clear that the error is because of the save mode and suggests a
workaround if Append behavior was expected.