### PR TITLE
 SPARKC-385 add driver.LocalDate conversion

### DIFF
--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -134,22 +134,23 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
         session.execute(s"""CREATE TABLE "MixedSpace"."MoxedCAs" (key INT PRIMARY KEY, value INT)""")
       },
       Future {
-        if (versionGreaterThanOrEquals(2,2)) {
+        if (versionGreaterThanOrEquals(2, 2)) {
           session.execute(
-            s""" CREATE TABLE $ks.user(
-          id int PRIMARY KEY,
-          login text,
-          firstname text,
-          lastname text,
-          country text
-        )""")
+            s"""
+               |CREATE TABLE $ks.user(
+               |  id int PRIMARY KEY,
+               |  login text,
+               |  firstname text,
+               |  lastname text,
+               |  country text)""".stripMargin)
 
           session.execute(
-            s"""CREATE MATERIALIZED VIEW $ks.user_by_country
-          AS SELECT *  //denormalize ALL columns
-          FROM user
-          WHERE country IS NOT NULL AND id IS NOT NULL
-          PRIMARY KEY(country, id);""")
+            s"""
+               |CREATE MATERIALIZED VIEW $ks.user_by_country
+               |  AS SELECT *  //denormalize ALL columns
+               |  FROM user
+               |  WHERE country IS NOT NULL AND id IS NOT NULL
+               |  PRIMARY KEY(country, id);""".stripMargin)
 
           session.execute(s"INSERT INTO $ks.user(id,login,firstname,lastname,country) VALUES(1, 'jdoe', 'John', 'DOE', 'US')")
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSpec.scala
@@ -9,6 +9,7 @@ import com.datastax.spark.connector._
 import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
 import com.datastax.spark.connector.cql.CassandraConnector
 import org.apache.spark.sql.SQLContext
+import org.joda.time.LocalDate
 
 class CassandraDataFrameSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
@@ -55,6 +56,12 @@ class CassandraDataFrameSpec extends SparkCassandraITFlatSpecBase {
         session.execute(s"CREATE TABLE $ks.tuple_test1 (id int, t Tuple<text, int>, PRIMARY KEY (id))")
         session.execute(s"CREATE TABLE $ks.tuple_test2 (id int, t Tuple<text, int>, PRIMARY KEY (id))")
         session.execute(s"INSERT INTO $ks.tuple_test1 (id, t) VALUES (1, ('xyz', 3))")
+      },
+
+      Future {
+        session.execute(s"create table $ks.date_test (key int primary key, dd date)")
+        session.execute(s"create table $ks.date_test2 (key int primary key, dd date)")
+        session.execute(s"insert into $ks.date_test (key, dd) values (1, '1930-05-31')")
       }
     )
   }
@@ -182,6 +189,26 @@ class CassandraDataFrameSpec extends SparkCassandraITFlatSpecBase {
 
     conn.withSessionDo { session =>
       session.execute(s"select count(1) from $ks.tuple_test2").one().getLong(0) should be (1)
+    }
+  }
+
+  it should "read and write C* LocalDate columns" in {
+    val df = sqlContext
+      .read
+      .format("org.apache.spark.sql.cassandra")
+      .options(Map("table" -> "date_test", "keyspace" -> ks, "cluster" -> "ClusterOne"))
+      .load
+
+    df.count should be (1)
+    df.first.getDate(1) should be (new LocalDate(1930, 5, 31).toDate)
+
+    df.write
+      .format("org.apache.spark.sql.cassandra")
+      .options(Map("table" -> "date_test2", "keyspace" -> ks, "cluster" -> "ClusterOne"))
+      .save
+
+    conn.withSessionDo { session =>
+      session.execute(s"select count(1) from $ks.date_test2").one().getLong(0) should be (1)
     }
   }
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/GettableData.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/GettableData.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 
 import scala.collection.JavaConversions._
 
-import com.datastax.driver.core.{Row, UDTValue => DriverUDTValue, TupleValue => DriverTupleValue}
+import com.datastax.driver.core.{LocalDate, Row, TupleValue => DriverTupleValue, UDTValue => DriverUDTValue}
 import com.datastax.spark.connector.types.TypeConverter.StringConverter
 import com.datastax.spark.connector.util.ByteBufferUtil
 
@@ -80,6 +80,7 @@ object GettableData {
       case map: java.util.Map[_, _] => map.view.map { case (k, v) => (convert(k), convert(v))}.toMap
       case udtValue: DriverUDTValue => UDTValue.fromJavaDriverUDTValue(udtValue)
       case tupleValue: DriverTupleValue => TupleValue.fromJavaDriverTupleValue(tupleValue)
+      case localDate: LocalDate => new org.joda.time.LocalDate(localDate.getMillisSinceEpoch)
       case other => other.asInstanceOf[AnyRef]
 
     }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
@@ -302,6 +302,7 @@ object TypeConverter {
       case x: UUID if x.version() == 1 => new Date(x.timestamp())
       case x: LocalDate => new Date(x.getMillisSinceEpoch)
       case x: String => TimestampParser.parse(x)
+      case x: org.joda.time.LocalDate => x.toDate
     }
   }
 

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSQLRow.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSQLRow.scala
@@ -78,6 +78,7 @@ object CassandraSQLRow {
     value match {
       case date: Date => new Timestamp(date.getTime)
       case localDate: LocalDate => new java.sql.Date(subtractTimeZoneOffset(localDate.getMillisSinceEpoch))
+      case localDate: org.joda.time.LocalDate => new java.sql.Date(localDate.toDate.getTime)
       case str: String => UTF8String.fromString(str)
       case bigInteger: BigInteger => Decimal(bigInteger.toString)
       case inetAddress: InetAddress => UTF8String.fromString(inetAddress.getHostAddress)

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/TypeConverterTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/TypeConverterTest.scala
@@ -136,11 +136,13 @@ class TypeConverterTest {
     val dayOnlyStr = "2014-04-23 0:0:0+0000"
     val dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ssZ")
     val localDate = LocalDate.fromYearMonthDay(2014,4,23)
+    val jodaLocalDate = new org.joda.time.LocalDate(2014, 4, 23)
 
     val date = dateFormat.parse(dateStr)
     val dateDayOnly = dateFormat.parse(dayOnlyStr)
 
     assertEquals(dateDayOnly, c.convert(localDate))
+    assertEquals(dateDayOnly, c.convert(jodaLocalDate))
     assertEquals(date, c.convert(dateStr))
   }
 
@@ -150,13 +152,14 @@ class TypeConverterTest {
 
     val targetDate = java.sql.Date.valueOf("2014-04-23")
 
-
     val localDate = LocalDate.fromYearMonthDay(2014,4,23)
+    val jodaLocalDate = new org.joda.time.LocalDate(2014, 4, 23)
 
     val dateFormat = new SimpleDateFormat("yyyy-MM-dd")
     val utilDate = dateFormat.parse("2014-04-23")
 
     assertEquals(targetDate, c.convert(localDate))
+    assertEquals(targetDate, c.convert(jodaLocalDate))
     assertEquals(targetDate, c.convert(utilDate))
   }
 
@@ -224,6 +227,7 @@ class TypeConverterTest {
     assertEquals(testDate, c.convert(date))
     assertEquals(testDate, c.convert(java.sql.Date.valueOf("1985-08-03")))
     assertEquals(testDate, c.convert(new DateTime(date)))
+    assertEquals(testDate, c.convert(new org.joda.time.LocalDate(1985, 8, 3)))
   }
 
   @Test


### PR DESCRIPTION
Conversion is added because driver's LocalDate is not
serializable.

GettableData now converts LocalDate to Joda's LocalDate.