### PR TITLE
SPARKC-360: Disable delayed retrying

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
@@ -89,7 +89,7 @@ object DefaultConnectionFactory extends CassandraConnectionFactory {
       .addContactPoints(conf.hosts.toSeq: _*)
       .withPort(conf.nativePort)
       .withRetryPolicy(
-        new MultipleRetryPolicy(conf.queryRetryCount, conf.queryRetryDelay))
+        new MultipleRetryPolicy(conf.queryRetryCount))
       .withReconnectionPolicy(
         new ExponentialReconnectionPolicy(conf.minReconnectionDelayMillis, conf.maxReconnectionDelayMillis))
       .withLoadBalancingPolicy(

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -29,6 +29,7 @@ case class CassandraConnectorConf(
   readTimeoutMillis: Int = CassandraConnectorConf.DefaultReadTimeoutMillis,
   connectionFactory: CassandraConnectionFactory = DefaultConnectionFactory,
   cassandraSSLConf: CassandraConnectorConf.CassandraSSLConf = CassandraConnectorConf.DefaultCassandraSSLConf,
+  @deprecated("delayed retrying has been disabled; see SPARKC-360", "1.2.6, 1.3.2, 1.4.3, 1.5.1")
   queryRetryDelay: CassandraConnectorConf.RetryDelayConf = CassandraConnectorConf.DefaultQueryRetryDelay
 )
 
@@ -48,10 +49,12 @@ object CassandraConnectorConf extends Logging {
     enabledAlgorithms: Set[String] = SSLOptions.DEFAULT_SSL_CIPHER_SUITES.toSet
   )
 
+  @deprecated("delayed retrying has been disabled; see SPARKC-360", "1.2.6, 1.3.2, 1.4.3, 1.5.1")
   trait RetryDelayConf {
     def forRetry(retryNumber: Int): Duration
   }
 
+  @deprecated("delayed retrying has been disabled; see SPARKC-360", "1.2.6, 1.3.2, 1.4.3, 1.5.1")
   object RetryDelayConf extends Serializable {
 
     case class ConstantDelay(delay: Duration) extends RetryDelayConf {
@@ -108,6 +111,7 @@ object CassandraConnectorConf extends Logging {
   val DefaultMinReconnectionDelayMillis = 1000
   val DefaultMaxReconnectionDelayMillis = 60000
   val DefaultQueryRetryCount = 10
+  @deprecated("delayed retrying has been disabled; see SPARKC-360", "1.2.6, 1.3.2, 1.4.3, 1.5.1")
   val DefaultQueryRetryDelay = RetryDelayConf.ExponentialDelay(4 seconds, 1.5d)
   val DefaultConnectTimeoutMillis = 5000
   val DefaultReadTimeoutMillis = 120000
@@ -184,8 +188,6 @@ object CassandraConnectorConf extends Logging {
     val minReconnectionDelay = conf.getInt(CassandraMinReconnectionDelayProperty, DefaultMinReconnectionDelayMillis)
     val maxReconnectionDelay = conf.getInt(CassandraMaxReconnectionDelayProperty, DefaultMaxReconnectionDelayMillis)
     val queryRetryCount = conf.getInt(CassandraQueryRetryCountProperty, DefaultQueryRetryCount)
-    val queryRetryDelay = RetryDelayConf.fromString(conf.get(CassandraQueryRetryDelayProperty, ""))
-      .getOrElse(DefaultQueryRetryDelay)
     val connectTimeout = conf.getInt(CassandraConnectionTimeoutProperty, DefaultConnectTimeoutMillis)
     val readTimeout = conf.getInt(CassandraReadTimeoutProperty, DefaultReadTimeoutMillis)
 
@@ -228,8 +230,7 @@ object CassandraConnectorConf extends Logging {
       connectTimeoutMillis = connectTimeout,
       readTimeoutMillis = readTimeout,
       connectionFactory = connectionFactory,
-      cassandraSSLConf = cassandraSSLConf,
-      queryRetryDelay = queryRetryDelay
+      cassandraSSLConf = cassandraSSLConf
     )
   }
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/MultipleRetryPolicy.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/MultipleRetryPolicy.scala
@@ -5,29 +5,56 @@ import com.datastax.driver.core.policies.RetryPolicy.RetryDecision
 import com.datastax.driver.core.{ConsistencyLevel, Statement, WriteType}
 
 /** Always retries with the same CL, constant number of times, regardless of circumstances */
-class MultipleRetryPolicy(maxRetryCount: Int, retryDelay: CassandraConnectorConf.RetryDelayConf)
+class MultipleRetryPolicy(maxRetryCount: Int)
   extends RetryPolicy {
 
-  private def retryOrThrow(cl: ConsistencyLevel, nbRetry: Int): RetryDecision = {
+  private def retryManyTimesOrThrow(cl: ConsistencyLevel, nbRetry: Int): RetryDecision = {
     if (nbRetry < maxRetryCount) {
-      if (nbRetry > 0) {
-        val delay = retryDelay.forRetry(nbRetry).toMillis
-        if (delay > 0) Thread.sleep(delay)
-      }
       RetryDecision.retry(cl)
     } else {
       RetryDecision.rethrow()
     }
   }
 
-  override def onReadTimeout(stmt: Statement, cl: ConsistencyLevel,
-                             requiredResponses: Int, receivedResponses: Int,
-                             dataRetrieved: Boolean, nbRetry: Int) = retryOrThrow(cl, nbRetry)
+  private def retryOnceOrThrow(cl: ConsistencyLevel, nbRetry: Int): RetryDecision = {
+    if (nbRetry == 0) {
+      RetryDecision.retry(cl)
+    } else {
+      RetryDecision.rethrow()
+    }
+  }
 
-  override def onUnavailable(stmt: Statement, cl: ConsistencyLevel,
-                             requiredReplica: Int, aliveReplica: Int, nbRetry: Int) = retryOrThrow(cl, nbRetry)
+  override def onReadTimeout(
+      stmt: Statement,
+      cl: ConsistencyLevel,
+      requiredResponses: Int,
+      receivedResponses: Int,
+      dataRetrieved: Boolean,
+      nbRetry: Int): RetryDecision = {
 
-  override def onWriteTimeout(stmt: Statement, cl: ConsistencyLevel, writeType: WriteType,
-                              requiredAcks: Int, receivedAcks: Int, nbRetry: Int) = retryOrThrow(cl, nbRetry)
+    retryManyTimesOrThrow(cl, nbRetry)
+  }
 
+  override def onWriteTimeout(
+      stmt: Statement,
+      cl: ConsistencyLevel,
+      writeType: WriteType,
+      requiredAcks: Int,
+      receivedAcks: Int,
+      nbRetry: Int): RetryDecision = {
+
+    retryManyTimesOrThrow(cl, nbRetry)
+  }
+
+  override def onUnavailable(
+      stmt: Statement,
+      cl: ConsistencyLevel,
+      requiredReplica: Int,
+      aliveReplica: Int,
+      nbRetry: Int): RetryDecision = {
+
+    // We retry once in hope we connect to another
+    // coordinator that can see more nodes (e.g. on another side of the network partition):
+    retryOnceOrThrow(cl, nbRetry)
+  }
 }

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/cql/CassandraConnectorConfSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/cql/CassandraConnectorConfSpec.scala
@@ -53,14 +53,15 @@ class CassandraConnectorConfSpec extends FlatSpec with Matchers {
     connConf.cassandraSSLConf.enabledAlgorithms should contain theSameElementsAs Seq("TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384", "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256")
   }
 
-  it should "resolve default retry delay settings correctly" in {
+  // retry delay temporary disabled due to SPARKC-360
+  ignore should "resolve default retry delay settings correctly" in {
     val sparkConf = new SparkConf(loadDefaults = false)
 
     val connConf = CassandraConnectorConf(sparkConf)
     connConf.queryRetryDelay shouldBe CassandraConnectorConf.DefaultQueryRetryDelay
   }
 
-  it should "resolve constant retry delay settings" in {
+  ignore should "resolve constant retry delay settings" in {
     val sparkConf = new SparkConf(loadDefaults = false)
     sparkConf.set("spark.cassandra.query.retry.delay", "1234")
 
@@ -68,7 +69,7 @@ class CassandraConnectorConfSpec extends FlatSpec with Matchers {
     connConf.queryRetryDelay shouldBe RetryDelayConf.ConstantDelay(1234 milliseconds)
   }
 
-  it should "resolve linear retry delay settings" in {
+  ignore should "resolve linear retry delay settings" in {
     val sparkConf = new SparkConf(loadDefaults = false)
     sparkConf.set("spark.cassandra.query.retry.delay", "1234+2000")
 
@@ -76,7 +77,7 @@ class CassandraConnectorConfSpec extends FlatSpec with Matchers {
     connConf.queryRetryDelay shouldBe RetryDelayConf.LinearDelay(1234 milliseconds, 2000 milliseconds)
   }
 
-  it should "resolve exponential retry delay settings" in {
+  ignore should "resolve exponential retry delay settings" in {
     val sparkConf = new SparkConf(loadDefaults = false)
     sparkConf.set("spark.cassandra.query.retry.delay", "1234*2.3")
 


### PR DESCRIPTION
Delayed retrying was implemented by Thread.sleep, which was
unfortunately executed by a Netty thread-pool. Blocking that thread pool
may lead to a general lockup of the connector.

Currently, there is no safe way of implementing delayed retries, because
such a feature would have to be implemented in the Java driver.

This change does not introduce API changes. Configuring delayed retrying is
still possible, but will have no effect.