### PR TITLE
SPARKC-379: Retry Schema Checks in case of Java Driver Debounce

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
@@ -6,9 +6,8 @@ import javax.net.ssl.{SSLContext, TrustManagerFactory}
 
 import org.apache.commons.io.IOUtils
 import org.apache.spark.SparkConf
-
 import com.datastax.driver.core.policies.ExponentialReconnectionPolicy
-import com.datastax.driver.core.{JdkSSLOptions, Cluster, SSLOptions, SocketOptions}
+import com.datastax.driver.core._
 import com.datastax.spark.connector.cql.CassandraConnectorConf.CassandraSSLConf
 import com.datastax.spark.connector.util.{ConfigParameter, ReflectionUtil}
 
@@ -45,6 +44,11 @@ object DefaultConnectionFactory extends CassandraConnectionFactory {
       .withAuthProvider(conf.authConf.authProvider)
       .withSocketOptions(options)
       .withCompression(conf.compression)
+      .withQueryOptions(
+        new QueryOptions()
+          .setRefreshNodeIntervalMillis(0)
+          .setRefreshNodeListIntervalMillis(0)
+          .setRefreshSchemaIntervalMillis(0))
 
     if (conf.cassandraSSLConf.enabled) {
       maybeCreateSSLOptions(conf.cassandraSSLConf) match {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableRowReaderProvider.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableRowReaderProvider.scala
@@ -47,16 +47,7 @@ trait CassandraTableRowReaderProvider[R] {
   lazy val rowReader: RowReader[R] =
     rowReaderFactory.rowReader(tableDef, columnNames.selectFrom(tableDef))
 
-  lazy val tableDef: TableDef = {
-    Schema.fromCassandra(connector, Some(keyspaceName), Some(tableName)).tables.headOption match {
-      case Some(t) => t
-      case None =>
-        val metadata: Metadata = connector.withClusterDo(_.getMetadata)
-        val suggestions = NameTools.getSuggestions(metadata, keyspaceName, tableName)
-        val errorMessage = NameTools.getErrorString(keyspaceName, tableName, suggestions)
-        throw new IOException(errorMessage)
-    }
-  }
+  lazy val tableDef: TableDef = Schema.tableFromCassandra(connector, keyspaceName, tableName)
 
   protected def checkColumnsExistence(columns: Seq[ColumnRef]): Seq[ColumnRef] = {
     val allColumnNames = tableDef.columns.map(_.columnName).toSet

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/ReplicaLocator.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/ReplicaLocator.scala
@@ -60,9 +60,7 @@ object ReplicaLocator {
       tableName: String,
       partitionKeyMapper: ColumnSelector): ReplicaLocator[T] = {
 
-    val schema = Schema.fromCassandra(connector, Some(keyspaceName), Some(tableName))
-    val tableDef = schema.tables.headOption
-      .getOrElse(throw new IOException(s"Table not found: $keyspaceName.$tableName"))
+    val tableDef = Schema.tableFromCassandra(connector, keyspaceName, tableName)
     val rowWriter = implicitly[RowWriterFactory[T]].rowWriter(
       tableDef,
       partitionKeyMapper.selectFrom(tableDef)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -264,9 +264,7 @@ object TableWriter {
       columnNames: ColumnSelector,
       writeConf: WriteConf): TableWriter[T] = {
 
-    val schema = Schema.fromCassandra(connector, Some(keyspaceName), Some(tableName))
-    val tableDef = schema.tables.headOption
-      .getOrElse(throw new IOException(s"Table not found: $keyspaceName.$tableName"))
+    val tableDef = Schema.tableFromCassandra(connector, keyspaceName, tableName)
     val selectedColumns = columnNames.selectFrom(tableDef)
     val optionColumns = writeConf.optionsAsColumns(keyspaceName, tableName)
     val rowWriter = implicitly[RowWriterFactory[T]].rowWriter(

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSourceRelation.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSourceRelation.scala
@@ -44,18 +44,10 @@ private[cassandra] class CassandraSourceRelation(
   with PrunedFilteredScan
   with Logging {
 
-  private[this] val tableDef = {
-    val tableName = tableRef.table
-    val keyspaceName = tableRef.keyspace
-    Schema.fromCassandra(connector, Some(keyspaceName), Some(tableName)).tables.headOption match {
-      case Some(t) => t
-      case None =>
-        val metadata: Metadata = connector.withClusterDo(_.getMetadata)
-        val suggestions = NameTools.getSuggestions(metadata, keyspaceName, tableName)
-        val errorMessage = NameTools.getErrorString(keyspaceName, tableName, suggestions)
-        throw new IOException(errorMessage)
-    }
-  }
+  private[this] val tableDef = Schema.tableFromCassandra(
+    connector,
+    tableRef.keyspace,
+    tableRef.table)
 
   override def schema: StructType = {
     userSpecifiedSchema.getOrElse(StructType(tableDef.columns.map(toStructField)))


### PR DESCRIPTION
Refactors all tableDef obtaining operations through tableFromCassandra
which attempts to retreive the given requested table def. If the call
fails, it sleeps for 1 second and retries. On the second failure it
throws an exception reporting that the table could not be found with the
table name recommendations as before. The sleep should be replaced with
a forced schema update once that becomes available in the Java Driver.