### PR TITLE
SPARKC-338-b1.5: Change DF ErrorIfExists Message

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+1.5.0
  * Fixed assembly build (SPARKC-311)
  * Upgrade Cassandra version to 3.0.2 by default and allow to specify arbitrary Cassandra version for
    integration tests through the command line (SPARKC-307)

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ This project has been published to the Maven Central Repository.
 For SBT to download the connector binaries, sources and javadoc, put this in your project 
 SBT config:
                                                                                                                            
-    libraryDependencies += "com.datastax.spark" %% "spark-cassandra-connector" % "1.5.0-RC1"
+    libraryDependencies += "com.datastax.spark" %% "spark-cassandra-connector" % "1.5.0"
 
 If you want to access the functionality of Connector from Java, you may want to add also a Java API module:
 
-    libraryDependencies += "com.datastax.spark" %% "spark-cassandra-connector-java" % "1.5.0-RC1"
+    libraryDependencies += "com.datastax.spark" %% "spark-cassandra-connector-java" % "1.5.0"
 
 ## Building
 See [Building And Artifacts](doc/12_building_and_artifacts.md)


### PR DESCRIPTION
The current message makes it seem as if there is no way to insert to a
C* table if there is data within it. This patch changes the message so
it is clear that the error is because of the save mode and suggests a
workaround if Append behavior was expected.