### PR TITLE
SPARKC-330: Implement org.apache.spark.Partitioner

### DIFF
--- a/doc/15_python.md
+++ b/doc/15_python.md
@@ -57,3 +57,5 @@ A DataFrame can be saved to an *existing* Cassandra table by using the the `org.
 
 The options and parameters are identical to the Scala Data Frames Api so
 please see [Data Frames](14_data_frames.md) for more information.
+
+[Next - Spark Partitioners](16_partitioning.md)

--- a/doc/16_partitioning.md
+++ b/doc/16_partitioning.md
@@ -1,0 +1,328 @@
+# Documentation
+
+## Spark Cassandra Connector and Spark Partitioners
+
+### What are Spark Partitioners
+
+Spark RDDs may have an element known as a [Partitioner](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/Partitioner.scala);
+these special classes are used during shuffles and co-grouping events (joins, groupBy) to map data 
+to the correct Spark Partition. When one isn't specified Spark will usually repartition using 
+a `HashPartitioner`. A repartition requires taking every value and moving it to the partition 
+specified by the given partitioner. This is the reason that many keyed operations are such expensive 
+operations.
+
+### What is a Cassandra Partitioner
+
+Cassandra also has a notion of a partitioner. The Cassandra partitioner takes the partition key of
+a CQL Row and uses it to determine what node in the Cassandra cluster should host that data. The 
+partitioner generates a `Token` which directly maps to the `TokenRange` of the CassandraCluster.
+Each node in the Cassandra Cluster is responsible for a specific section of the full `TokenRange`.
+
+For more information on Cassandra Data Modeling check out the resources on 
+[DataStax Academy](https://academy.datastax.com/courses/ds220-data-modeling).
+
+### How to take advantage of Cassandra Partitioning in Spark
+
+The Spark Cassandra Connector now implements a `CassandraPartitioner` for specific RDDs when they
+have been keyed using `keyBy`. This can only be done when a `CassandraTableScanRDD` has `keyBy` 
+called and is keyed by the partition keys of the underlying table. The key may contain other
+elements of the table but the partition key is required to build a `CassandraPartitioner`
+
+*All of these examples are run with Spark in Local Mode and --driver-memory 4g*
+
+#### Example Schema
+
+
+```sql
+CREATE KEYSPACE doc_example WITH replication = 
+    {'class': 'SimpleStrategy', 'replication_factor': '1'}  AND durable_writes = true;
+
+CREATE TABLE doc_example.purchases (
+    userid int,
+    purchaseid int,
+    objectid text,
+    amount int,
+    PRIMARY KEY (userid, purchaseid, objectid) //Partition Key "userid"
+);
+
+CREATE TABLE doc_example.users (
+    userid int PRIMARY KEY, // Partition key "userid"
+    name text,
+    zipcode int
+);
+```
+
+For a data generation sample, jump see [here](#data-generator).
+
+#### Keying a Table with the Partition Key Produces an RDD with a Partitioner
+
+```scala
+import com.datastax.spark.connector._
+
+val ks = "doc_example"
+val rdd = { sc.cassandraTable[(String, Int)](ks, "users")
+  .select("name" as "_1", "zipcode" as "_2", "userid")
+  .keyBy[Tuple1[Int]]("userid")
+}
+
+//16/04/08 11:19:52 DEBUG CassandraPartitioner: Building Partitioner with mapping
+//Vector((userid,userid))
+//for table TableDef(doc_example,users,ArrayBuffer(ColumnDef(userid,PartitionKeyColumn,IntType)),ArrayBuffer(),ArrayBuffer(ColumnDef(name,RegularColumn,VarCharType), ColumnDef(zipcode,RegularColumn,IntType)),List(),false)
+//16/04/08 11:19:52 DEBUG CassandraTableScanRDD: Made partitioner Some(com.datastax.spark.connector.rdd.partitioner.CassandraPartitioner@6709eccf) for CassandraTableScanRDD[5] at RDD at CassandraRDD.scala:15
+//16/04/08 11:19:52 DEBUG CassandraTableScanRDD: Assigning new Partitioner com.datastax.spark.connector.rdd.partitioner.CassandraPartitioner@6709eccf
+
+rdd.partitioner
+//res3: Option[org.apache.spark.Partitioner] = Some(com.datastax.spark.connector.rdd.partitioner.CassandraPartitioner@94515d3e)
+```
+
+#### Reading a table into a (K,V) type or Not Including the Partition Key will not Create a Partitioner
+
+```scala
+import com.datastax.spark.connector._
+
+val ks = "doc_example"
+val rdd1 = sc.cassandraTable[(Int,Int)](ks, "users")
+rdd1.partitioner
+//res8: Option[org.apache.spark.Partitioner] = None
+
+
+val rdd2 = { sc.cassandraTable[(Int, String)](ks, "users")
+  .select("name" as "_2", "zipcode" as "_1", "userid")
+  .keyBy[Tuple1[Int]]("zipcode")
+}
+rdd2.partitioner
+//res11: Option[org.apache.spark.Partitioner] = None
+```
+
+### Capabilities and limitations of CassandraPartitioner
+
+Having a partitioner allow for groupByKey operations to no longer require a shuffle. Previously
+`spanByKey` allowed Spark to take advantage of the natural ordering of C* tables. The new partitioner
+allows this to go a step further and group on any combination of the primary key which also contains
+the partition key.
+
+#### Grouping/Reducing on out of order Clustering keys
+
+```scala
+import com.datastax.spark.connector._
+val ks = "doc_example"
+val rdd = { sc.cassandraTable[(Int, Int)](ks, "purchases")
+  .select("purchaseid" as "_1", "amount" as "_2", "userid", "objectid")
+  .keyBy[(Int, String)]("userid","objectid")
+}
+
+rdd.groupByKey.toDebugString
+//res28: String =
+//(4) MapPartitionsRDD[50] at groupByKey at <console>:43 []
+// |  CassandraTableScanRDD[41] at RDD at CassandraRDD.scala:15 []
+//
+// Note that there are no shuffles present in this tree
+rdd.groupByKey.count
+// 16/04/08 16:23:42 INFO DAGScheduler: Job 0 finished: count at <console>:35, took 34.171709 s
+```
+
+Doing the same thing without a partitioner requires a shuffle:
+
+```scala
+val ks = "doc_example"
+
+//Empty map will remove the partitioner
+val rdd = { sc.cassandraTable[(Int, Int)](ks, "purchases")
+  .select("purchaseid" as "_1", "amount" as "_2", "userid", "objectid")
+  .keyBy[(Int, String)]("userid","objectid")
+}.map( x => x)
+
+rdd.partitioner
+//res2: Option[org.apache.spark.Partitioner] = None
+
+rdd.groupByKey.toDebugString
+//res3: String =
+//(4) ShuffledRDD[11] at groupByKey at <console>:35 []
+// +-(4) MapPartitionsRDD[10] at map at <console>:35 []
+//    |  CassandraTableScanRDD[9] at RDD at CassandraRDD.scala:15 []
+
+rdd.groupByKey.count
+//16/04/08 16:28:23 INFO DAGScheduler: Job 1 finished: count at <console>:35, took 46.550789 s
+```
+
+In this example the partitioner example takes 70% of the time of the partitioned one.  This is even
+with the entire load taking place on a single machine without any network traffic. When 
+shuffles have to spill to disk the difference in times can become even greater. With very
+large examples we've seen the cost of the shuffle even double the total compute time. 
+
+*Limitations*
+
+This can only be applied to RDDs that are keyed with their partition key, so it can not be used
+to group or reduce on a generic Cassandra column. As long as you are grouping/reducing within a C*
+partition this approach should save significant time.
+
+
+#### Joining to Cassandra RDDs from non Cassandra RDDs
+
+When joining two RDDs they are both required to be partitioned before the join can occur. Previously
+this meant that when joining against a Cassandra both the Cassandra RDD and the RDD to be joined
+would need to be shuffled. Now if the Cassandra RDD is keyed on the partition key you can join 
+without the Cassandra RDD being shuffled.
+
+```scala
+import com.datastax.spark.connector._
+
+val ks = "doc_example"
+val rdd = { sc.cassandraTable[(String, Int)](ks, "users")
+  .select("name" as "_1", "zipcode" as "_2", "userid")
+  .keyBy[Tuple1[Int]]("userid")
+}
+
+val joinrdd = sc.parallelize(1 to 10000).map(x => (Tuple1(x),x) ).join(rdd)
+joinrdd.toDebugString
+//(1) MapPartitionsRDD[26] at join at <console>:35 []
+// |  MapPartitionsRDD[25] at join at <console>:35 []
+// |  CoGroupedRDD[24] at join at <console>:35 []
+// +-(8) MapPartitionsRDD[23] at map at <console>:35 []
+// |  |  ParallelCollectionRDD[22] at parallelize at <console>:35 []
+// |  CassandraTableScanRDD[16] at RDD at CassandraRDD.scala:15 []
+joinrdd.count
+//16/04/08 17:25:47 INFO DAGScheduler: Job 14 finished: count at <console>:37, took 5.339490 s
+
+//Use an empty map to drop the partitioner
+val rddnopart = { sc.cassandraTable[(String, Int)](ks, "users")
+                  .select("name" as "_1", "zipcode" as "_2", "userid")
+                  .keyBy[Tuple1[Int]]("userid").map( x => x)
+}
+
+val joinnopart = sc.parallelize(1 to 10000).map(x => (Tuple1(x),x) ).join(rddnopart)
+joinnopart.toDebugString
+//res18: String =
+//(8) MapPartitionsRDD[73] at join at <console>:36 []
+// |  MapPartitionsRDD[72] at join at <console>:36 []
+// |  CoGroupedRDD[71] at join at <console>:36 []
+// +-(8) MapPartitionsRDD[70] at map at <console>:36 []
+// |  |  ParallelCollectionRDD[69] at parallelize at <console>:36 []
+// +-(1) MapPartitionsRDD[68] at map at <console>:34 []
+//    |  CassandraTableScanRDD[61] at RDD at CassandraRDD.scala:15 []
+
+joinnopart.count
+//16/04/08 17:30:04 INFO DAGScheduler: Job 19 finished: count at <console>:37, took 6.308165 s
+```
+
+So again we can save the time of a shuffle if we are joining on a partition key of a C* table. The
+advantages here scale as well, the larger the data to be joined the greater the advantage to be 
+gained.
+
+*Limitations*
+
+Again it is important to note that this is only possible when using the Partition key as the key
+of the RDD.
+
+#### Joining to Cassandra RDDs on Common Partition Keys
+
+One area that can benefit greatly from the Partitioner is joins between Cassandra tables on a 
+common partition key. This previously would requiring both RDDs but now requires no shuffles at
+all. To use this both RDDs must have the *same partitioner*. A helper method `applyPartitionerFrom`
+has been added to make it easy to share a partitioner between Cassandra RDDs.
+
+```scala
+val ks = "doc_example"
+val rdd1 = { sc.cassandraTable[(Int, Int, String)](ks, "purchases")
+  .select("purchaseid" as "_1", "amount" as "_2", "objectid" as "_3", "userid")
+  .keyBy[Tuple1[Int]]("userid")
+}
+
+val rdd2 = { sc.cassandraTable[(String, Int)](ks, "users")
+  .select("name" as "_1", "zipcode" as "_2", "userid")
+  .keyBy[Tuple1[Int]]("userid")
+}.applyPartitionerFrom(rdd1) // Assigns the partitioner from the first rdd to this one
+
+val joinRDD = rdd1.join(rdd2)
+joinRDD.toDebugString
+//res37: String =
+//(1) MapPartitionsRDD[123] at join at <console>:36 []
+// |  MapPartitionsRDD[122] at join at <console>:36 []
+// |  CoGroupedRDD[121] at join at <console>:36 []
+// |  CassandraTableScanRDD[115] at RDD at CassandraRDD.scala:15 []
+// |  CassandraTableScanRDD[120] at RDD at CassandraRDD.scala:15 []
+
+joinRDD.count
+//16/04/08 17:53:45 INFO DAGScheduler: Job 24 finished: count at <console>:39, took 27.583355 s
+
+//Unpartitioned join
+val rdd1nopart = { sc.cassandraTable[(Int, Int, String)](ks, "purchases")
+  .select("purchaseid" as "_1", "amount" as "_2", "objectid" as "_3", "userid")
+  .keyBy[Tuple1[Int]]("userid")
+}.map(x => x)
+
+val rdd2nopart = { sc.cassandraTable[(String, Int)](ks, "users")
+  .select("name" as "_1", "zipcode" as "_2", "userid")
+  .keyBy[Tuple1[Int]]("userid")
+}.map(x => x)
+
+val joinnopart = rdd1nopart.join(rdd2nopart)
+joinnopart.toDebugString
+//   res41: String =
+//   (4) MapPartitionsRDD[136] at join at <console>:36 []
+//    |  MapPartitionsRDD[135] at join at <console>:36 []
+//    |  CoGroupedRDD[134] at join at <console>:36 []
+//    +-(1) MapPartitionsRDD[128] at map at <console>:35 []
+//    |  |  CassandraTableScanRDD[127] at RDD at CassandraRDD.scala:15 []
+//    +-(4) MapPartitionsRDD[133] at map at <console>:35 []
+//       |  CassandraTableScanRDD[132] at RDD at CassandraRDD.scala:15 []
+
+joinnopart.count
+//16/04/08 17:54:58 INFO DAGScheduler: Job 25 finished: count at <console>:39, took 40.040341 s
+```
+
+Again we can save a significant portion of time by eliminating the need for a shuffle.
+
+
+### Caveats
+The partitioning mechanism is very sensitive to the underlying C* tables partitioning so this is
+not a generic solution to all joins and groupBys. In addition it is important to note 
+
+`applyPartitionerFrom` will copy the partitioning exactly from the host RDD to the target. 
+This means it will only work if the key portion of both RDDs are the same. When applied, the host
+partitioning takes over. This means it often makes sense to apply the partitioner from the RDD with
+more partitions to get proper parallelism.
+
+To key and apply a partitioner at the same time you can use `keyAndApplyPartitionerFrom`. These 
+APIs are documented in `CassandraTableScanRDDFunctions` and are provided as implicits on 
+`CassandraTableScanRDD`s.
+
+Due to the way RDDs are constructed, the CassandraPartitioner cannot be applied without 
+an explicit `KeyBy` call.
+
+The class of the Key must be a true class and not a primitive. The Partitioner uses the a `RowWriter`
+like the `saveToCassandra` method to convert key data to a C* token. This `RowWriter` cannot be 
+built for primitives which is why the above examples use `Tuple1` so frequently.
+
+This functionality does not currently function in DataFrames.
+
+
+###Data Generator
+```scala
+
+import com.datastax.spark.connector._
+import java.util.Random
+val ks = "doc_example"
+val r = new Random(100)
+val zipcodes = (1 to 100).map(_ => r.nextInt(99999)).distinct
+val objects = Seq("pepper", "lemon", "pear", "squid", "beet", "iron", "grass", "axe", "grape")
+
+case class RandomListSelector[T](list: Seq[T]) {
+    val r = { new Random() }
+    def next(): T = list(r.nextInt(list.length))
+}
+
+val randomObject = RandomListSelector(objects)
+val randomZipCode = RandomListSelector(zipcodes)
+
+//About 25 Seconds on my MBP 
+sc.parallelize(1 to 1000000).map(x => 
+    (x, s"User $x", randomZipCode.next)
+  ).saveToCassandra(ks, "users")
+ 
+//About 60 Seconds on my MBP
+sc.parallelize(1 to 1000000).flatMap(x => 
+    (1 to 10).map( p => (x, p, randomObject.next, p))
+  ).saveToCassandra(ks, "purchases")
+
+```

--- a/project/SparkCassandraConnectorBuild.scala
+++ b/project/SparkCassandraConnectorBuild.scala
@@ -98,7 +98,7 @@ object CassandraSparkBuild extends Build {
     id = s"$namespace-doc",
     base = file(s"$namespace-doc"),
     settings = defaultSettings ++ Seq(libraryDependencies ++= Dependencies.spark)
-  ) dependsOn(connector)
+  ) dependsOn connector
 
   def crossBuildPath(base: sbt.File, v: String): sbt.File = base / s"scala-$v" / "src"
 
@@ -206,6 +206,7 @@ object Artifacts {
   object Test {
     val akkaTestKit       = "com.typesafe.akka"       %% "akka-testkit"                 % Akka      % "test,it"       // ApacheV2
     val commonsIO         = "commons-io"              % "commons-io"                    % CommonsIO % "test,it"       // ApacheV2
+    val scalaCheck        = "org.scalacheck"          %% "scalacheck"                   % ScalaCheck % "test,it"      // BSD
     val scalaMock         = "org.scalamock"           %% "scalamock-scalatest-support"  % ScalaMock % "test,it"       // BSD
     val scalaTest         = "org.scalatest"           %% "scalatest"                    % ScalaTest % "test,it"       // ApacheV2
     val scalactic         = "org.scalactic"           %% "scalactic"                    % Scalactic % "test,it"       // ApacheV2
@@ -237,6 +238,7 @@ object Dependencies {
     Test.commonsIO,
     Test.junit,
     Test.junitInterface,
+    Test.scalaCheck,
     Test.scalaMock,
     Test.scalaTest,
     Test.scalactic,

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -43,9 +43,10 @@ object Versions {
   val Kafka210        = "0.8.1.1"
   val Lzf             = "0.8.4"
   val CodaHaleMetrics = "3.0.2"
+  val ScalaCheck      = "1.12.5"
   val ScalaMock       = "3.2"
-  val ScalaTest       = "2.2.2"
-  val Scalactic       = "2.2.2"
+  val ScalaTest       = "2.2.6"
+  val Scalactic       = "2.2.6"
   val Slf4j           = "1.6.1"//1.7.7"
 
   // Spark version can be specified as:

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaRDDSpec.scala
@@ -264,7 +264,10 @@ class CassandraJavaRDDSpec extends SparkCassandraITFlatSpecBase {
     val rows = javaFunctions(sc)
       .cassandraTable(ks, "test_table", mapColumnTo(classOf[java.lang.String]))
       .select("value", "key")
-      .keyBy(mapColumnTo(classOf[java.lang.Integer]), classOf[Integer], "key")
+      .keyBy(
+        mapColumnTo(classOf[java.lang.Integer]),
+        mapToRow(classOf[java.lang.Integer]),
+        classOf[Integer], "key")
       .collect()
 
     rows should have size 3
@@ -276,7 +279,11 @@ class CassandraJavaRDDSpec extends SparkCassandraITFlatSpecBase {
   it should "allow to transform rows into KV pairs of a single-column type and a multi-column type" in {
     val rows = javaFunctions(sc)
       .cassandraTable(ks, "test_table", mapRowTo(classOf[SampleJavaBean]))
-      .keyBy(mapColumnTo(classOf[java.lang.Integer]), classOf[Integer], "key")
+      .keyBy(
+        mapColumnTo(classOf[java.lang.Integer]),
+        mapToRow(classOf[java.lang.Integer]),
+        classOf[Integer],
+        "key")
       .collect().map { case (i, x) ⇒ (i, (x.getKey, x.getValue))}
 
     rows should have size 3
@@ -289,7 +296,10 @@ class CassandraJavaRDDSpec extends SparkCassandraITFlatSpecBase {
     val rows = javaFunctions(sc)
       .cassandraTable(ks, "test_table", mapColumnTo(classOf[java.lang.Integer]))
       .select("key", "value")
-      .keyBy(mapRowTo(classOf[SampleJavaBean]), classOf[SampleJavaBean])
+      .keyBy(
+        mapRowTo(classOf[SampleJavaBean]),
+        mapToRow(classOf[SampleJavaBean]),
+        classOf[SampleJavaBean])
       .collect().map { case (x, i) ⇒ ((x.getKey, x.getValue), i)}
 
     rows should have size 3
@@ -301,7 +311,10 @@ class CassandraJavaRDDSpec extends SparkCassandraITFlatSpecBase {
   it should "allow to transform rows into KV pairs of multi-column types" in {
     val rows = javaFunctions(sc)
       .cassandraTable(ks, "test_table", mapRowTo(classOf[SampleJavaBean]))
-      .keyBy(mapRowTo(classOf[SampleJavaBean]), classOf[SampleJavaBean])
+      .keyBy(
+        mapRowTo(classOf[SampleJavaBean]),
+        mapToRow(classOf[SampleJavaBean]),
+        classOf[SampleJavaBean])
       .collect().map { case (x, y) ⇒ ((x.getKey, x.getValue), (y.getKey, y.getValue))}
 
     rows should have size 3

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/PartitionedCassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/PartitionedCassandraRDDSpec.scala
@@ -1,0 +1,277 @@
+package com.datastax.spark.connector.rdd
+
+import java.lang.{Long => JLong}
+
+import scala.concurrent.Future
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.cql.CassandraConnector
+import java.lang.{Integer => JInt}
+
+import scala.collection.JavaConversions._
+import org.apache.spark.rdd.RDD
+
+import scala.reflect.ClassTag
+
+case class PKey(key: Int)
+
+case class PKeyCKey(key: Int, ckey: Int)
+
+case class X(x: Int)
+
+case class WeirdMapping(weirdkey: Int, weirdcol: Int)
+
+class PartitionedCassandraRDDSpec extends SparkCassandraITFlatSpecBase {
+
+  useCassandraConfig(Seq("cassandra-default.yaml.template"))
+  useSparkConf(defaultConf.set("spark.cassandra.input.consistency.level", "ONE"))
+
+  val conn = CassandraConnector(defaultConf)
+  val rowCount = 100
+
+  conn.withSessionDo { session =>
+    createKeyspace(session)
+
+    awaitAll(
+      Future {
+        session.execute(
+          s"""CREATE TABLE $ks.table1 (key INT, ckey INT, value INT, PRIMARY KEY (key, ckey)
+              |)""".stripMargin)
+        val ps = session.prepare( s"""INSERT INTO $ks.table1 (key, ckey, value) VALUES (?, ?, ?)""")
+        val results = for (value <- 1 to rowCount) yield {
+          session.executeAsync(ps.bind(value: JInt, value: JInt, value: JInt))
+        }
+        results.map(_.get)
+      },
+      Future {
+        session.execute(
+          s"""CREATE TABLE $ks.a (x INT, a INT, b INT, PRIMARY KEY (x)
+              |)""".stripMargin)
+        val ps = session.prepare( s"""INSERT INTO $ks.a (x, a, b) VALUES (?, ?, ?)""")
+        val results = for (value <- 1 to rowCount) yield {
+          session.executeAsync(ps.bind(value: JInt, value: JInt, value: JInt))
+        }
+        results.map(_.get)
+      },
+      Future {
+        session.execute(
+          s"""CREATE TABLE $ks.b (y INT, c INT, d INT, PRIMARY KEY (y)
+              |)""".stripMargin)
+        val ps = session.prepare( s"""INSERT INTO $ks.b (y, c, d) VALUES (?, ?, ?)""")
+        val results = for (value <- 1 to rowCount) yield {
+          session.executeAsync(ps.bind(value: JInt, value: JInt, value: JInt))
+        }
+        results.map(_.get)
+      },
+      Future {
+        session.execute(
+          s"""CREATE TABLE $ks.table2 (key INT, ckey INT, value INT, PRIMARY KEY
+              |(key, ckey))""".stripMargin)
+        val ps = session.prepare( s"""INSERT INTO $ks.table2 (key, ckey, value) VALUES (?, ?, ?)""")
+        val results = for (value <- 1 to rowCount) yield {
+          session.executeAsync(ps.bind(value: JInt, value: JInt, (rowCount - value): JInt))
+        }
+        results.map(_.get)
+      }
+    )
+  }
+
+  // Make sure that all tests have enough partitions to make things interesting
+  val customReadConf = ReadConf(splitCount = Some(20))
+
+  val testRDD = sc.cassandraTable(ks, "table1").withReadConf(customReadConf)
+  val joinTarget = sc.cassandraTable(ks, "table2")
+
+  def getPartitionMap[T](rdd: RDD[T]): Map[T, Int] = {
+    rdd.mapPartitionsWithIndex { case (index, it) =>
+      it.map(row => (row, index))
+    }.collect.toMap
+  }
+
+  def checkPartitionerKeys[K: ClassTag, V: ClassTag](rdd: RDD[(K, V)]): Unit = {
+    rdd.partitioner shouldBe defined
+    val partitioner = rdd.partitioner.get
+    val realPartitionMap = getPartitionMap(rdd.keys)
+    for ((row, partId) <- realPartitionMap) {
+      partitioner.getPartition(row) should be(partId)
+    }
+  }
+
+  "A CassandraPartitioner" should " be creatable from a generic CassandraTableRDD" in {
+    val rdd = testRDD
+    val partitioner = rdd.partitionGenerator.partitioner[PKey](PartitionKeyColumns)
+    partitioner.get.numPartitions should be(rdd.partitions.length)
+  }
+
+  "keyBy" should "create a partitioned RDD without any parameters" in {
+    val keyedRDD = testRDD.keyBy[CassandraRow]
+    checkPartitionerKeys(keyedRDD)
+  }
+
+  it should "create a partitioned RDD selecting the Partition Key" in {
+    val keyedRDD = testRDD.keyBy[CassandraRow](PartitionKeyColumns)
+    checkPartitionerKeys(keyedRDD)
+  }
+
+  it should "create a partitioned RDD when the partition key is mapped to something else" in {
+    val keyedRDD = testRDD.keyBy[CassandraRow](SomeColumns("key" as "notkey"))
+    checkPartitionerKeys(keyedRDD)
+  }
+
+  it should "create a partitioned RDD with a case class" in {
+    val keyedRDD = testRDD.keyBy[PKey](SomeColumns("key"))
+    checkPartitionerKeys(keyedRDD)
+  }
+
+  it should "create a partitioned RDD with a case class with more than the Partition Key" in {
+    val keyedRDD = testRDD.keyBy[PKeyCKey]
+    checkPartitionerKeys(keyedRDD)
+  }
+
+  it should "NOT create a partitioned RDD that does not cover the Partition Key" in {
+    val keyedRDD = testRDD.keyBy[Tuple1[Int]](SomeColumns("ckey"))
+    keyedRDD.partitioner.isEmpty should be(true)
+  }
+
+  "CassandraTableScanRDD " should " not have a partitioner by default" in {
+    testRDD.partitioner should be(None)
+  }
+
+  it should " be able to be assigned a partitioner from RDD with the same key" in {
+    val keyedRDD = testRDD.keyBy[PKey](SomeColumns("key"))
+    val otherRDD = joinTarget.keyBy[PKey](SomeColumns("key")).applyPartitionerFrom(keyedRDD)
+    checkPartitionerKeys(otherRDD)
+  }
+
+  it should " be joinable against an RDD without a partitioner" in {
+    val keyedRDD = testRDD.keyBy[PKey](SomeColumns("key"))
+    val joinedRDD = keyedRDD.join(sc.parallelize(1 to rowCount).map(x => (PKey(x), -x)))
+    val results = joinedRDD.values.collect
+    results should have length (rowCount)
+    for (row <- results) {
+      row._1.getInt("key") should be(-row._2)
+    }
+  }
+
+  it should "not shuffle during a join with an RDD with the same partitioner" in {
+    val keyedRDD = testRDD.keyBy[PKey](SomeColumns("key"))
+    val otherRDD = joinTarget.keyBy[PKey](SomeColumns("key")).applyPartitionerFrom(keyedRDD)
+    val joinRDD = keyedRDD.join(otherRDD)
+    joinRDD.toDebugString should not contain ("+-")
+    // "+-" in the debug string means there is more than 1 stage and thus a shuffle
+  }
+
+  it should "correctly join against an RDD with the same partitioner" in {
+    val keyedRDD = testRDD.keyBy[PKey](SomeColumns("key"))
+    val otherRDD = joinTarget.keyBy[PKey](SomeColumns("key")).applyPartitionerFrom(keyedRDD)
+    val joinRDD = keyedRDD.join(otherRDD)
+    val results = joinRDD.values.collect()
+    results should have length (rowCount)
+    for (row <- results) {
+      row._1.getInt("key") should be(row._2.getInt("key"))
+    }
+  }
+
+  it should "join against an RDD with different partition key names without a shuffle " in {
+    val a = sc.cassandraTable[(Int, Int)](ks, "a")
+      .withReadConf(customReadConf)
+      .select("a" as "_1", "b" as "_2", "x")
+      .keyBy[Tuple1[Int]]("x")
+
+    val b = sc.cassandraTable[(Int, Int)](ks, "b")
+      .select("c" as "_1", "d" as "_2", "y")
+      .keyBy[Tuple1[Int]]("y")
+      .applyPartitionerFrom(a)
+
+    a.partitioner.get should be(b.partitioner.get)
+    val joinRDD = a.join(b)
+    val results = joinRDD.values.collect()
+    results should have length (rowCount)
+    joinRDD.toDebugString should not contain ("+-")
+    for (row <- results) {
+      row._1 should be(row._2)
+    }
+  }
+
+  it should "join against an RDD with different names and mappings without a shuffle" in {
+    val a = sc.cassandraTable[(Int, Int)](ks, "a")
+      .withReadConf(customReadConf)
+      .select("a" as "_1", "b" as "_2", "x")
+      .keyBy[X]("x")
+
+    val b_prime = sc.cassandraTable[(Int, Int)](ks, "b")
+      .select("c" as "_1", "d" as "_2", "y" as "x")
+      .keyBy[X]("y" as "x")
+
+    b_prime.partitioner shouldBe defined
+
+    val b = b_prime.applyPartitionerFrom(a)
+
+    a.partitioner.get should be(b.partitioner.get)
+    val joinRDD = a.join(b)
+    val results = joinRDD.values.collect()
+    results should have length (rowCount)
+    joinRDD.toDebugString should not contain ("+-")
+    for (row <- results) {
+      row._1 should be(row._2)
+    }
+  }
+
+  it should "join against an RDD with strange mapping without a shuffle" in {
+    val a = sc.cassandraTable[(Int, Int)](ks, "a")
+      .withReadConf(customReadConf)
+      .select("a" as "_1", "b" as "_2", "x" as "weirdkey")
+      .keyBy[WeirdMapping]("x" as "weirdkey", "b" as "weirdcol")
+
+    a.partitioner shouldBe defined
+
+    val b_prime = sc.cassandraTable[(Int, Int)](ks, "b")
+      .select("c" as "_1", "d" as "_2", "y" as "weirdkey")
+      .keyBy[WeirdMapping]("y" as "weirdkey", "d" as "weirdcol")
+
+    b_prime.partitioner shouldBe defined
+
+    val b = b_prime.applyPartitionerFrom(a)
+
+    a.partitioner.get should be(b.partitioner.get)
+    val joinRDD = a.join(b)
+    val results = joinRDD.values.collect()
+    results should have length (rowCount)
+    joinRDD.toDebugString should not contain ("+-")
+    for (row <- results) {
+      row._1 should be(row._2)
+    }
+  }
+
+  it should "not shuffle in a keyed self-join" in {
+    val keyedRDD = testRDD.keyBy[PKey](SomeColumns("key"))
+    val joinRDD = keyedRDD.join(keyedRDD)
+    val results = joinRDD.values.collect()
+    results should have length (rowCount)
+    joinRDD.toDebugString should not contain ("+-")
+    for (row <- results) {
+      row._1.getInt("key") should be(row._2.getInt("key"))
+    }
+  }
+
+  "CassandraTableScanPairRDDFunctions" should "not apply an empty partitioner" in {
+    val keyedRDD = testRDD.keyBy[Tuple1[Int]](SomeColumns("ckey"))
+    intercept[IllegalArgumentException] {
+      joinTarget.keyBy[Tuple1[Int]](SomeColumns("key")).applyPartitionerFrom(keyedRDD)
+    }
+  }
+
+  "CassandraTableScanRDDFunctions" should "key and apply another RDD" in {
+    val keyedRDD = testRDD.keyBy[PKey]
+    val otherRDD = joinTarget.keyAndApplyPartitionerFrom(keyedRDD)
+    val joinRDD = keyedRDD.join(otherRDD)
+    joinRDD.toDebugString should not contain ("+-")
+    val results = joinRDD.values.collect()
+    results should have length (rowCount)
+    for (row <- results) {
+      row._1.getInt("key") should be(row._2.getInt("key"))
+    }
+
+
+  }
+
+}

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartitionGeneratorSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartitionGeneratorSpec.scala
@@ -9,7 +9,7 @@ import com.datastax.spark.connector.embedded.{CassandraRunner, SparkTemplate, Em
 import com.datastax.spark.connector.rdd.CqlWhereClause
 import com.datastax.spark.connector.testkit.SharedEmbeddedCassandra
 
-class CassandraRDDPartitionerSpec
+class CassandraPartitionGeneratorSpec
   extends SparkCassandraITFlatSpecBase with Inspectors  {
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
@@ -20,19 +20,19 @@ class CassandraRDDPartitionerSpec
     session.execute(s"CREATE TABLE $ks.empty(key INT PRIMARY KEY)")
   }
 
-  // TODO: Currently CassandraRDDPartitioner uses a size-based algorithm that doesn't guarantee exact
+  // TODO: Currently CassandraPartitionGenerator uses a size-based algorithm that doesn't guarantee exact
   // split count, so we are only checking if the split count is "close enough" to the desired value.
   // Should be improved in the future.
   private def testPartitionCount(numPartitions: Int, min: Int, max: Int): Unit = {
     val table = Schema.fromCassandra(conn, Some(ks), Some("empty")).tables.head
-    val partitioner = CassandraRDDPartitioner(conn, table, Some(numPartitions), 10000)
-    val partitions = partitioner.partitions(CqlWhereClause.empty)
+    val partitioner = CassandraPartitionGenerator(conn, table, Some(numPartitions), 10000)
+    val partitions = partitioner.partitions
     partitions.length should be >= min
     partitions.length should be <= max
   }
 
-  "CassandraRDDPartitioner" should "create 1 partition per node if splitCount == 1" in {
-    testPartitionCount(1, conn.hosts.size, conn.hosts.size)
+  "CassandraPartitionGenerator" should "create 1 partition if splitCount == 1" in {
+    testPartitionCount(1, 1, 1)
   }
 
   // we won't run it on a 10000 node cluster, so we don't need to check node count
@@ -64,8 +64,8 @@ class CassandraRDDPartitionerSpec
       s"Data size estimates not present after $timeout ms. Test cannot be finished.")
 
     val table = Schema.fromCassandra(conn, Some(ks), Some(tableName)).tables.head
-    val partitioner = CassandraRDDPartitioner(conn, table, splitCount = None, splitSize = 1000000)
-    val partitions = partitioner.partitions(CqlWhereClause.empty)
+    val partitioner = CassandraPartitionGenerator(conn, table, splitCount = None, splitSize = 1000000)
+    val partitions = partitioner.partitions
 
     // theoretically there should be 64 splits, but it is ok to be "a little" inaccurate
     partitions.length should be >= 16
@@ -74,8 +74,8 @@ class CassandraRDDPartitionerSpec
 
   it should "align index fields of partitions with their place in the array" in {
     val table = Schema.fromCassandra(conn, Some(ks), Some("data")).tables.head
-    val partitioner = CassandraRDDPartitioner(conn, table, splitCount = Some(1000), splitSize = 100)
-    val partToIndex = partitioner.partitions(CqlWhereClause.empty).zipWithIndex
+    val partitioner = CassandraPartitionGenerator(conn, table, splitCount = Some(1000), splitSize = 100)
+    val partToIndex = partitioner.partitions.zipWithIndex
     forAll (partToIndex) { case (part, index) => part.index should be (index) }
   }
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/partitioner/TokenGeneratorSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/partitioner/TokenGeneratorSpec.scala
@@ -1,0 +1,82 @@
+package com.datastax.spark.connector.rdd.partitioner
+
+import com.datastax.spark.connector.{PartitionKeyColumns, SparkCassandraITFlatSpecBase}
+import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.cql.Schema
+import com.datastax.driver.core.Token
+import com.datastax.spark.connector.writer.RowWriterFactory
+import org.scalatest.Inspectors
+
+import scala.collection.JavaConversions._
+import scala.concurrent.Future
+
+class TokenGeneratorSpec extends SparkCassandraITFlatSpecBase {
+
+  case class SimpleKey(key: Int)
+  case class ComplexKey(key1: Int, key2: Int, key3: String)
+
+  useCassandraConfig(Seq("cassandra-default.yaml.template"))
+  val conn = CassandraConnector(defaultConf)
+
+  val simpleKeys = Seq(1, -500, 2801, 4000000, -95500).map(SimpleKey(_))
+  val complexKey = simpleKeys.map{ case SimpleKey(x) => ComplexKey(x, x, x.toString)}
+
+  conn.withSessionDo { session =>
+    createKeyspace(session)
+    awaitAll(
+      Future{session.execute(s"CREATE TABLE $ks.simple(key INT PRIMARY KEY)")},
+      Future{session.execute(s"CREATE TABLE $ks.complex(key1 INT, key2 INT, key3 text, PRIMARY KEY ((key1, key2, key3)))")}
+    )
+    val simplePS = session.prepare(s"INSERT INTO $ks.simple (key) VALUES (?)")
+    val complexPS = session.prepare(s"INSERT INTO $ks.complex (key1, key2, key3) VALUES (?, ?, ?)")
+    val insertFutures =
+      simpleKeys.map( simpleKey =>
+        session.executeAsync(simplePS.bind(simpleKey.key: java.lang.Integer))) ++
+      complexKey.map( complexKey =>
+        session.executeAsync(complexPS.bind(
+          complexKey.key1: java.lang.Integer,
+          complexKey.key2: java.lang.Integer,
+          complexKey.key3: java.lang.String)))
+    insertFutures.map(_.get())
+  }
+
+  val simpleTokenMap: Map[SimpleKey, Token] = conn.withSessionDo { session =>
+    val resultSet = session.execute(s"SELECT key, TOKEN(key) FROM $ks.simple").all()
+    resultSet.map(row => SimpleKey(row.getInt("key")) -> row.getPartitionKeyToken).toMap
+  }
+
+  val complexTokenMap: Map[ComplexKey, Token] = conn.withSessionDo { session =>
+    val resultSet = session
+      .execute(s"SELECT key1, key2, key3, TOKEN(key1, key2, key3) FROM $ks.complex")
+      .all()
+
+    resultSet.map(row =>
+      ComplexKey(row.getInt("key1"), row.getInt("key2"), row.getString("key3")) -> row.getPartitionKeyToken
+    ).toMap
+  }
+
+  val simpleTableDef = Schema.fromCassandra(conn, Some(ks), Some("simple")).tables.head
+  val complexTableDef = Schema.fromCassandra(conn, Some(ks), Some("complex")).tables.head
+
+  val simpleRW = implicitly[RowWriterFactory[SimpleKey]]
+    .rowWriter(simpleTableDef, PartitionKeyColumns.selectFrom(simpleTableDef))
+
+  val complexRW = implicitly[RowWriterFactory[ComplexKey]]
+    .rowWriter(complexTableDef, PartitionKeyColumns.selectFrom(complexTableDef))
+
+  "TokenGenerators" should "be able to determine simple partition keys" in {
+
+    val tokenGenerator = new TokenGenerator[SimpleKey](conn, simpleTableDef, simpleRW)
+    for ((key, token) <- simpleTokenMap) {
+      tokenGenerator.getTokenFor(key) should be (token)
+    }
+  }
+
+  it should "be able to determine composite keys" in {
+    val tokenGenerator = new TokenGenerator[ComplexKey](conn, complexTableDef, complexRW)
+    for ((key, token) <- complexTokenMap) {
+      tokenGenerator.getTokenFor(key) should be (token)
+    }
+  }
+
+}

--- a/spark-cassandra-connector/src/main/java/com/datastax/driver/core/MetadataHook.java
+++ b/spark-cassandra-connector/src/main/java/com/datastax/driver/core/MetadataHook.java
@@ -1,0 +1,24 @@
+package com.datastax.driver.core;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Wraps the driver's metadata to add the ability to build tokens from partition keys.
+ * <p/>
+ * This class has to live in {@code com.datastax.driver.core} in order to access package-private fields.
+ */
+public class MetadataHook {
+    /**
+     * Builds a new {@link Token} from a partition key, according to the partitioner reported by the Cassandra nodes.
+     *
+     * @param metadata               the original driver's metadata.
+     * @param routingKey             the routing key of the bound partition key
+     * @return the token.
+     * @throws IllegalStateException if the token factory was not initialized. This would typically
+     *                               happen if metadata was explicitly disabled with {@link QueryOptions#setMetadataEnabled(boolean)}
+     *                               before startup.
+     */
+    public static Token newToken(Metadata metadata, ByteBuffer routingKey) {
+        return metadata.tokenFactory().hash(routingKey);
+    }
+}

--- a/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraTableScanJavaRDD.java
+++ b/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraTableScanJavaRDD.java
@@ -1,5 +1,6 @@
 package com.datastax.spark.connector.japi.rdd;
 
+import com.datastax.spark.connector.writer.RowWriterFactory;
 import scala.Tuple2;
 import scala.collection.Seq;
 import scala.reflect.ClassTag;
@@ -82,17 +83,22 @@ public class CassandraTableScanJavaRDD<R> extends CassandraJavaRDD<R> {
      * If no selected columns are given, all available columns are selected.
      *
      * @param rrf row reader factory to convert the key to desired type K
+     * @param rwf row writer factory for creating a partitioner for key type K
      * @param keyClassTag class tag of K, required to construct the result JavaPairRDD
      * @param columns list of columns passed to the rrf to create the row reader,
      *                useful when the key is mapped to a tuple or a single value
      */
     public <K> CassandraJavaPairRDD<K, R> keyBy(
-        RowReaderFactory<K> rrf, ClassTag<K> keyClassTag, ColumnRef... columns) {
+        ClassTag<K> keyClassTag,
+        RowReaderFactory<K> rrf,
+        RowWriterFactory<K> rwf,
+        ColumnRef... columns) {
+
         Seq<ColumnRef> columnRefs = JavaApiHelper.toScalaSeq(columns);
         CassandraRDD<Tuple2<K, R>> resultRDD =
                 columns.length == 0
-                        ? rdd().keyBy(rrf)
-                        : rdd().keyBy(columnRefs, rrf);
+                        ? rdd().keyBy(keyClassTag, rrf, rwf)
+                        : rdd().keyBy(columnRefs, keyClassTag, rrf, rwf);
         return new CassandraJavaPairRDD<>(resultRDD, keyClassTag, classTag());
     }
 
@@ -100,25 +106,57 @@ public class CassandraTableScanJavaRDD<R> extends CassandraJavaRDD<R> {
      * @see {@link #keyBy(RowReaderFactory, ClassTag, ColumnRef...)}
      */
     public <K> CassandraJavaPairRDD<K, R> keyBy(
-            RowReaderFactory<K> rrf, Class<K> keyClass, ColumnRef... columns) {
-        return keyBy(rrf, JavaApiHelper.getClassTag(keyClass), columns);
+            RowReaderFactory<K> rrf,
+            RowWriterFactory<K> rwf,
+            Class<K> keyClass,
+            ColumnRef... columns) {
+        return keyBy(JavaApiHelper.getClassTag(keyClass), rrf, rwf, columns);
     }
 
     /**
      * @see {@link #keyBy(RowReaderFactory, ClassTag, ColumnRef...)}
      */
     public <K> CassandraJavaPairRDD<K, R> keyBy(
-            RowReaderFactory<K> rrf, Class<K> keyClass, String... columnNames) {
+            RowReaderFactory<K> rrf,
+            RowWriterFactory<K> rwf,
+            Class<K> keyClass,
+            String... columnNames) {
         ColumnRef[] columnRefs = toSelectableColumnRefs(columnNames);
-        return keyBy(rrf, JavaApiHelper.getClassTag(keyClass), columnRefs);
+        return keyBy(JavaApiHelper.getClassTag(keyClass), rrf, rwf, columnRefs);
     }
 
 
     /**
      * @see {@link #keyBy(RowReaderFactory, ClassTag, ColumnRef...)}
      */
-    public <K> CassandraJavaPairRDD<K, R> keyBy(RowReaderFactory<K> rrf, Class<K> keyClass) {
-        return keyBy(rrf, JavaApiHelper.getClassTag(keyClass));
+    public <K> CassandraJavaPairRDD<K, R> keyBy(
+            RowReaderFactory<K> rrf,
+            RowWriterFactory<K> rwf,
+            Class<K> keyClass) {
+        return keyBy(JavaApiHelper.getClassTag(keyClass), rrf, rwf);
+    }
+
+
+    /**
+     * Builds a K/V Pair RDD using the partitioner from an existing
+     * CassandraTableScanPairRDD. Since we cannot determine ahead of time
+     * the type of the PairRDD or the type of it's partitioner this method will
+     * throw exceptions if the Partitioner is not a CassandraPartitioner at
+     * runtime.
+     */
+    public <K> CassandraJavaPairRDD<K, R> keyAndApplyPartitionerFrom(
+            RowReaderFactory<K> rrf,
+            RowWriterFactory<K> rwf,
+            Class<K> keyClass,
+            CassandraJavaPairRDD<K, ?> otherRDD) {
+
+        ClassTag<K> keyClassTag = JavaApiHelper.getClassTag(keyClass);
+
+        CassandraRDD<Tuple2<K, R>> newRDD =  this.rdd()
+            .keyBy(keyClassTag, rrf, rwf)
+            .withPartitioner(otherRDD.rdd().partitioner());
+
+        return new CassandraJavaPairRDD<>(newRDD, keyClassTag, classTag());
     }
 
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/CassandraTableScanRDDFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/CassandraTableScanRDDFunctions.scala
@@ -1,0 +1,58 @@
+package com.datastax.spark.connector
+
+import com.datastax.spark.connector.rdd.CassandraTableScanRDD
+import com.datastax.spark.connector.rdd.partitioner.CassandraPartitioner
+import com.datastax.spark.connector.rdd.partitioner.dht.Token
+import com.datastax.spark.connector.rdd.reader.RowReaderFactory
+import com.datastax.spark.connector.writer.RowWriterFactory
+import org.apache.spark.Partitioner
+
+import scala.reflect.ClassTag
+
+final class CassandraTableScanPairRDDFunctions[K, V](rdd: CassandraTableScanRDD[(K, V)]) extends
+  Serializable {
+
+  /**
+    * Use the [[CassandraPartitioner]] from another [[CassandraTableScanRDD]] which
+    * shares the same key type. All Partition Keys columns must also be present in the keys of
+    * the target RDD.
+    */
+  def applyPartitionerFrom[X](
+    thatRdd: CassandraTableScanRDD[(K, X)]): CassandraTableScanRDD[(K, V)] = {
+
+    val partitioner = thatRdd.partitioner match {
+      case Some(part: CassandraPartitioner[K, _, _]) => part
+      case Some(other: Partitioner) =>
+        throw new IllegalArgumentException(s"Partitioner $other is not a CassandraPartitioner")
+      case None => throw new IllegalArgumentException(s"$thatRdd has no partitioner to apply")
+    }
+
+    applyPartitioner(partitioner)
+  }
+
+  /**
+    * Use a specific [[CassandraPartitioner]] to use with this PairRDD.
+    */
+  def applyPartitioner[TokenValue, T <: Token[TokenValue]](
+    partitioner: CassandraPartitioner[K, TokenValue, T]): CassandraTableScanRDD[(K, V)] = {
+    rdd.withPartitioner(Some(partitioner))
+  }
+}
+
+final class CassandraTableScanRDDFunctions[R](rdd: CassandraTableScanRDD[R]) extends Serializable {
+  /**
+    * Shortcut for `rdd.keyBy[K].applyPartitionerFrom(thatRDD[K, V])` where K is the key
+    * type of the target RDD. This guarentees that the partitioner applied to this rdd
+    * will match the key type.
+    */
+  def keyAndApplyPartitionerFrom[K, X](
+    thatRDD: CassandraTableScanRDD[(K, X)],
+    columnSelector: ColumnSelector = PartitionKeyColumns)(
+  implicit
+    classTag: ClassTag[K],
+    rrf: RowReaderFactory[K],
+    rwf: RowWriterFactory[K]) = {
+
+    rdd.keyBy[K](columnSelector).applyPartitionerFrom(thatRDD)
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/SparkContextFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/SparkContextFunctions.scala
@@ -2,7 +2,8 @@ package com.datastax.spark.connector
 
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.rdd.reader.RowReaderFactory
-import com.datastax.spark.connector.rdd.{CassandraTableScanRDD, EmptyCassandraRDD, ReadConf, ValidRDDType}
+import com.datastax.spark.connector.rdd._
+import com.datastax.spark.connector.writer.RowWriterFactory
 import org.apache.spark.SparkContext
 
 import scala.reflect.ClassTag
@@ -44,12 +45,14 @@ class SparkContextFunctions(@transient val sc: SparkContext) extends Serializabl
     *   rdd3.first.word  // foo
     *   rdd3.first.count // 20
     * }}}*/
-  def cassandraTable[T](keyspace: String, table: String)
-                       (implicit connector: CassandraConnector = CassandraConnector(sc.getConf),
-                        readConf: ReadConf = ReadConf.fromSparkConf(sc.getConf),
-                        ct: ClassTag[T], rrf: RowReaderFactory[T],
-                        ev: ValidRDDType[T]) =
-    new CassandraTableScanRDD[T](sc, connector, keyspace, table, readConf = readConf)
+  def cassandraTable[T](
+    keyspace: String,
+    table: String)(
+  implicit
+    connector: CassandraConnector = CassandraConnector(sc.getConf),
+    readConf: ReadConf = ReadConf.fromSparkConf(sc.getConf),
+    ct: ClassTag[T], rrf: RowReaderFactory[T],
+    ev: ValidRDDType[T]) = new CassandraTableScanRDD[T](sc, connector, keyspace, table, readConf = readConf)
 
   /** Produces the empty CassandraRDD which does not perform any validation and it does not even
     * try to return any rows. */

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/package.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/package.scala
@@ -1,5 +1,6 @@
 package com.datastax.spark
 
+import com.datastax.spark.connector.rdd.CassandraTableScanRDD
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.DataFrame
@@ -59,11 +60,19 @@ package object connector {
   implicit def toRDDFunctions[T](rdd: RDD[T]): RDDFunctions[T] =
     new RDDFunctions(rdd)
 
+  implicit def toCassandraTableScanFunctions[T](rdd: CassandraTableScanRDD[T]) =
+    new CassandraTableScanRDDFunctions(rdd)
+
   implicit def toDataFrameFunctions(dataFrame: DataFrame): DataFrameFunctions =
     new DataFrameFunctions(dataFrame)
 
   implicit def toPairRDDFunctions[K, V](rdd: RDD[(K, V)]): PairRDDFunctions[K, V] =
     new PairRDDFunctions(rdd)
+
+  implicit def toCassandraTableScanRDDPairFunctions[K, V](
+    rdd: CassandraTableScanRDD[(K, V)]): CassandraTableScanPairRDDFunctions[K, V] =
+    new CassandraTableScanPairRDDFunctions(rdd)
+
 
   implicit class ColumnNameFunctions(val columnName: String) extends AnyVal {
     def writeTime: WriteTime = WriteTime(columnName)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
@@ -28,9 +28,9 @@ abstract class CassandraRDD[R : ClassTag](
   
   ConfigCheck.checkConfig(sc.getConf)
 
-  protected def keyspaceName: String
+  protected[connector] def keyspaceName: String
 
-  protected def tableName: String
+  protected[connector] def tableName: String
 
   protected def columnNames: ColumnSelector
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
@@ -2,22 +2,24 @@ package com.datastax.spark.connector.rdd
 
 import java.io.IOException
 
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.cql._
+import com.datastax.spark.connector.rdd.partitioner._
+import com.datastax.spark.connector.rdd.partitioner.dht.{Token => ConnectorToken}
+import com.datastax.spark.connector.rdd.reader._
+import com.datastax.spark.connector.types.ColumnType
+import com.datastax.spark.connector.util.CqlWhereParser.{EqPredicate, InListPredicate, InPredicate, Predicate, RangePredicate}
+import com.datastax.spark.connector.util.Quote._
+import com.datastax.spark.connector.util.{CountingIterator, CqlWhereParser}
+import com.datastax.spark.connector.writer.RowWriterFactory
+
+import com.datastax.driver.core._
+import org.apache.spark.metrics.InputMetricsUpdater
+import org.apache.spark.{Partition, Partitioner, SparkContext, TaskContext}
+
 import scala.collection.JavaConversions._
 import scala.language.existentials
 import scala.reflect.ClassTag
-
-import org.apache.spark.metrics.InputMetricsUpdater
-import org.apache.spark.{Partition, SparkContext, TaskContext}
-
-import com.datastax.driver.core._
-import com.datastax.spark.connector._
-import com.datastax.spark.connector.cql._
-import com.datastax.spark.connector.rdd.partitioner.dht.TokenFactory
-import com.datastax.spark.connector.rdd.partitioner.{NodeAddresses, CassandraPartition, CassandraRDDPartitioner, CqlTokenRange}
-import com.datastax.spark.connector.rdd.reader._
-import com.datastax.spark.connector.types.ColumnType
-import com.datastax.spark.connector.util.CountingIterator
-import com.datastax.spark.connector.util.Quote._
 
 
 /** RDD representing a Table Scan of A Cassandra table.
@@ -65,7 +67,8 @@ class CassandraTableScanRDD[R] private[connector](
     val where: CqlWhereClause = CqlWhereClause.empty,
     val limit: Option[Long] = None,
     val clusteringOrder: Option[ClusteringOrder] = None,
-    val readConf: ReadConf = ReadConf())(
+    val readConf: ReadConf = ReadConf(),
+    overridePartitioner: Option[Partitioner] = None)(
   implicit
     val classTag: ClassTag[R],
     @transient val rowReaderFactory: RowReaderFactory[R])
@@ -98,8 +101,11 @@ class CassandraTableScanRDD[R] private[connector](
       where = where,
       limit = limit,
       clusteringOrder = clusteringOrder,
-      readConf = readConf)
+      readConf = readConf,
+      overridePartitioner = overridePartitioner)
   }
+
+
 
   override protected def convertTo[B : ClassTag : RowReaderFactory]: CassandraTableScanRDD[B] = {
     new CassandraTableScanRDD[B](
@@ -111,7 +117,52 @@ class CassandraTableScanRDD[R] private[connector](
       where = where,
       limit = limit,
       clusteringOrder = clusteringOrder,
-      readConf = readConf)
+      readConf = readConf,
+      overridePartitioner = overridePartitioner)
+  }
+
+  /**
+    * Internal method for assigning a partitioner to this RDD, this lacks type safety checks for
+    * the Partitioner of type [K]. End users will use the implicit provided in
+    * [[CassandraTableScanPairRDDFunctions]]
+    */
+  private[connector] def withPartitioner[K, V, T <: ConnectorToken[V]](
+    partitioner: Option[Partitioner]): CassandraTableScanRDD[R] = {
+
+    val cassPart = partitioner match {
+      case Some(newPartitioner: CassandraPartitioner[K, V, T]) => {
+        this.partitioner match {
+          case Some(currentPartitioner: CassandraPartitioner[K, V, T]) =>
+            /** Preserve the mapping set by the current partitioner **/
+            logDebug(
+              s"""Preserving Partitioner: $currentPartitioner with mapping
+                 |${currentPartitioner.keyMapping}""".stripMargin)
+            Some(
+              newPartitioner
+                .withTableDef(tableDef)
+                .withKeyMapping(currentPartitioner.keyMapping))
+          case _ =>
+            logDebug(s"Assigning new Partitioner $newPartitioner")
+            Some(newPartitioner.withTableDef(tableDef))
+        }
+      }
+      case Some(other: Partitioner) => throw new IllegalArgumentException(
+        s"""Unable to assign
+          |non-CassandraPartitioner $other to CassandraTableScanRDD """.stripMargin)
+      case None => None
+    }
+
+    new CassandraTableScanRDD[R](
+      sc = sc,
+      connector = connector,
+      keyspaceName = keyspaceName,
+      tableName = tableName,
+      columnNames = columnNames,
+      where = where,
+      limit = limit,
+      clusteringOrder = clusteringOrder,
+      readConf = readConf,
+      overridePartitioner = cassPart)
   }
 
   /** Selects a subset of columns mapped to the key and returns an RDD of pairs.
@@ -119,30 +170,76 @@ class CassandraTableScanRDD[R] private[connector](
     * RowReaderFactory to construct the key objects.
     * The selected columns must be available in the CassandraRDD.
     *
+    * If the selected columns contain the complete partition key a
+    * `CassandraPartitioner` will also be created.
+    *
     * @param columns column selector passed to the rrf to create the row reader,
     *                useful when the key is mapped to a tuple or a single value
     */
-  def keyBy[K : RowReaderFactory](columns: ColumnSelector): CassandraTableScanRDD[(K, R)] = {
+  def keyBy[K](columns: ColumnSelector)(implicit
+    classtag: ClassTag[K],
+    rrf: RowReaderFactory[K],
+    rwf: RowWriterFactory[K]): CassandraTableScanRDD[(K, R)] = {
+
     val kRRF = implicitly[RowReaderFactory[K]]
     val vRRF = rowReaderFactory
     implicit val kvRRF = new KeyValueRowReaderFactory[K, R](columns, kRRF, vRRF)
-    convertTo[(K, R)]
+
+    val selectedColumnNames = columns.selectFrom(tableDef).map(_.columnName).toSet
+    val partitionKeyColumnNames = PartitionKeyColumns.selectFrom(tableDef).map(_.columnName).toSet
+
+    if (selectedColumnNames.containsAll(partitionKeyColumnNames)) {
+      val partitioner = partitionGenerator.partitioner[K](columns)
+      logDebug(
+        s"""Made partitioner ${partitioner} for $this""".stripMargin)
+      convertTo[(K, R)].withPartitioner(partitioner)
+
+    } else {
+      convertTo[(K, R)]
+    }
   }
 
   /** Extracts a key of the given class from the given columns.
+    *
     *  @see `keyBy(ColumnSelector)` */
-  def keyBy[K : RowReaderFactory](columns: ColumnRef*): CassandraTableScanRDD[(K, R)] =
+  def keyBy[K](columns: ColumnRef*)(implicit
+    classtag: ClassTag[K],
+    rrf: RowReaderFactory[K],
+    rwf: RowWriterFactory[K]): CassandraTableScanRDD[(K, R)] =
     keyBy(SomeColumns(columns: _*))
 
   /** Extracts a key of the given class from all the available columns.
+    *
     * @see `keyBy(ColumnSelector)` */
-  def keyBy[K : RowReaderFactory]: CassandraTableScanRDD[(K, R)] =
+  def keyBy[K]()(implicit
+    classtag: ClassTag[K],
+    rrf: RowReaderFactory[K],
+    rwf: RowWriterFactory[K]): CassandraTableScanRDD[(K, R)] =
     keyBy(AllColumns)
+
+  @transient lazy val partitionGenerator = {
+    if (containsPartitionKey(where)) {
+      CassandraPartitionGenerator(connector, tableDef, Some(1), splitSize)
+    } else {
+      CassandraPartitionGenerator(connector, tableDef, splitCount, splitSize)
+    }
+  }
+
+  @transient override val partitioner = overridePartitioner
 
   override def getPartitions: Array[Partition] = {
     verify() // let's fail fast
-    val partitioner = CassandraRDDPartitioner(connector, tableDef, splitCount, splitSize)
-    val partitions = partitioner.partitions(where)
+    val partitions: Array[Partition] = partitioner match {
+      case Some(cassPartitioner: CassandraPartitioner[_, _, _]) => {
+        cassPartitioner.verify()
+        cassPartitioner.partitions.toArray[Partition]
+      }
+      case Some(other: Partitioner) =>
+        throw new IllegalArgumentException(s"Invalid partitioner $other")
+
+      case None => partitionGenerator.partitions.toArray[Partition]
+    }
+
     logDebug(s"Created total ${partitions.length} partitions for $keyspaceName.$tableName.")
     logTrace("Partitions: \n" + partitions.mkString("\n"))
     partitions
@@ -150,12 +247,16 @@ class CassandraTableScanRDD[R] private[connector](
 
   private lazy val nodeAddresses = new NodeAddresses(connector)
 
-  override def getPreferredLocations(split: Partition): Seq[String] =
-    split.asInstanceOf[CassandraPartition].endpoints.flatMap(nodeAddresses.hostNames).toSeq
+  private lazy val partitionKeyStr =
+    tableDef.partitionKey.map(_.columnName).map(quote).mkString(", ")
 
-  private def tokenRangeToCqlQuery(range: CqlTokenRange): (String, Seq[Any]) = {
+  override def getPreferredLocations(split: Partition): Seq[String] =
+    split.asInstanceOf[CassandraPartition[_, _]].endpoints.flatMap(nodeAddresses.hostNames).toSeq
+
+  private def tokenRangeToCqlQuery(range: CqlTokenRange[_, _]): (String, Seq[Any]) = {
     val columns = selectedColumnRefs.map(_.cql).mkString(", ")
-    val filter = (range.cql +: where.predicates).filter(_.nonEmpty).mkString(" AND ")
+    val (cql, values) = range.cql(partitionKeyStr)
+    val filter = (cql +: where.predicates).filter(_.nonEmpty).mkString(" AND ")
     val limitClause = limit.map(limit => s"LIMIT $limit").getOrElse("")
     val orderBy = clusteringOrder.map(_.toCql(tableDef)).getOrElse("")
     val quotedKeyspaceName = quote(keyspaceName)
@@ -164,7 +265,7 @@ class CassandraTableScanRDD[R] private[connector](
       s"SELECT $columns " +
         s"FROM $quotedKeyspaceName.$quotedTableName " +
         s"WHERE $filter $orderBy $limitClause ALLOW FILTERING"
-    val queryParamValues = range.values ++ where.values
+    val queryParamValues = values ++ where.values
     (queryTemplate, queryParamValues)
   }
 
@@ -190,12 +291,12 @@ class CassandraTableScanRDD[R] private[connector](
 
   private def fetchTokenRange(
     session: Session,
-    range: CqlTokenRange,
+    range: CqlTokenRange[_, _],
     inputMetricsUpdater: InputMetricsUpdater): Iterator[R] = {
 
     val (cql, values) = tokenRangeToCqlQuery(range)
     logDebug(
-      s"Fetching data for range ${range.cql} " +
+      s"Fetching data for range ${range.cql(partitionKeyStr)} " +
         s"with $cql " +
         s"with params ${values.mkString("[", ",", "]")}")
     val stmt = createStatement(session, cql, values: _*)
@@ -206,7 +307,7 @@ class CassandraTableScanRDD[R] private[connector](
       val iterator = new PrefetchingResultSetIterator(rs, fetchSize)
       val iteratorWithMetrics = iterator.map(inputMetricsUpdater.updateMetrics)
       val result = iteratorWithMetrics.map(rowReader.read(_, columnNamesArray))
-      logDebug(s"Row iterator for range ${range.cql} obtained successfully.")
+      logDebug(s"Row iterator for range ${range.cql(partitionKeyStr)} obtained successfully.")
       result
     } catch {
       case t: Throwable =>
@@ -216,7 +317,7 @@ class CassandraTableScanRDD[R] private[connector](
 
   override def compute(split: Partition, context: TaskContext): Iterator[R] = {
     val session = connector.openSession()
-    val partition = split.asInstanceOf[CassandraPartition]
+    val partition = split.asInstanceOf[CassandraPartition[_, _]]
     val tokenRanges = partition.tokenRanges
     val metricsUpdater = InputMetricsUpdater(context, readConf)
 
@@ -224,7 +325,7 @@ class CassandraTableScanRDD[R] private[connector](
     // flatMap on iterator is lazy, therefore a query for the next token range is executed not earlier
     // than all of the rows returned by the previous query have been consumed
     val rowIterator = tokenRanges.iterator.flatMap(
-      fetchTokenRange(session, _, metricsUpdater))
+      fetchTokenRange(session, _: CqlTokenRange[_, _], metricsUpdater))
     val countingIterator = new CountingIterator(rowIterator, limit)
 
     context.addTaskCompletionListener { (context) =>
@@ -269,6 +370,30 @@ class CassandraTableScanRDD[R] private[connector](
 
     counts.reduce(_ + _)
   }
+
+
+  private def containsPartitionKey(clause: CqlWhereClause) = {
+    val pk = tableDef.partitionKey.map(_.columnName).toSet
+    val wherePredicates: Seq[Predicate] = clause.predicates.flatMap(CqlWhereParser.parse)
+
+    val whereColumns: Set[String] = wherePredicates.collect {
+      case EqPredicate(c, _) if pk.contains(c) => c
+      case InPredicate(c) if pk.contains(c) => c
+      case InListPredicate(c, _) if pk.contains(c) => c
+      case RangePredicate(c, _, _) if pk.contains(c) =>
+        throw new UnsupportedOperationException(
+          s"Range predicates on partition key columns (here: $c) are " +
+            s"not supported in where. Use filter instead.")
+    }.toSet
+
+    if (whereColumns.nonEmpty && whereColumns.size < pk.size) {
+      val missing = pk -- whereColumns
+      throw new UnsupportedOperationException(
+        s"Partition key predicate must include all partition key columns. Missing columns: ${missing.mkString(",")}"
+      )
+    }
+    whereColumns.nonEmpty
+  }
 }
 
 object CassandraTableScanRDD {
@@ -295,9 +420,10 @@ object CassandraTableScanRDD {
     implicit
       keyCT: ClassTag[K],
       valueCT: ClassTag[V],
-      rrf: RowReaderFactory[(K, V)]): CassandraTableScanRDD[(K, V)] = {
+      rrf: RowReaderFactory[(K, V)],
+      rwf: RowWriterFactory[K]): CassandraTableScanRDD[(K, V)] = {
 
-    new CassandraTableScanRDD[(K, V)](
+    val rdd = new CassandraTableScanRDD[(K, V)](
       sc = sc,
       connector = CassandraConnector(sc.getConf),
       keyspaceName = keyspaceName,
@@ -305,5 +431,6 @@ object CassandraTableScanRDD {
       readConf = ReadConf.fromSparkConf(sc.getConf),
       columnNames = AllColumns,
       where = CqlWhereClause.empty)
+    rdd.withPartitioner(rdd.partitionGenerator.partitioner[K](PartitionKeyColumns))
   }
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/BucketingRangeIndex.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/BucketingRangeIndex.scala
@@ -1,0 +1,78 @@
+package com.datastax.spark.connector.rdd.partitioner
+
+import scala.collection.mutable.ArrayBuffer
+
+import com.datastax.spark.connector.rdd.partitioner.dht.Token
+
+/** A mapping from T values to an integer range [0, n),
+  * such that for any (t1: T) > (t2: T), bucket(t1) >= bucket(t2). */
+trait MonotonicBucketing[-T] {
+  def bucket(n: Int): T => Int
+}
+
+object MonotonicBucketing {
+
+  val lnOf2 = scala.math.log(2)
+  def log2(x: Double) = scala.math.log(x) / lnOf2
+
+  implicit object IntBucketing extends MonotonicBucketing[Int] {
+    override def bucket(n: Int): Int => Int = {
+      val shift = 31 - log2(n).toInt
+      x => (x / 2 - Int.MinValue / 2) >> shift
+    }
+  }
+
+  implicit object LongBucketing extends MonotonicBucketing[Long] {
+    override def bucket(n: Int): Long => Int = {
+      val shift = 63 - log2(n).toInt
+      x => ((x / 2 - Long.MinValue / 2) >> shift).toInt
+    }
+  }
+}
+
+/** Extracts rangeBounds of a range R.
+  * This is to allow working with any representation of rangesContaining.
+  * The range must not wrap, that is `end` >= `start`. */
+trait RangeBounds[-R, T] {
+  def start(range: R): T
+  def end(range: R): T
+  def contains(range: R, point: T): Boolean
+  def isFull(range: R): Boolean
+}
+
+/** A special structure for fast lookup of rangesContaining containing given point.*/
+class BucketingRangeIndex[R, T](ranges: Seq[R])
+  (implicit bounds: RangeBounds[R, T], ordering: Ordering[T], bucketing: MonotonicBucketing[T]) {
+
+  private val sizeLog = MonotonicBucketing.log2(ranges.size).toInt + 1
+  private val size = math.pow(2, sizeLog).toInt
+  private val table = Array.fill(size)(new ArrayBuffer[R])
+  private val bucket: T => Int = bucketing.bucket(size)
+
+  private def add(r: R, startHash: Int, endHash: Int): Unit = {
+    var i = startHash
+    while (i <= endHash) {
+      table(i) += r
+      i += 1
+    }
+  }
+
+  for (r <- ranges) {
+    val start = bounds.start(r)
+    val end = bounds.end(r)
+    val startBucket = bucket(start)
+    val endBucket = bucket(end)
+    if (bounds.isFull(r))
+      add(r, 0, size - 1)
+    else if (ordering.lt(end, start)) {
+      add(r, startBucket, size - 1)
+      add(r, 0, endBucket)
+    }
+    else
+      add(r, startBucket, endBucket)
+  }
+
+  /** Finds rangesContaining containing given point in O(1) time. */
+  def rangesContaining(point: T): IndexedSeq[R] =
+    table(bucket(point)).filter(bounds.contains(_, point))
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartitioner.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartitioner.scala
@@ -1,0 +1,146 @@
+package com.datastax.spark.connector.rdd.partitioner
+
+import scala.reflect.ClassTag
+import scala.util.Try
+
+import org.apache.spark.{Logging, Partitioner}
+
+import com.datastax.spark.connector.cql.{CassandraConnector, TableDef}
+import com.datastax.spark.connector.rdd.partitioner.dht.{Token, TokenFactory, TokenRange}
+import com.datastax.spark.connector.writer.RowWriterFactory
+import com.datastax.spark.connector.{ColumnSelector, PartitionKeyColumns}
+
+/** Holds a token range together with the index of a partition this token range belongs to */
+case class TokenRangeWithPartitionIndex[V, T <: Token[V]](range: TokenRange[V, T], partitionIndex: Int)
+
+object TokenRangeWithPartitionIndex {
+
+  implicit def rangeBounds[V, T <: Token[V]](implicit tf: TokenFactory[V, T])
+      : RangeBounds[TokenRangeWithPartitionIndex[V, T], T] = {
+    type ITR = TokenRangeWithPartitionIndex[V, T]
+    new RangeBounds[ITR, T] {
+      override def start(range: ITR): T = range.range.start
+      override def end(range: ITR): T = range.range.end
+      override def isFull(range: ITR): Boolean = range.range.isFull
+      override def contains(range: ITR, token: T): Boolean = range.range.contains(token)
+    }
+  }
+
+}
+
+/**
+  * A [[org.apache.spark.Partitioner]] implementation which performs the inverse
+  * operation of a traditional C* hashing. Requires the Key type and the token
+  * value type V.
+  *
+  * Will take objects of type Key and determine given the token ranges in `indexedRanges`
+  * which range the Key would belong in given the C* schema in `TableDef`
+  *
+  * Under the hood uses a bound statement to generate routing keys which are then
+  * used the driver's internal token factories to determine the token for the
+  * routing key.
+  */
+private[connector] class CassandraPartitioner[Key : ClassTag, V, T <: Token[V]](
+  private val connector: CassandraConnector,
+  private val tableDef: TableDef,
+  val partitions: Seq[CassandraPartition[V, T]],
+  val keyMapping: ColumnSelector = PartitionKeyColumns)(
+implicit
+  @transient
+  rwf: RowWriterFactory[Key],
+  tokenFactory: TokenFactory[V, T]) extends Partitioner with Logging {
+
+  /** Changes the tableDef target of this partitioner. Can only be done within a keyspace
+    * verification of key mapping will occur with the call to [[verify()]] */
+  def withTableDef(tableDef: TableDef): CassandraPartitioner[Key, V, T] = {
+    if (tableDef.keyspaceName != this.tableDef.keyspaceName) {
+      throw new IllegalArgumentException(
+        s"""Cannot apply partitioner from keyspace
+           |${this.tableDef.keyspaceName} to table
+           |${tableDef.keyspaceName}.${tableDef.tableName} because the keyspaces do
+           |not match""".stripMargin)
+    }
+
+    new CassandraPartitioner(connector, tableDef, partitions, keyMapping)
+  }
+
+  /** Changes the current key mapping for this partitioner. Verification of the mapping
+    * occurs on call to [[verify()]] */
+  def withKeyMapping(keyMapping: ColumnSelector): CassandraPartitioner[Key, V, T] =
+    new CassandraPartitioner(connector, tableDef, partitions, keyMapping)
+
+  private lazy val partitionKeyNames =
+    PartitionKeyColumns.selectFrom(tableDef).map(_.columnName).toSet
+
+  private lazy val partitionKeyMapping = keyMapping
+    .selectFrom(tableDef)
+    .filter( colRef => partitionKeyNames.contains(colRef.columnName))
+
+  private lazy val partitionKeyWriter = {
+    logDebug(
+      s"""Building Partitioner with mapping
+         |${partitionKeyMapping.map(x => (x.columnName, x.selectedAs))}
+         |for table $tableDef""".stripMargin)
+    implicitly[RowWriterFactory[Key]]
+      .rowWriter(tableDef, partitionKeyMapping)
+  }
+
+  /** Builds and makes sure we can make a rowWriter with the current TableDef and keyMapper */
+  def verify(log: Boolean = true): Unit = {
+    val attempt = Try(partitionKeyWriter)
+    if (attempt.isFailure) {
+      if (log)
+        logError("Unable to build partition key writer CassandraPartitioner.", attempt.failed.get)
+      throw attempt.failed.get
+    }
+  }
+
+  /** Since the Token Generator relies on a (non-serializable) prepared statement we need to
+    * make sure it is not serialized to executors and is made fresh on each executor */
+  @transient
+  private lazy val tokenGenerator =
+    new TokenGenerator(connector, tableDef, partitionKeyWriter)
+
+  private type ITR = TokenRangeWithPartitionIndex[V, T]
+
+  @transient
+  private lazy val indexedTokenRanges: Seq[ITR] =
+    for (p <- partitions; tr <- p.tokenRanges) yield
+      TokenRangeWithPartitionIndex(tr.range, p.index)
+
+  @transient
+  private lazy val tokenRangeLookupTable: BucketingRangeIndex[ITR, T] = {
+    implicit val tokenOrdering = tokenFactory.tokenOrdering
+    implicit val tokenBucketing = tokenFactory.tokenBucketing
+    new BucketingRangeIndex(indexedTokenRanges)
+  }
+
+  override def getPartition(key: Any): Int = {
+    key match {
+      case x: Key =>
+        val driverToken = tokenGenerator.getTokenFor(x)
+        val connectorToken = tokenFactory.tokenFromString(driverToken.getValue.toString)
+        tokenRangeLookupTable.rangesContaining(connectorToken).head.partitionIndex
+      case other =>
+        throw new IllegalArgumentException(s"Couldn't determine the key from object $other")
+    }
+  }
+
+  override def numPartitions: Int =
+    partitions.length
+
+  override def equals(that: Any): Boolean = that match {
+    case that: CassandraPartitioner[Key, V, T] =>
+      (this.indexedTokenRanges == that.indexedTokenRanges
+        && this.tableDef.keyspaceName == that.tableDef.keyspaceName
+        && this.connector == that.connector)
+    case _ =>
+      false
+  }
+
+  override def hashCode: Int = {
+    indexedTokenRanges.hashCode() + tableDef.keyspaceName.hashCode * 31
+  }
+
+}
+

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/TokenGenerator.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/TokenGenerator.scala
@@ -1,0 +1,38 @@
+package com.datastax.spark.connector.rdd.partitioner
+
+import com.datastax.driver.core.{Token, MetadataHook}
+import com.datastax.spark.connector.cql.{CassandraConnector, TableDef}
+import com.datastax.spark.connector.util.PatitionKeyTools._
+import com.datastax.spark.connector.writer.{BoundStatementBuilder, RoutingKeyGenerator, RowWriter}
+import org.apache.spark.Logging
+
+/**
+  * A utility class for determining the token of a given key. Uses a bound statement to determine
+  * the routing key and the uses that with the TokenFactory to determine the hashed Token.
+  */
+private[connector] class TokenGenerator[T] (
+  connector: CassandraConnector,
+  tableDef: TableDef,
+  rowWriter: RowWriter[T]) extends Serializable with Logging {
+
+  val protocolVersion = connector.withSessionDo { session =>
+    session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersion
+  }
+
+  //Makes a PreparedStatement which we use only to generate routing keys on the client
+  val stmt = connector.withSessionDo { session => prepareDummyStatement(session, tableDef) }
+  val metadata = connector.withClusterDo(_.getMetadata)
+
+  val routingKeyGenerator = new RoutingKeyGenerator(
+    tableDef,
+    tableDef.partitionKey.map(_.columnName))
+
+  val boundStmtBuilder = new BoundStatementBuilder(
+    rowWriter,
+    stmt,
+    protocolVersion = protocolVersion)
+
+  def getTokenFor(key: T): Token = {
+    MetadataHook.newToken(metadata, routingKeyGenerator.apply(boundStmtBuilder.bind(key)))
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/TokenRangeClusterer.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/TokenRangeClusterer.scala
@@ -8,16 +8,16 @@ import com.datastax.spark.connector.rdd.partitioner.dht.{Token, TokenRange}
 
 import scala.annotation.tailrec
 
-/** Divides a set of token ranges into groups containing not more than `maxRowCountPerGroup` rows
-  * and not more than `maxGroupSize` token ranges. Each group will form a single `CassandraRDDPartition`.
+/** Divides a set of token rangesContaining into groups containing not more than `maxRowCountPerGroup` rows
+  * and not more than `maxGroupSize` token rangesContaining. Each group will form a single `CassandraPartition`.
   *
   * The algorithm is as follows:
-  * 1. Sort token ranges by endpoints lexicographically.
-  * 2. Take the highest possible number of token ranges from the beginning of the list,
+  * 1. Sort token rangesContaining by endpoints lexicographically.
+  * 2. Take the highest possible number of token rangesContaining from the beginning of the list,
   *    such that their sum of rowCounts does not exceed `maxRowCountPerGroup` and they all contain at
   *    least one common endpoint. If it is not possible, take at least one item.
-  *    Those token ranges will make a group.
-  * 3. Repeat the previous step until no more token ranges left.*/
+  *    Those token rangesContaining will make a group.
+  * 3. Repeat the previous step until no more token rangesContaining left.*/
 class TokenRangeClusterer[V, T <: Token[V]](maxRowCountPerGroup: Long, maxGroupSize: Int = Int.MaxValue) {
 
   private implicit object InetAddressOrdering extends Ordering[InetAddress] {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/dht/Token.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/dht/Token.scala
@@ -1,17 +1,61 @@
 package com.datastax.spark.connector.rdd.partitioner.dht
 
+import com.datastax.spark.connector.rdd.partitioner.MonotonicBucketing
+import com.datastax.spark.connector.rdd.partitioner.MonotonicBucketing.LongBucketing
+
 trait Token[T] extends Ordered[Token[T]] {
+  def ord: Ordering[T]
   def value: T
 }
+
 
 case class LongToken(value: Long) extends Token[Long] {
   override def compare(that: Token[Long]) = value.compareTo(that.value)
   override def toString = value.toString
+  override def ord: Ordering[Long] = implicitly[Ordering[Long]]
+}
+
+object LongToken {
+
+  // Will work both for MonotonicOrdering[Token[Long]] and MonotonicOrdering[LongToken]
+  // because MonotonicOrdering is contravariant on T
+  implicit object LongTokenBucketing extends MonotonicBucketing[Token[Long]] {
+    override def bucket(n: Int): Token[Long] => Int = {
+      val longBucket = LongBucketing.bucket(n)
+      x => longBucket(x.value)
+    }
+  }
+
+  // Ordering[T] is not contravariant, so despite getting an automatic Ordering[Token[Long]] for free
+  // (because it is Ordered), we don't get a similar Ordering[LongToken].
+  // Therefore we have to define it here:
+  implicit val LongTokenOrdering: Ordering[LongToken] =
+    Ordering.by(_.value)
 }
 
 case class BigIntToken(value: BigInt) extends Token[BigInt] {
   override def compare(that: Token[BigInt]) = value.compare(that.value)
   override def toString = value.toString()
+
+  override def ord: Ordering[BigInt] = implicitly[Ordering[BigInt]]
 }
 
+object BigIntToken {
+
+  // Will work both for MonotonicOrdering[Token[Long]] and MonotonicOrdering[BigIntToken],
+  // because MonotonicOrdering is contravariant on T
+  implicit object BigIntTokenBucketing extends MonotonicBucketing[Token[BigInt]] {
+    override def bucket(n: Int): Token[BigInt] => Int = {
+      val shift = 127 - MonotonicBucketing.log2(n).toInt
+      def clamp(x: BigInt): BigInt = if (x == BigInt(-1)) BigInt(0) else x
+      x => (clamp(x.value) >> shift).toInt
+    }
+  }
+
+  // Ordering[T] is not contravariant, so despite getting an automatic Ordering[Token[BigInt]] for free
+  // (because it is Ordered), we don't get a similar Ordering[BigIntToken].
+  // Therefore we have to define it here:
+  implicit val BigIntTokenOrdering: Ordering[BigIntToken] =
+    Ordering.by(_.value)
+}
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/dht/TokenRange.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/dht/TokenRange.scala
@@ -2,20 +2,33 @@ package com.datastax.spark.connector.rdd.partitioner.dht
 
 import java.net.InetAddress
 
-
 case class TokenRange[V, T <: Token[V]] (
     start: T, end: T, replicas: Set[InetAddress], dataSize: Long) {
 
-  def isWrapAround: Boolean =
-    start >= end
+  def isWrappedAround(implicit tf: TokenFactory[V, T]): Boolean =
+    start >= end && end != tf.minToken
 
-  def unwrap(implicit tokenFactory: TokenFactory[V, T]): Seq[TokenRange[V, T]] = {
-    val minToken = tokenFactory.minToken
-    if (isWrapAround)
+  def isFull(implicit tf: TokenFactory[V, T]): Boolean =
+    start == end && end == tf.minToken
+
+  def isEmpty(implicit tf: TokenFactory[V, T]): Boolean =
+    start == end && end != tf.minToken
+
+  def unwrap(implicit tf: TokenFactory[V, T]): Seq[TokenRange[V, T]] = {
+    val minToken = tf.minToken
+    if (isWrappedAround)
       Seq(
         TokenRange(start, minToken, replicas, dataSize / 2),
         TokenRange(minToken, end, replicas, dataSize / 2))
     else
       Seq(this)
   }
+
+  def contains(token: T)(implicit tf: TokenFactory[V, T]): Boolean = {
+    (end == tf.minToken && token > start
+      || start == tf.minToken && token <= end
+      || !isWrappedAround && token > start && token <= end
+      || isWrappedAround && (token > start || token <= end))
+  }
 }
+

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/PatitionKeyTools.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/PatitionKeyTools.scala
@@ -1,0 +1,36 @@
+package com.datastax.spark.connector.util
+
+import java.io.IOException
+
+import com.datastax.driver.core.{PreparedStatement, Session}
+import com.datastax.spark.connector.cql.{ColumnDef, TableDef}
+import com.datastax.spark.connector.util.Quote._
+
+import scala.collection.Seq
+
+object PatitionKeyTools {
+  /**
+    * This query is only used to build a prepared statement so we can more easily extract
+    * partition tokens from tables. We prepare a statement of the form SELECT * FROM keyspace.table
+    * where x= .... This statement is never executed.
+    */
+  private[connector] def querySelectUsingOnlyPartitionKeys(tableDef: TableDef): String = {
+    val partitionKeys = tableDef.partitionKey
+    def quotedColumnNames(columns: Seq[ColumnDef]) = partitionKeys.map(_.columnName).map(quote)
+    val whereClause = quotedColumnNames(partitionKeys).map(c => s"$c = :$c").mkString(" AND ")
+    s"SELECT * FROM ${quote(tableDef.keyspaceName)}.${quote(tableDef.tableName)} WHERE $whereClause"
+  }
+
+  private[connector] def prepareDummyStatement(session: Session, tableDef: TableDef): PreparedStatement = {
+    try {
+      session.prepare(querySelectUsingOnlyPartitionKeys(tableDef))
+    }
+    catch {
+      case t: Throwable =>
+        throw new IOException(
+          s"""Failed to prepare statement
+             | ${querySelectUsingOnlyPartitionKeys(tableDef)}: """.stripMargin + t.getMessage, t)
+    }
+  }
+
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/ReplicaLocator.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/ReplicaLocator.scala
@@ -7,7 +7,7 @@ import java.net.InetAddress
 import com.datastax.driver.core._
 import com.datastax.spark.connector.ColumnSelector
 import com.datastax.spark.connector.cql._
-import com.datastax.spark.connector.util.Quote._
+import com.datastax.spark.connector.util.PatitionKeyTools._
 import org.apache.spark.Logging
 
 import scala.collection.JavaConversions._
@@ -28,28 +28,6 @@ class ReplicaLocator[T] private(
   val columnNames = rowWriter.columnNames
 
   /**
-   * This query is only used to build a prepared statement so we can more easily extract
-   * partition tokens from tables. We prepare a statement of the form SELECT * FROM keyspace.table
-   * where x= .... This statement is never executed.
-   */
-  private lazy val querySelectUsingOnlyPartitionKeys: String = {
-    val partitionKeys = tableDef.partitionKey
-    def quotedColumnNames(columns: Seq[ColumnDef]) = partitionKeys.map(_.columnName).map(quote)
-    val whereClause = quotedColumnNames(partitionKeys).map(c => s"$c = :$c").mkString(" AND ")
-    s"SELECT * FROM ${quote(keyspaceName)}.${quote(tableName)} WHERE $whereClause"
-  }
-
-  private def prepareDummyStatement(session: Session): PreparedStatement = {
-    try {
-      session.prepare(querySelectUsingOnlyPartitionKeys)
-    }
-    catch {
-      case t: Throwable =>
-        throw new IOException(s"Failed to prepare statement $querySelectUsingOnlyPartitionKeys: " + t.getMessage, t)
-    }
-  }
-
-  /**
    * Pairs each piece of data with the Cassandra Replicas which that data would be found on
    * @param data A source of data which can be bound to a statement by BatchStatementBuilder
    * @return an Iterator over the same data keyed by the replica's ip addresses
@@ -57,7 +35,7 @@ class ReplicaLocator[T] private(
   def keyByReplicas(data: Iterator[T]): Iterator[(scala.collection.immutable.Set[InetAddress], T)] = {
       connector.withSessionDo { session =>
         val protocolVersion = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersion
-        val stmt = prepareDummyStatement(session)
+        val stmt = prepareDummyStatement(session, tableDef)
         val routingKeyGenerator = new RoutingKeyGenerator(tableDef, columnNames)
         val boundStmtBuilder = new BoundStatementBuilder(rowWriter, stmt, protocolVersion = protocolVersion)
         val clusterMetadata = session.getCluster.getMetadata
@@ -91,5 +69,4 @@ object ReplicaLocator {
     )
     new ReplicaLocator[T](connector, tableDef, rowWriter)
   }
-
 }

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSourceRelation.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSourceRelation.scala
@@ -15,7 +15,7 @@ import org.apache.spark.{Logging, SparkConf}
 
 import com.datastax.driver.core.Metadata
 import com.datastax.spark.connector.cql.{CassandraConnector, CassandraConnectorConf, Schema}
-import com.datastax.spark.connector.rdd.partitioner.CassandraRDDPartitioner._
+import com.datastax.spark.connector.rdd.partitioner.CassandraPartitionGenerator._
 import com.datastax.spark.connector.rdd.partitioner.DataSizeEstimates
 import com.datastax.spark.connector.rdd.{CassandraRDD, ReadConf}
 import com.datastax.spark.connector.types.{InetType, UUIDType, VarIntType}

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/partitioner/BucketingRangeIndexSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/partitioner/BucketingRangeIndexSpec.scala
@@ -1,0 +1,164 @@
+package com.datastax.spark.connector.rdd.partitioner
+
+import scala.util.Random
+
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FlatSpec, ShouldMatchers}
+
+import com.datastax.spark.connector.rdd.partitioner.dht.TokenFactory.{Murmur3TokenFactory, RandomPartitionerTokenFactory}
+import com.datastax.spark.connector.rdd.partitioner.dht.{BigIntToken, LongToken, TokenRange}
+
+class BucketingRangeIndexSpec extends FlatSpec with PropertyChecks with ShouldMatchers {
+
+  private val clusterSize = 1000 * 16
+
+  private implicit object TupleBounds extends RangeBounds[(Int, Int), Int] {
+    override def start(range: (Int, Int)): Int =
+      range._1
+    override def end(range: (Int, Int)): Int =
+      range._2
+    override def isFull(range: (Int, Int)): Boolean =
+      range._1 == range._2
+    override def contains(range: (Int, Int), point: Int): Boolean =
+      if (range._2 <= range._1)
+        point >= range._1 || point < range._2
+      else
+        point >= range._1 && point < range._2
+  }
+
+  /** Creates non overlapping random rangesContaining */
+  private def randomRanges(n: Int): Seq[(Int, Int)] = {
+    val randomInts =
+      (Int.MinValue +: Iterator.continually(Random.nextInt()).take(n).toSeq :+ Int.MaxValue)
+        .distinct
+        .sortBy(identity)
+    val randomRanges = for (Seq(a, b) <- randomInts.sliding(2).toSeq) yield (a, b)
+    randomRanges
+  }
+
+  "BucketingRangeIndex" should "find ranges containing given point when ranges do not overlap" in {
+    val index = new BucketingRangeIndex(randomRanges(clusterSize))
+    for (x <- Iterator.continually(Random.nextInt()).take(100000)) {
+      val containingRanges = index.rangesContaining(x)
+      assert(containingRanges.size == 1)
+      assert(x >= containingRanges.head._1)
+      assert(x < containingRanges.head._2)
+    }
+  }
+
+  it should "find ranges containing given point when ranges do overlap" in {
+    val index = new BucketingRangeIndex(
+      randomRanges(clusterSize) ++ randomRanges(clusterSize) ++ randomRanges(clusterSize))
+    for (x <- Iterator.continually(Random.nextInt()).take(100000)) {
+      val containingRanges = index.rangesContaining(x)
+      assert(containingRanges.size == 3)
+      assert(containingRanges forall (x >= _._1))
+      assert(containingRanges forall (x < _._2))
+    }
+  }
+
+  it should "find proper ranges when they wrap around" in {
+    val range1 = (0, 0)                         // full range
+    val range2 = (Int.MaxValue, Int.MinValue)   // only MaxValue included
+    val range3 = (Int.MaxValue, 0)              // lower half
+    val index = new BucketingRangeIndex(Seq(range1, range2, range3))
+    assert(index.rangesContaining(0) == Seq(range1))
+    assert(index.rangesContaining(Int.MaxValue) == Seq(range1, range2, range3))
+    assert(index.rangesContaining(Int.MaxValue / 2) == Seq(range1))
+    assert(index.rangesContaining(Int.MinValue) == Seq(range1, range3))
+    assert(index.rangesContaining(Int.MinValue / 2) == Seq(range1, range3))
+  }
+
+  def randomBigIntToken(): BigIntToken =
+    BigIntToken(BigInt(127, Random).abs)
+
+  val bigIntTokens = Gen.const(1).map(_ => randomBigIntToken())
+  val longTokens = Gen.choose(Long.MinValue, Long.MaxValue).map(LongToken.apply)
+  val positiveIntegers = Gen.choose(1, Int.MaxValue)
+
+  "LongTokenBucketing" should "respect the required bucket range" in {
+    val bucketing = implicitly[MonotonicBucketing[LongToken]]
+    forAll(longTokens, positiveIntegers) { (t: LongToken, n: Int) =>
+      val b = bucketing.bucket(n)(t)
+      assert(b >= 0)
+      assert(b < n)
+    }
+  }
+
+  it should "be weakly monotonic" in {
+    val bucketing = implicitly[MonotonicBucketing[LongToken]]
+    forAll(longTokens, longTokens, positiveIntegers) { (t1: LongToken, t2: LongToken, n: Int) =>
+      val b1 = bucketing.bucket(n)(t1)
+      val b2 = bucketing.bucket(n)(t2)
+      assert(t1 == t2 && b1 == b2 || t1 < t2 && b1 <= b2 || t1 > t2 && b1 >= b2)
+    }
+  }
+
+  "BigIntTokenBucketing" should "respect the required bucket range" in {
+    val bucketing = implicitly[MonotonicBucketing[BigIntToken]]
+    forAll(bigIntTokens, positiveIntegers) { (t: BigIntToken, n: Int) =>
+      val b = bucketing.bucket(n)(t)
+      assert(b >= 0)
+      assert(b < n)
+    }
+  }
+
+  it should "be weakly monotonic" in {
+    val bucketing = implicitly[MonotonicBucketing[BigIntToken]]
+    forAll(bigIntTokens, bigIntTokens, positiveIntegers) { (t1: BigIntToken, t2: BigIntToken, n: Int) =>
+      val b1 = bucketing.bucket(n)(t1)
+      val b2 = bucketing.bucket(n)(t2)
+      assert(t1 == t2 && b1 == b2 || t1 < t2 && b1 <= b2 || t1 > t2 && b1 >= b2)
+    }
+  }
+
+  private type LTR = TokenRangeWithPartitionIndex[Long, LongToken]
+  private type LT = LongToken
+  private type LV = Long
+
+  private val longTokenFactory = Murmur3TokenFactory
+
+  private val LongFullRange = TokenRange[LV, LT](
+      longTokenFactory.minToken,
+      longTokenFactory.minToken,
+      Set.empty,
+      0)
+
+
+  "Murmur3Bucketing" should "  map all tokens to a single wrapping range" in {
+    val singleRangeBucketing =
+      new BucketingRangeIndex[LTR, LT](Seq(TokenRangeWithPartitionIndex(LongFullRange, 0)))
+
+    for (tokenValue <- Iterator.continually(Random.nextLong()).take(100000)) {
+      val token = LongToken(tokenValue)
+      singleRangeBucketing.rangesContaining(token).headOption shouldBe defined
+      singleRangeBucketing.rangesContaining(token).head.partitionIndex should be(0)
+    }
+  }
+
+  private type BITR = TokenRangeWithPartitionIndex[BigInt, BigIntToken]
+  private type BT = BigIntToken
+  private type BV = BigInt
+
+  private val bigTokenFactory = RandomPartitionerTokenFactory
+  private val bigFullRange = TokenRange[BV, BT](
+      bigTokenFactory.minToken,
+      bigTokenFactory.minToken,
+      Set.empty,
+      0)
+
+
+  "RandomBucketing" should " map all tokens to a single wrapping range" in {
+     val singleRangeBucketing =
+      new BucketingRangeIndex[BITR, BT](Seq(TokenRangeWithPartitionIndex(bigFullRange, 0)))
+
+    for (tokenValue <- Iterator.continually(Random.nextLong().abs).take(100000)) {
+      val token = BigIntToken(tokenValue)
+      singleRangeBucketing.rangesContaining(token).headOption shouldBe defined
+      singleRangeBucketing.rangesContaining(token).head.partitionIndex should be(0)
+    }
+
+
+  }
+}

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/partitioner/dht/TokenRangeSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/partitioner/dht/TokenRangeSpec.scala
@@ -1,0 +1,68 @@
+package com.datastax.spark.connector.rdd.partitioner.dht
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import com.datastax.driver.core.{TokenRange => DTokenRange, Token => DToken}
+
+class TokenRangeSpec extends FlatSpec with Matchers  {
+
+  type LongRange = TokenRange[Long, LongToken]
+  type BigRange = TokenRange[BigInt, BigIntToken]
+
+
+  "LongRanges " should " contain tokens with easy no wrapping bounds" in {
+    val lr = new LongRange(LongToken(-100), LongToken(10000), Set.empty, 0)
+    //Tokens Inside
+    for (l <- 1 to 1000) {
+      lr.contains(LongToken(l)) should be (true)
+    }
+
+    //Tokens outside
+    for (l <- -500 to -300) {
+      lr.contains((LongToken(l))) should be (false)
+    }
+  }
+
+  it should " contain tokens with wrapping bounds in" in {
+    val lr = new LongRange(LongToken(1000), LongToken(-1000), Set.empty, 0)
+
+    //Tokens Inside
+    for (l <- 30000 to 30500) {
+      lr.contains((LongToken(l))) should be(true)
+    }
+
+    //Tokens outside
+    for (l <- -500 to 500) {
+      lr.contains(LongToken(l)) should be(false)
+    }
+
+  }
+
+  "BigRanges " should " contain tokens with easy no wrapping bounds" in {
+    val lr = new BigRange(BigIntToken(-100), BigIntToken(10000), Set.empty, 0)
+    //Tokens Inside
+    for (l <- 1 to 1000) {
+      lr.contains(BigIntToken(l)) should be (true)
+    }
+
+    //Tokens outside
+    for (l <- -500 to -300) {
+      lr.contains((BigIntToken(l))) should be (false)
+    }
+  }
+
+  it should " contain tokens with wrapping bounds in" in {
+    val lr = new BigRange(BigIntToken(1000), BigIntToken(100), Set.empty, 0)
+
+    //Tokens Inside
+    for (l <- 0 to 50) {
+      lr.contains(BigIntToken(l)) should be (true)
+    }
+
+    //Tokens outside
+    for (l <- 200 to 500) {
+      lr.contains((BigIntToken(l))) should be (false)
+    }
+  }
+
+}


### PR DESCRIPTION
Currently once a CassandraTableScanRDD is created there is no mapping back to the partitioning that created it. For limited instances we can can use the partitioning that created the TableScanRDD to remove the need for shuffles during some spark joins. 

To this purpose we enhance the .keyBy method of C*TableScanRDD to automatically create a Spark Partitioner class for the tablescan RDD if it is valid. This partitioner can then be shared with other RDD's with the same key type and partitioning. When joined these new table will not require a shuffle