### PR TITLE
 SPARKC-348 accept predicates with indexed partition columns

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
@@ -160,6 +160,10 @@ case class TableDef(
     }
   }
 
+  def isIndexed(column: String): Boolean = {
+    indexesForTarget.contains(column)
+  }
+
   def isIndexed(column: ColumnDef): Boolean = {
     indexesForColumnDef.contains(column)
   }


### PR DESCRIPTION
Preconditions with indexed columns that belong to partition key but do
not form the whole partition key generate failures.
This kind of queries should be executed as a query with index column
specified, not discarded as a query with incomplete partition key.

This changes CassandraRDDPartitioner#containsPartitionKey so that it
does not throw exception whenever the partition key is incomplete and
all precodition colums are indexed. Other cases for
CassandraRDDPartitioner#containsPartitionKey are not changed.