### PR TITLE
[SPARKC-346] - Nested Optional Case Class can be save as UDT

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+ * Nested Optional Case Class can be save as UDT (SPARKC-346)
  * Merged Java API into main module (SPARKC-335)
  * Upgraded to Spark 1.6.1 (SPARKC-344)
  * Removed the ability to specify cluster alias directly and added some helper methods which make it easier to configure


### PR DESCRIPTION
Allow to save nested optional case class in udt.

Some(caseClass) is save like a caseClass.
None is save like null.

Is a quick fix I thinks it's can be donne in a better way.

ps : Is may be a good idea to replace run time reflection by compile time macro.