### PR TITLE
SPARKC-161: RDD coalesce() pushdown to cassandra.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+ * CassandraRDD.coalesce() is pushed down to connector partition generator (SPARKC-161)
  * Add RDD.deleteFromCassandra() method (SPARKC-349)
  * Fixed use of connection.local_dc parameter (SPARKC-448)
  * Removed demos and benchmarks (SPARKC-398)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -1075,6 +1075,36 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
     localDate should be(expected)
   }
 
+  "RDD.coalesce"  should "not loose data" in {
+    val rdd = sc.cassandraTable(ks, "big_table").coalesce(4)
+    rdd.count should be (bigTableRowCount)
+  }
+
+  it should "set exact number of partitions" in {
+    val rdd = sc.cassandraTable(ks, "big_table").coalesce(8)
+    rdd.partitions.size should be (8 +-1 )
+  }
+
+  it should "set exact number of partitions (1)" in {
+    val rdd = sc.cassandraTable(ks, "big_table").coalesce(1)
+    rdd.partitions.size should be (1)
+  }
+
+  it should "work with 0" in {
+    val rdd = sc.cassandraTable(ks, "big_table").coalesce(0)
+    rdd.partitions.size should be (1)
+  }
+
+  "RDD.repartition"  should "not loose data" in {
+    val rdd = sc.cassandraTable(ks, "big_table").repartition(4)
+    rdd.count should be (bigTableRowCount)
+  }
+
+  it should "set exact number of partitions" in {
+    val rdd = sc.cassandraTable(ks, "big_table").repartition(4)
+    rdd.partitions.size should be (4)
+  }
+
   it should "delete rows just selected from the C*" in {
 
     conn.withSessionDo { session =>


### PR DESCRIPTION
The coalesce method looks more convinient to specify the number of paritions than ReadConf usage.
