### PR TITLE
SPARKC-233 use executeAsync when joining with C* table

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+ * Use executeAsync while joining with C* table (SPARKC-233)
  * Fix support for C* Tuples in Dataframes (SPARKC-357)
 
 1.6.0 M2

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -196,6 +196,11 @@ OSS Cassandra this should never be used.</td>
   <td>Number of CQL rows fetched per driver request</td>
 </tr>
 <tr>
+  <td><code>input.join.throughput_query_per_sec</code></td>
+  <td>9223372036854775807</td>
+  <td>Maximum read throughput allowed per single core in query/s while joining RDD with C* table</td>
+</tr>
+<tr>
   <td><code>input.metrics</code></td>
   <td>true</td>
   <td>Sets whether to record connector specific metrics on write</td>

--- a/project/SparkCassandraConnectorBuild.scala
+++ b/project/SparkCassandraConnectorBuild.scala
@@ -20,6 +20,7 @@ import java.io.File
 import sbt._
 import sbt.Keys._
 import sbtsparkpackage.SparkPackagePlugin.autoImport._
+import pl.project13.scala.sbt.JmhPlugin
 
 object CassandraSparkBuild extends Build {
   import Settings._
@@ -99,6 +100,13 @@ object CassandraSparkBuild extends Build {
     base = file(s"$namespace-doc"),
     settings = defaultSettings ++ Seq(libraryDependencies ++= Dependencies.spark)
   ) dependsOn connector
+
+  lazy val perf = Project(
+    id = s"$namespace-perf",
+    base = file(s"$namespace-perf"),
+    settings = projectSettings,
+    dependencies = Seq(connector, embedded)
+  ) enablePlugins(JmhPlugin)
 
   def crossBuildPath(base: sbt.File, v: String): sbt.File = base / s"scala-$v" / "src"
 
@@ -260,6 +268,8 @@ object Dependencies {
 
   val embedded = logging ++ spark ++ cassandra ++ Seq(
     cassandraServer % "it,test", Embedded.jopt, Embedded.sparkRepl, Embedded.kafka, Embedded.snappy, guava)
+
+  val perf = logging ++ spark ++ cassandra
 
   val kafka = Seq(Demos.kafka, Demos.kafkaStreaming)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,3 +20,5 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
 resolvers += "Spark Packages Main repo" at "https://dl.bintray.com/spark-packages/maven" 
 
 addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.3")
+
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.6")

--- a/spark-cassandra-connector-perf/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDDBenchmark.scala
+++ b/spark-cassandra-connector-perf/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDDBenchmark.scala
@@ -1,0 +1,103 @@
+package com.datastax.spark.connector.rdd
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+
+import com.datastax.driver.core.Session
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.embedded.SparkTemplate
+import com.datastax.spark.connector.rdd.CassandraJoinRDDBenchmark._
+
+/**
+  * Performs a benchmark of fetching and joining C* table data with given "left" iterator. This
+  * is used in [[RDDFunctions.joinWithCassandraTable]] operation.
+  * External C* cluster should be started before benchmark execution.
+  */
+@State(Scope.Benchmark)
+class CassandraJoinRDDBenchmark {
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.SingleShotTime))
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  @Fork(jvmArgs = Array("-Xmx2048m"))
+  def measureOneElementPerPartitionsJoin(f: OneElementPerPartitionsFixture): List[_] = {
+    val it = f.rdd.fetchIterator(f.session, f.rdd.boundStatementBuilder(f.session), f.left.iterator)
+    it.toList
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.SingleShotTime))
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  @Fork(jvmArgs = Array("-Xmx2048m"))
+  def measureSmallPartitionsJoin(f: SmallPartitionsFixture): List[_] = {
+    val it = f.rdd.fetchIterator(f.session, f.rdd.boundStatementBuilder(f.session), f.left.iterator)
+    it.toList
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.SingleShotTime))
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  @Fork(jvmArgs = Array("-Xmx2048m"))
+  def measureModeratePartitionsJoin(f: ModeratePartitionsFixture): List[_] = {
+    val it = f.rdd.fetchIterator(f.session, f.rdd.boundStatementBuilder(f.session), f.left.iterator)
+    it.toList
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.SingleShotTime))
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  @Fork(jvmArgs = Array("-Xmx2048m"))
+  def measureBigPartitionsJoin(f: BigPartitionsFixture): List[_] = {
+    val it = f.rdd.fetchIterator(f.session, f.rdd.boundStatementBuilder(f.session), f.left.iterator)
+    it.toList
+  }
+}
+
+object CassandraJoinRDDBenchmark {
+  val Keyspace = "spark_connector_join_performance_test"
+
+  val Rows = 200000
+  val SmallPartitionSize = 10
+  val ModeratePartitionSize = 500
+  val BigPartitionSize = 5000
+
+  @State(Scope.Benchmark)
+  class Fixture(partitionSize: Int, table: String) extends SparkTemplate {
+
+    def NormalState() {}
+
+    val config = defaultConf.set("spark.cassandra.connection.port", "9042")
+    useSparkConf(config)
+
+    var left: Seq[Tuple1[Int]] = _
+    var rdd: CassandraJoinRDD[Tuple1[Int], CassandraRow] = _
+    var session: Session = _
+
+    @Setup(Level.Trial)
+    def init(): Unit = {
+      left = (0 until Rows / partitionSize).map(Tuple1(_))
+      rdd = sc.parallelize(left).joinWithCassandraTable(Keyspace, table)
+      session = rdd.connector.openSession()
+    }
+
+    @TearDown(Level.Trial)
+    def tearDown(): Unit = {
+      session.close()
+      sc.stop()
+    }
+  }
+
+  @State(Scope.Benchmark)
+  class OneElementPerPartitionsFixture extends Fixture(1, "one_element_partitions")
+
+  @State(Scope.Benchmark)
+  class SmallPartitionsFixture extends Fixture(SmallPartitionSize, "small_partitions")
+
+  @State(Scope.Benchmark)
+  class ModeratePartitionsFixture extends Fixture(ModeratePartitionSize, "moderate_partitions")
+
+  @State(Scope.Benchmark)
+  class BigPartitionsFixture extends Fixture(BigPartitionSize, "big_partitions")
+
+}

--- a/spark-cassandra-connector-perf/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDDData.scala
+++ b/spark-cassandra-connector-perf/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDDData.scala
@@ -1,0 +1,71 @@
+package com.datastax.spark.connector.rdd
+
+import java.lang.{Long => JLong}
+
+import com.datastax.driver.core.{ResultSet, ResultSetFuture, Session}
+import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.embedded.SparkTemplate
+import com.datastax.spark.connector.rdd.CassandraJoinRDDBenchmark._
+import com.datastax.spark.connector.writer.AsyncExecutor
+
+object CassandraJoinRDDData extends App with SparkTemplate {
+
+  val config = defaultConf.set("spark.cassandra.connection.port", "9042")
+
+  val someContent =
+    """Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam quis augue
+      tristique, ultricies nisl sit amet, condimentum felis. Ut blandit nisi eget imperdiet pretium. Ut a
+      erat in tortor ultrices posuere quis eu dui. Lorem ipsum dolor sit amet, consectetur adipiscing
+      elit. Integer vestibulum vitae arcu ac vehicula. Praesent non erat quis ipsum tempor tempus
+      vitae quis neque. Aenean eget urna egestas, lobortis velit sed, vestibulum justo. Nam nibh
+      risus, bibendum non ex ac, bibendum varius purus. """
+
+  def createKeyspaceCql(name: String) =
+    s"""
+       |CREATE KEYSPACE IF NOT EXISTS $name
+       |WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }
+       |AND durable_writes = false
+       |""".stripMargin
+
+  def createTableCql(keyspace: String, tableName: String): String =
+    s"""
+       |CREATE TABLE $keyspace.$tableName (
+       |  key INT,
+       |  group BIGINT,
+       |  value TEXT,
+       |  PRIMARY KEY (key, group)
+       |)""".stripMargin
+
+  def insertData(session: Session, keyspace: String, table: String, partitions: Int,
+    partitionSize: Int): Unit = {
+    def executeAsync(data: (Int, Long, String)): ResultSetFuture = {
+      session.executeAsync(
+        s"INSERT INTO $Keyspace.$table (key, group, value) VALUES (?, ?, ?)",
+        data._1: Integer, data._2.toLong: JLong, data._3.toString
+      )
+    }
+    val executor = new AsyncExecutor[(Int, Long, String), ResultSet](executeAsync, 1000, None, None)
+
+    for (
+      partition <- 0 until partitions;
+      group <- 0 until partitionSize
+    ) yield executor.executeAsync((partition, group, s"${partition}_${group}_${someContent}"))
+    executor.waitForCurrentlyExecutingTasks()
+  }
+
+  val conn = CassandraConnector(config)
+  conn.withSessionDo { session =>
+    session.execute(s"DROP KEYSPACE IF EXISTS $Keyspace")
+    session.execute(createKeyspaceCql(Keyspace))
+
+    session.execute(createTableCql(Keyspace, "one_element_partitions"))
+    session.execute(createTableCql(Keyspace, "small_partitions"))
+    session.execute(createTableCql(Keyspace, "moderate_partitions"))
+    session.execute(createTableCql(Keyspace, "big_partitions"))
+
+    insertData(session, Keyspace, "one_element_partitions", Rows, 1)
+    insertData(session, Keyspace, "small_partitions", Rows / SmallPartitionSize, SmallPartitionSize)
+    insertData(session, Keyspace, "moderate_partitions", Rows/ ModeratePartitionSize, ModeratePartitionSize)
+    insertData(session, Keyspace, "big_partitions", Rows / BigPartitionSize, BigPartitionSize)
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
@@ -2,7 +2,7 @@ package com.datastax.spark.connector.rdd
 
 import org.apache.spark.metrics.InputMetricsUpdater
 
-import com.datastax.driver.core.Session
+import com.datastax.driver.core.{ResultSet, Session}
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.rdd.reader._
@@ -12,8 +12,9 @@ import com.datastax.spark.connector.writer._
 import com.datastax.spark.connector.util.Quote._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{Partition, TaskContext}
-
 import scala.reflect.ClassTag
+
+import com.google.common.util.concurrent.{FutureCallback, Futures, SettableFuture}
 
 /**
  * An [[org.apache.spark.rdd.RDD RDD]] that will do a selecting join between `left` RDD and the specified
@@ -205,6 +206,12 @@ class CassandraJoinRDD[L, R] private[connector](
     query
   }
 
+  private[rdd] def boundStatementBuilder(session: Session): BoundStatementBuilder[L] = {
+    val protocolVersion = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersion
+    val stmt = session.prepare(singleKeyCqlQuery).setConsistencyLevel(consistencyLevel)
+    new BoundStatementBuilder[L](rowWriter, stmt, where.values, protocolVersion = protocolVersion)
+  }
+
   /**
    * When computing a CassandraPartitionKeyRDD the data is selected via single CQL statements
    * from the specified C* Keyspace and Table. This will be preformed on whatever data is
@@ -212,9 +219,7 @@ class CassandraJoinRDD[L, R] private[connector](
    */
   override def compute(split: Partition, context: TaskContext): Iterator[(L, R)] = {
     val session = connector.openSession()
-    val protocolVersion = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersion
-    val stmt = session.prepare(singleKeyCqlQuery).setConsistencyLevel(consistencyLevel)
-    val bsb = new BoundStatementBuilder[L](rowWriter, stmt, where.values, protocolVersion = protocolVersion)
+    val bsb = boundStatementBuilder(session)
     val metricsUpdater = InputMetricsUpdater(context, readConf)
     val rowIterator = fetchIterator(session, bsb, left.iterator(split, context))
     val countingIterator = new CountingIterator(rowIterator, limit)
@@ -230,18 +235,36 @@ class CassandraJoinRDD[L, R] private[connector](
     countingIterator
   }
 
-  private def fetchIterator(
+  private[rdd] def fetchIterator(
     session: Session,
     bsb: BoundStatementBuilder[L],
-    lastIt: Iterator[L]): Iterator[(L, R)] = {
-
+    leftIterator: Iterator[L]): Iterator[(L, R)] = {
     val columnNamesArray = selectedColumnRefs.map(_.selectedAs).toArray
-    for (leftSide <- lastIt;
-         rightSide <- {
-           val rs = session.execute(bsb.bind(leftSide))
-           val iterator = new PrefetchingResultSetIterator(rs, fetchSize)
-           iterator.map(rowReader.read(_, columnNamesArray))
-         }) yield (leftSide, rightSide)
+    val rateLimiter = new RateLimiter(
+      readConf.throughputJoinQueryPerSec, readConf.throughputJoinQueryPerSec)
+
+    def pairWithRight(left: L): SettableFuture[Iterator[(L, R)]] = {
+      val resultFuture = SettableFuture.create[Iterator[(L, R)]]
+      val leftSide = Iterator.continually(left)
+
+      val queryFuture = session.executeAsync(bsb.bind(left))
+      Futures.addCallback(queryFuture, new FutureCallback[ResultSet] {
+        def onSuccess(rs: ResultSet) {
+          val resultSet = new PrefetchingResultSetIterator(rs, fetchSize)
+          val rightSide = resultSet.map(rowReader.read(_, columnNamesArray))
+          resultFuture.set(leftSide.zip(rightSide))
+        }
+        def onFailure(throwable: Throwable) {
+          resultFuture.setException(throwable)
+        }
+      })
+      resultFuture
+    }
+    val queryFutures = leftIterator.map(left => {
+      rateLimiter.maybeSleep(1)
+      pairWithRight(left)
+    }).toList
+    queryFutures.iterator.flatMap(_.get)
   }
 
   override protected def getPartitions: Array[Partition] = {


### PR DESCRIPTION
This ought to speed up joining with C* table by using executeAsync
(instead of execute) and prematerializing C* ResultSets during join
operation. Current implementation materializes all ResultSetFutures
and returns iterator that blocks on future's result.

This also adds performance module with jmh plugin. Within module
there is a simple benchmark that was used to generate results 
in one of the following comments.