### PR TITLE
SPARKC-372 Infer schema from DataFrame

### DIFF
--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/DefaultSource.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/DefaultSource.scala
@@ -79,7 +79,7 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
     data: DataFrame): BaseRelation = {
 
     val (tableRef, options) = TableRefAndOptions(parameters)
-    val table = CassandraSourceRelation(tableRef, sqlContext, options)
+    val table = CassandraSourceRelation(tableRef, sqlContext, options, Option(data.schema))
 
     mode match {
       case Append => table.insert(data, overwrite = false)
@@ -100,7 +100,7 @@ class DefaultSource extends RelationProvider with SchemaRelationProvider with Cr
         }
     }
 
-    CassandraSourceRelation(tableRef, sqlContext, options)
+    CassandraSourceRelation(tableRef, sqlContext, options, Option(data.schema))
   }
 }
 


### PR DESCRIPTION
Now the Cassandra DataSource API when implements the DefaultSource of Spark search the schema in Cassandra. It is possible that the Schema of the DataFrame is not the same with some data types. This produce errors in some scenarios.
When creating one Relation inside the DefaultSource and the data is contained in a Spark DataFrame, the CassandraSourceRelation should be created inferring the schema associated to this DataFrame.