### PR TITLE
SPARKC-367 move back to VM infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: scala
 jdk:
   - oraclejdk8
-sudo: false
+sudo: required
+dist: trusty
 scala:
   - 2.10.5
   - 2.11.7

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -52,7 +52,7 @@ object Settings extends Build {
   val osmxBean = ManagementFactory.getOperatingSystemMXBean.asInstanceOf[OperatingSystemMXBean]
   val sysMemoryInMB = osmxBean.getTotalPhysicalMemorySize >> 20
   val singleRunRequiredMem = 3 * 1024 + 512
-  val parallelTasks = if (isTravis) 1 else Math.max(1, ((sysMemoryInMB - 1550) / singleRunRequiredMem).toInt)
+  val parallelTasks = if (isTravis) 2 else Math.max(1, ((sysMemoryInMB - 1550) / singleRunRequiredMem).toInt)
 
   // Due to lack of entrophy on virtual machines we want to use /dev/urandom instead of /dev/random
   val useURandom = Files.exists(Paths.get("/dev/urandom"))
@@ -67,7 +67,6 @@ object Settings extends Build {
   val cassandraTestVersion = sys.props.get("test.cassandra.version").getOrElse(Versions.Cassandra)
 
   lazy val TEST_JAVA_OPTS = Seq(
-    "-XX:MaxPermSize=256M",
     "-Xms256m",
     "-Xmx512m",
     "-Dsun.io.serialization.extendedDebugInfo=true",


### PR DESCRIPTION
As we have problems with container based infrastructure (these manifest
themselves as JVM exiting with 137 code). This commit moves travis
builds back to VM infrastructure, to Trusty (with 7.5GB of memory), see:
https://docs.travis-ci.com/user/ci-environment/

Also this commit bumps up parallelism for test execution