### PR TITLE
SPARKC-368: Cql for SinglePartition Queries needs to use >= MinToken

### DIFF
--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
@@ -382,6 +382,14 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
     checkArrayCassandraRow(result)
   }
 
+  it should "support single partition where clauses" in {
+    val someCass = sc
+      .cassandraTable[FullRow](ks, tableName)
+      .where("key = 1 and group = 100")
+    val result = someCass.collect
+    result should contain theSameElementsAs Seq(FullRow(1,100,"1"))
+  }
+
   "A Joined CassandraRDD " should " support select clauses " in {
     val someCass = sc.cassandraTable(ks, otherTable).joinWithCassandraTable(ks, tableName).select("value")
     val results = someCass.collect.map(_._2).map(_.getInt("value")).sorted

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartition.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartition.scala
@@ -12,7 +12,9 @@ case class CqlTokenRange[V, T <: Token[V]](range: TokenRange[V, T])(implicit tf:
   require(!range.isWrappedAround)
 
   def cql(pk: String): (String, Seq[Any]) =
-    if (range.start == tf.minToken)
+    if (range.start == tf.minToken && range.end == tf.minToken)
+      (s"token($pk) >= ?", Seq(range.start.value))
+    else if (range.start == tf.minToken)
       (s"token($pk) <= ?", Seq(range.end.value))
     else if (range.end == tf.minToken)
       (s"token($pk) > ?", Seq(range.start.value))


### PR DESCRIPTION
While <= MinToken wraps and works correctly by itself, when coupled with
a predicate such as "x =1" it fails to wrap. To fix this we just check
that the token(pk) >= MinToken if the partition spans (MinToken,
Mintoken)