### PR TITLE
Sparkc 357 support for C* Tuples in Dataframes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ project/boot/
 project/plugins/project/
 sbt/sbt-launch*.jar
 cassandra-server/*
+metastore_db
 
 # Scala-IDE specific
 .scala_dependencies

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+ * Fix support for C* Tuples in Dataframes (SPARKC-357)
+
 1.6.0 M2
  * Performance improvement: keyBy creates an RDD with CassandraPartitioner 
    so shuffling can be avoided in many cases, e.g. when keyBy is followed

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/TupleValue.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/TupleValue.scala
@@ -7,8 +7,12 @@ import org.apache.spark.sql.catalyst.ReflectionLock.SparkReflectionLock
 import com.datastax.driver.core.{TupleValue => DriverTupleValue}
 import com.datastax.spark.connector.types.NullableTypeConverter
 
-final case class TupleValue(values: Any*) extends ScalaGettableByIndexData {
+final case class TupleValue(values: Any*) extends ScalaGettableByIndexData with Product {
   override def columnValues = values.toIndexedSeq.map(_.asInstanceOf[AnyRef])
+
+  override def productArity: Int = columnValues.size
+
+  override def productElement(n: Int): Any = getRaw(n)
 }
 
 object TupleValue {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TupleType.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TupleType.scala
@@ -8,6 +8,7 @@ import scala.reflect.runtime.universe._
 
 import org.apache.commons.lang3.tuple.{Triple, Pair}
 import org.apache.spark.sql.catalyst.ReflectionLock.SparkReflectionLock
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 
 import com.datastax.driver.core.{TupleValue => DriverTupleValue, TupleType => DriverTupleType, DataType}
 import com.datastax.spark.connector.{TupleValue, ColumnName}
@@ -69,6 +70,8 @@ case class TupleType(componentTypes: TupleFieldDef*)
       override def targetTypeTag = TupleValue.TypeTag
 
       override def convertPF = {
+        case x: GenericRowWithSchema =>
+          newInstance(componentConverters)(x.toSeq: _*)
         case x: TupleValue =>
           newInstance(componentConverters)(x.columnValues: _*)
         case x: Product => // converts from Scala tuples

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSQLRow.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSQLRow.scala
@@ -86,7 +86,7 @@ object CassandraSQLRow {
       case list: List[_] => list.map(toSparkSqlType)
       case map: Map[_, _] => map map { case(k, v) => (toSparkSqlType(k), toSparkSqlType(v))}
       case udt: UDTValue => UDTValue(udt.columnNames, udt.columnValues.map(toSparkSqlType))
-      case tupleValue: TupleValue => TupleValue(tupleValue.values.map(toSparkSqlType))
+      case tupleValue: TupleValue => TupleValue(tupleValue.values.map(toSparkSqlType): _*)
       case _ => value.asInstanceOf[AnyRef]
     }
   }


### PR DESCRIPTION
Fix support for C* Tuples in Dataframes.

This commit adds conversion methods. C* Tuples are converted to catylyst's StructType with index.toString as name.

TupleValue implements Product to allow catalyst properly iterate over it's values.

Also added some test for RDD and C* Tuples.