### PR TITLE
SPARKC-347 drop indices that can not be used in predicate push down

### DIFF
--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/SchemaSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/SchemaSpec.scala
@@ -45,6 +45,10 @@ class SchemaSpec extends SparkCassandraITWordSpecBase {
         |  PRIMARY KEY ((k1, k2, k3), c1, c2, c3)
         |)
       """.stripMargin)
+    session.execute(
+      s"""CREATE INDEX test_d9_map_idx ON $ks.test (keys(d9_map))""")
+    session.execute(
+      s"""CREATE INDEX test_d7_int_idx ON $ks.test (d7_int)""")
   }
 
   val schema = Schema.fromCassandra(conn)
@@ -128,6 +132,15 @@ class SchemaSpec extends SparkCassandraITWordSpecBase {
       val udt = table.columnByName("d16_address").columnType.asInstanceOf[UserDefinedType]
       udt.columnNames shouldBe Seq("street", "city", "zip")
       udt.columnTypes shouldBe Seq(VarCharType, VarCharType, IntType)
+    }
+
+    "should not recognize column with collection index as indexed" in {
+      table.indexedColumns.size shouldBe 1
+      table.indexedColumns.head.columnName shouldBe "d7_int"
+    }
+
+    "should hold all indices retrieved from cassandra" in {
+      table.indexes.size shouldBe 2
     }
   }
 


### PR DESCRIPTION
We store indices definitions in TableDef in order to use them in

predicate push down. As discussed, currently we do not support predicate
push down for custom and collection indices.

This commit drops these kinds of indices for TableDef#isIndexed and
TableDef#indexedColumns methods. Meaning if an index is not targeted at
single column it never participates in an evaluation of a result for
these two methods.

Nevertheless please note that all indices are present in TableDef.
Unused indices eventually are going to be used in predicate pushdown as
well.

To hide this planned changes from users, some of the TableDef properties
are now private.