### PR TITLE
[SPARKC-342] support Joda time for LocalDate type

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
@@ -450,6 +450,7 @@ object TypeConverter {
       case x: Int => LocalDate.fromDaysSinceEpoch(x)
       case x: java.sql.Date => LocalDate.fromMillisSinceEpoch(addTimeZoneOffset(x.getTime))
       case x: Date => LocalDate.fromMillisSinceEpoch(x.getTime)
+      case x: DateTime => LocalDate.fromMillisSinceEpoch(x.getMillis)
     }
   }
 

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/TypeConverterTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/TypeConverterTest.scala
@@ -223,6 +223,7 @@ class TypeConverterTest {
     assertEquals(testDate, c.convert(5693))
     assertEquals(testDate, c.convert(date))
     assertEquals(testDate, c.convert(java.sql.Date.valueOf("1985-08-03")))
+    assertEquals(testDate, c.convert(new DateTime(date)))
   }
 
   @Test


### PR DESCRIPTION
Adds type conversion support for `org.joda.time.DateTime` to `com.datastax.driver.core.LocalDate`. Solves  [SPARKC-342](https://datastax-oss.atlassian.net/browse/SPARKC-342)

@RussellSpitzer  @pkolaczk for review