### PR TITLE
per-batch wrapup statements

### DIFF
--- a/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/DStreamJavaFunctions.java
+++ b/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/DStreamJavaFunctions.java
@@ -3,10 +3,15 @@ package com.datastax.spark.connector.japi;
 import com.datastax.spark.connector.ColumnSelector;
 import com.datastax.spark.connector.cql.CassandraConnector;
 import com.datastax.spark.connector.streaming.DStreamFunctions;
+import com.datastax.spark.connector.writer.BatchWrapupBuilder;
+import com.datastax.spark.connector.writer.JavaBatchWrapupBuilderFactory;
 import com.datastax.spark.connector.writer.RowWriterFactory;
 import com.datastax.spark.connector.writer.WriteConf;
 import org.apache.spark.SparkConf;
 import org.apache.spark.streaming.dstream.DStream;
+import scala.Function0;
+import scala.None$;
+import scala.Option;
 
 /**
  * A Java API wrapper over {@link DStream} to provide Spark Cassandra Connector functionality.
@@ -37,6 +42,14 @@ public class DStreamJavaFunctions<T> extends RDDAndDStreamCommonJavaFunctions<T>
     @Override
     protected void saveToCassandra(String keyspace, String table, RowWriterFactory<T> rowWriterFactory,
                                    ColumnSelector columnNames, WriteConf conf, CassandraConnector connector) {
-        dsf.saveToCassandra(keyspace, table, columnNames, conf, connector, rowWriterFactory);
+        dsf.saveToCassandra(keyspace, table, columnNames, conf, None$.<Function0<BatchWrapupBuilder<T>>>empty(), connector, rowWriterFactory);
+    }
+
+    @Override
+    protected void saveToCassandra(String keyspace, String table, RowWriterFactory<T> rowWriterFactory,
+                                   ColumnSelector columnNames, WriteConf conf,
+                                   JavaBatchWrapupBuilderFactory<T> wrapupBuilder, CassandraConnector connector) {
+        dsf.saveToCassandra(keyspace, table, columnNames, conf,
+                Option.apply((Function0<BatchWrapupBuilder<T>>)wrapupBuilder), connector, rowWriterFactory);
     }
 }

--- a/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/RDDAndDStreamCommonJavaFunctions.java
+++ b/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/RDDAndDStreamCommonJavaFunctions.java
@@ -45,10 +45,15 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
     protected abstract void saveToCassandra(String keyspace, String table, RowWriterFactory<T> rowWriterFactory,
                                             ColumnSelector columnNames, WriteConf conf, CassandraConnector connector);
 
-    /**
-     * @deprecated this method will be removed in future release, please use {@link #writerBuilder(String, String,
-     * com.datastax.spark.connector.writer.RowWriterFactory)}
-     */
+
+    protected abstract void saveToCassandra(String keyspace, String table, RowWriterFactory<T> rowWriterFactory,
+                                            ColumnSelector columnNames, WriteConf conf,
+                                            JavaBatchWrapupBuilderFactory<T> wrapupBuilder, CassandraConnector connector);
+
+        /**
+         * @deprecated this method will be removed in future release, please use {@link #writerBuilder(String, String,
+         * com.datastax.spark.connector.writer.RowWriterFactory)}
+         */
     @Deprecated
     public void saveToCassandra(String keyspace, String table, RowWriterFactory<T> rowWriterFactory, ColumnSelector columnNames) {
         new WriterBuilder(keyspace, table, rowWriterFactory, columnNames, defaultConnector(), defaultWriteConf()).saveToCassandra();
@@ -177,7 +182,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                     new WriteConf(batchSize, writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                         writeConf.consistencyLevel(), writeConf.ignoreNulls(), writeConf.parallelismLevel(),
-                        writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
+                        writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled(), writeConf.batchType()));
             else
                 return this;
         }
@@ -195,7 +200,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), batchGroupingBufferSize, writeConf.batchGroupingKey(),
                         writeConf.consistencyLevel(), writeConf.ignoreNulls(), writeConf.parallelismLevel(),
-                        writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
+                        writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled(), writeConf.batchType()));
             else
                 return this;
         }
@@ -213,7 +218,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), batchGroupingKey,
                         writeConf.consistencyLevel(), writeConf.ignoreNulls(), writeConf.parallelismLevel(),
-                        writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
+                        writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled(), writeConf.batchType()));
             else
                 return this;
         }
@@ -231,7 +236,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                         consistencyLevel, writeConf.ignoreNulls(), writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
-                        writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
+                        writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled(), writeConf.batchType()));
             else
                 return this;
         }
@@ -249,7 +254,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                         writeConf.consistencyLevel(), writeConf.ignoreNulls(), parallelismLevel, writeConf.throughputMiBPS(),
-                        writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
+                        writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled(), writeConf.batchType()));
             else
                 return this;
         }
@@ -267,7 +272,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                         writeConf.consistencyLevel(), writeConf.ignoreNulls(), writeConf.parallelismLevel(), throughputMBPS,
-                        writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
+                        writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled(), writeConf.batchType()));
             else
               return this;
         }
@@ -285,7 +290,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                         new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                                 writeConf.consistencyLevel(), writeConf.ignoreNulls(), writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
-                                writeConf.ttl(), writeConf.timestamp(), taskMetricsEnabled));
+                                writeConf.ttl(), writeConf.timestamp(), taskMetricsEnabled, writeConf.batchType()));
             else
                 return this;
         }
@@ -302,7 +307,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                         new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                                 writeConf.consistencyLevel(), ignoreNulls, writeConf.parallelismLevel(), writeConf.throughputMiBPS(),
-                                writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
+                                writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled(), writeConf.batchType()));
             else
                 return this;
         }
@@ -320,7 +325,8 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                     writeConf.throughputMiBPS(),
                     writeConf.ttl(),
                     timestamp,
-                    writeConf.taskMetricsEnabled()));
+                    writeConf.taskMetricsEnabled(),
+                    writeConf.batchType()));
         }
 
 
@@ -400,7 +406,8 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                     writeConf.throughputMiBPS(),
                     ttl,
                     writeConf.timestamp(),
-                    writeConf.taskMetricsEnabled()));
+                    writeConf.taskMetricsEnabled(),
+                    writeConf.batchType()));
         }
 
         /**

--- a/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/RDDJavaFunctions.java
+++ b/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/RDDJavaFunctions.java
@@ -1,7 +1,11 @@
 package com.datastax.spark.connector.japi;
 
 import com.datastax.spark.connector.rdd.reader.RowReader;
+import com.datastax.spark.connector.writer.BatchWrapupBuilder;
 import com.datastax.spark.connector.writer.RowWriter;
+import com.datastax.spark.connector.writer.JavaBatchWrapupBuilderFactory;
+import scala.Function0;
+import scala.None$;
 import scala.Option;
 import scala.Tuple2;
 import scala.reflect.ClassTag;
@@ -58,7 +62,20 @@ public class RDDJavaFunctions<T> extends RDDAndDStreamCommonJavaFunctions<T> {
             WriteConf conf,
             CassandraConnector connector
     ) {
-        rddFunctions.saveToCassandra(keyspace, table, columnNames, conf, connector, rowWriterFactory);
+        rddFunctions.saveToCassandra(keyspace, table, columnNames, conf, None$.<Function0<BatchWrapupBuilder<T>>>empty(), connector, rowWriterFactory);
+    }
+
+    public void saveToCassandra(
+            String keyspace,
+            String table,
+            RowWriterFactory<T> rowWriterFactory,
+            ColumnSelector columnNames,
+            WriteConf conf,
+            JavaBatchWrapupBuilderFactory<T> wrapupBuilder,
+            CassandraConnector connector
+    ) {
+        rddFunctions.saveToCassandra(keyspace, table, columnNames, conf,
+                Option.apply((Function0<BatchWrapupBuilder<T>>)wrapupBuilder), connector, rowWriterFactory);
     }
 
     /**

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/DStreamFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/DStreamFunctions.scala
@@ -44,13 +44,14 @@ class DStreamFunctions[T](dstream: DStream[T])
     keyspaceName: String,
     tableName: String,
     columnNames: ColumnSelector = AllColumns,
-    writeConf: WriteConf = WriteConf.fromSparkConf(conf))(
+    writeConf: WriteConf = WriteConf.fromSparkConf(conf),
+    wrapupBuilderFactory: Option[() => BatchWrapupBuilder[T]])(
   implicit
     connector: CassandraConnector = CassandraConnector(conf),
     rwf: RowWriterFactory[T]): Unit = {
     warnIfKeepAliveIsShort()
 
-    val writer = TableWriter(connector, keyspaceName, tableName, columnNames, writeConf)
+    val writer = TableWriter(connector, keyspaceName, tableName, columnNames, writeConf, wrapupBuilderFactory)
     dstream.foreachRDD(rdd => rdd.sparkContext.runJob(rdd, writer.write _))
   }
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/Batch.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/Batch.scala
@@ -5,22 +5,23 @@ import com.datastax.spark.connector.{BatchSize, BytesInBatch, RowsInBatch}
 import scala.collection.mutable.ArrayBuffer
 
 /** A simple wrapper over a collection of bound statements. */
-private[writer] sealed trait Batch extends Ordered[Batch] {
+private[writer] sealed trait Batch[T] extends Ordered[Batch[T]] {
   protected[Batch] val buf: ArrayBuffer[RichBoundStatement]
+  protected[Batch] val wrapupBuilder: Option[BatchWrapupBuilder[T]]
   protected[Batch] var _bytesCount = 0
   
   /** Returns `true` if the element has been successfully added. Returns `false` if the element
     * cannot be added because adding it would violate the size limitation. If `force` is set to `true`,
     * it adds the item regardless of size limitations and always returns `true`. */
-  def add(stmt: RichBoundStatement, force: Boolean = false): Boolean
+  def add(datum: T, stmt: RichBoundStatement, force: Boolean = false): Boolean
 
   /** Collected statements */
-  def statements: Seq[RichBoundStatement] = buf
+  def statements: Seq[RichBoundStatement] = buf ++ wrapupBuilder.map(_.build()).getOrElse(Seq.empty)
 
   /** Only for internal use - batches are compared by this value. */
   protected[Batch] def size: Int
 
-  override def compare(that: Batch): Int = size.compareTo(that.size)
+  override def compare(that: Batch[T]): Int = size.compareTo(that.size)
 
   /** Removes all the collected statements and resets this batch to the initial state. */
   def clear(): Unit = {
@@ -34,25 +35,26 @@ private[writer] sealed trait Batch extends Ordered[Batch] {
 
 private[writer] object Batch {
 
-  implicit val batchOrdering = Ordering.ordered[Batch]
+  implicit def batchOrdering[T] = Ordering.ordered[Batch[T]]
 
-  def apply(batchSize: BatchSize): Batch = {
+  def apply[T](batchSize: BatchSize, wrapupBuilder: Option[BatchWrapupBuilder[T]]): Batch[T] = {
     batchSize match {
-      case RowsInBatch(rows) => new RowLimitedBatch(rows)
-      case BytesInBatch(bytes) => new SizeLimitedBatch(bytes)
+      case RowsInBatch(rows) => new RowLimitedBatch(rows, wrapupBuilder)
+      case BytesInBatch(bytes) => new SizeLimitedBatch(bytes, wrapupBuilder)
     }
   }
 }
 
 /** The implementation which uses the number of items as a size constraint. */
-private[writer] class RowLimitedBatch(val maxRows: Int) extends Batch {
+private[writer] class RowLimitedBatch[T](val maxRows: Int, val wrapupBuilder: Option[BatchWrapupBuilder[T]]) extends Batch[T] {
   override protected[writer] val buf = new ArrayBuffer[RichBoundStatement](maxRows)
 
-  override def add(stmt: RichBoundStatement, force: Boolean = false): Boolean = {
+  override def add(datum: T, stmt: RichBoundStatement, force: Boolean = false): Boolean = {
     if (!force && buf.size >= maxRows) {
       false
     } else {
       buf += stmt
+      wrapupBuilder.foreach(_.add(datum))
       _bytesCount += stmt.bytesCount
       true
     }
@@ -63,15 +65,16 @@ private[writer] class RowLimitedBatch(val maxRows: Int) extends Batch {
 }
 
 /** The implementation which uses length in bytes as a size constraint. */
-private[writer] class SizeLimitedBatch(val maxBytes: Int) extends Batch {
+private[writer] class SizeLimitedBatch[T](val maxBytes: Int, val wrapupBuilder: Option[BatchWrapupBuilder[T]]) extends Batch[T] {
   override protected[writer] val buf = new ArrayBuffer[RichBoundStatement](10)
 
-  override def add(stmt: RichBoundStatement, force: Boolean = false): Boolean = {
+  override def add(datum: T, stmt: RichBoundStatement, force: Boolean = false): Boolean = {
     // buf.nonEmpty here is to allow adding at least a single statement regardless its size
     if (!force && (_bytesCount + stmt.bytesCount) > maxBytes) {
       false
     } else {
       buf += stmt
+      wrapupBuilder.foreach(_.add(datum))
       _bytesCount += stmt.bytesCount
       true
     }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/BatchWrapupBuilder.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/BatchWrapupBuilder.scala
@@ -1,0 +1,19 @@
+package com.datastax.spark.connector.writer
+
+import scala.collection.JavaConverters._
+
+trait BatchWrapupBuilder[T] extends Serializable {
+  def add(t: T): Unit
+  def build(): Seq[RichBoundStatement]
+}
+
+trait JavaBatchWrapupBuilder[T] extends BatchWrapupBuilder[T] {
+  def add(t: T): Unit
+  def buildIterable(): java.lang.Iterable[RichBoundStatement]
+  override def build(): Seq[RichBoundStatement] = buildIterable().asScala.toSeq
+}
+
+trait JavaBatchWrapupBuilderFactory[T] extends Function0[BatchWrapupBuilder[T]] with Serializable {
+  def get(): JavaBatchWrapupBuilder[T]
+  def apply: JavaBatchWrapupBuilder[T] = get()
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WritableToCassandra.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WritableToCassandra.scala
@@ -44,7 +44,8 @@ abstract class WritableToCassandra[T] {
   def saveToCassandra(keyspaceName: String,
                       tableName: String,
                       columnNames: ColumnSelector,
-                      writeConf: WriteConf)
+                      writeConf: WriteConf,
+                      wrapupBuilderFactory: Option[() => BatchWrapupBuilder[T]] = None)
                      (implicit connector: CassandraConnector, rwf: RowWriterFactory[T])
 
 }


### PR DESCRIPTION
WIP, but please take a look.

Code changes:
added `batchType` to `WriteConf` to enable use of logged batches,
added `WrapupBuilder[T]` to add some final statements to the batch based on batch contents.

Motivation:
Basically, I need to update some static columns inside a batch.
In my use case, those would be `min_offset`, `max_offset`, `min_ts`, `max_ts` (Kafka offsets for exactly-once delivery and timestamps extracted from data).
So, I would be adding four extra statements, like these:
`UPDATE ... SET min_offset=? WHERE topic=? AND topic_partition=? AND bucket=? IF min_offset>?`
`UPDATE ... SET max_offset=? WHERE topic=? AND topic_partition=? AND bucket=? IF max_offset<?`

The thing is that those must be in the same batch as the data on which those are based.

When I'll integrate this into my program, I'll post a snippet of how it could be used, but for now, just review this please.

Thanks!