### PR TITLE
SPARKC-356 fix itegration test classpath

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -24,7 +24,6 @@ import com.typesafe.sbt.SbtScalariform
 import com.typesafe.sbt.SbtScalariform._
 import com.typesafe.tools.mima.plugin.MimaKeys._
 import com.typesafe.tools.mima.plugin.MimaPlugin._
-import net.virtualvoid.sbt.graph.Plugin.graphSettings
 import sbt.Keys._
 import sbt.Tests._
 import sbt._
@@ -135,7 +134,7 @@ object Settings extends Build {
 
   val installSparkTask = taskKey[Unit]("Optionally install Spark from Git to local Maven repository")
 
-  lazy val projectSettings = graphSettings ++ Seq(
+  lazy val projectSettings = Seq(
 
     concurrentRestrictions in Global += Tags.limit(Tags.Test, parallelTasks),
 
@@ -290,7 +289,7 @@ object Settings extends Build {
     }.toSeq
   }
 
-  lazy val testSettings = testConfigs ++ testArtifacts ++ graphSettings ++ Seq(
+  lazy val testSettings = testConfigs ++ testArtifacts ++ Seq(
     parallelExecution in Test := true,
     parallelExecution in IntegrationTest := true,
     javaOptions in IntegrationTest ++= TEST_JAVA_OPTS,

--- a/project/SparkCassandraConnectorBuild.scala
+++ b/project/SparkCassandraConnectorBuild.scala
@@ -145,9 +145,10 @@ object Artifacts {
     def sparkExclusions: ModuleID = module.guavaExclude
       .exclude("org.apache.spark", s"spark-core_$scalaBinary")
 
-    def logbackExclude: ModuleID = module
+    def cassandraExclusions: ModuleID = module
       .exclude("ch.qos.logback", "logback-classic")
       .exclude("ch.qos.logback", "logback-core")
+      .exclude("org.slf4j", "log4j-over-slf4j")
 
     def replExclusions: ModuleID = module.guavaExclude
       .exclude("org.apache.spark", s"spark-bagel_$scalaBinary")
@@ -159,6 +160,9 @@ object Artifacts {
       .exclude("com.sun.jmx", "jmxri")
       .exclude("com.sun.jdmk", "jmxtools")
       .exclude("net.sf.jopt-simple", "jopt-simple")
+
+    def sparkTestExclusions: ModuleID = module.guavaExclude
+      .exclude("org.slf4j", "slf4j-api")
   }
 
   val akkaActor           = "com.typesafe.akka"       %% "akka-actor"            % Akka           % "provided"  // ApacheV2
@@ -185,7 +189,7 @@ object Artifacts {
   val sparkCatalyst       = "org.apache.spark"        %% "spark-catalyst"        % Spark sparkExclusions        // ApacheV2
   val sparkHive           = "org.apache.spark"        %% "spark-hive"            % Spark sparkExclusions        // ApacheV2
 
-  val cassandraServer     = "org.apache.cassandra"    % "cassandra-all"          % Settings.cassandraTestVersion      logbackExclude    // ApacheV2
+  val cassandraServer     = "org.apache.cassandra"    % "cassandra-all"          % Settings.cassandraTestVersion      cassandraExclusions    // ApacheV2
 
   object Metrics {
     val metricsCore       = "com.codahale.metrics"    % "metrics-core"           % CodaHaleMetrics % "provided"
@@ -218,8 +222,8 @@ object Artifacts {
     val scalaMock         = "org.scalamock"           %% "scalamock-scalatest-support"  % ScalaMock % "test,it"       // BSD
     val scalaTest         = "org.scalatest"           %% "scalatest"                    % ScalaTest % "test,it"       // ApacheV2
     val scalactic         = "org.scalactic"           %% "scalactic"                    % Scalactic % "test,it"       // ApacheV2
-    val sparkCoreT        = "org.apache.spark"        %% "spark-core"                   % Spark     % "test,it" classifier "tests"
-    val sparkStreamingT   = "org.apache.spark"        %% "spark-streaming"              % Spark     % "test,it" classifier "tests"
+    val sparkCoreT        = "org.apache.spark"        %% "spark-core"                   % Spark     % "test,it" classifier "tests" sparkTestExclusions
+    val sparkStreamingT   = "org.apache.spark"        %% "spark-streaming"              % Spark     % "test,it" classifier "tests" sparkTestExclusions
     val mockito           = "org.mockito"             % "mockito-all"                   % "1.10.19" % "test,it"       // MIT
     val junit             = "junit"                   % "junit"                         % "4.11"    % "test,it"
     val junitInterface    = "com.novocode"            % "junit-interface"               % "0.10"    % "test,it"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -34,7 +34,7 @@ object Versions {
   val CommonsIO       = "2.4"
   val CommonsLang3    = "3.3.2"
   val Config          = "1.2.1"
-  val Guava           = "16.0.1"
+  val Guava           = "18.0"
   val JDK             = "1.7"
   val JodaC           = "1.2"
   val JodaT           = "2.3"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 // pulls in: sbt-pgp, sbt-release, sbt-mima-plugin, sbt-dependency-graph, sbt-buildinfo, sbt-sonatype
 // TODO use sbt-release plugin
-addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.3.1")
+addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.3.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.4")
 


### PR DESCRIPTION
Old guava and slf4j made running integration tests within idea
impossible. This commit removes these two dependencies from test
classpath.

Now it is possible to run/debug integration tests within idea. Before
running tests specify -DbaseDir=<xyz> parameter.