### PR TITLE
SPARKC-278: Make Repartition by Cassandra Replica Deterministic

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartitionedRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartitionedRDD.scala
@@ -24,11 +24,13 @@ class CassandraPartitionedRDD[T](
   @transient
   override val partitioner: Option[Partitioner] = prev.partitioner
 
-  private val replicaPartitioner: ReplicaPartitioner =
+  private val replicaPartitioner: ReplicaPartitioner[_] =
     partitioner match {
-      case Some(rp: ReplicaPartitioner) => rp
-      case _ => throw new IllegalArgumentException("CassandraPartitionedRDD hasn't been " +
-        "partitioned by ReplicaPartitioner. Unable to do any work with data locality.")
+      case Some(rp: ReplicaPartitioner[_]) => rp
+      case other => throw new IllegalArgumentException(
+        s"""CassandraPartitionedRDD hasn't been
+           |partitioned by ReplicaPartitioner. Unable to do any work with data locality.
+           |Found: $other""".stripMargin)
     }
 
   private lazy val nodeAddresses = new NodeAddresses(replicaPartitioner.connector)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/ReplicaPartitioner.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/ReplicaPartitioner.scala
@@ -38,6 +38,7 @@ implicit
   @transient lazy private val metadata = connector.withClusterDo(_.getMetadata)
   @transient lazy private val protocolVersion = connector
     .withClusterDo(_.getConfiguration.getProtocolOptions.getProtocolVersion)
+  @transient lazy private val clazz = implicitly[ClassTag[T]].runtimeClass
 
   private val hosts = connector.hosts.toVector
   private val hostSet = connector.hosts
@@ -62,7 +63,7 @@ implicit
    */
   override def getPartition(key: Any): Int = {
     key match {
-      case key: T =>
+      case key: T if clazz.isInstance(key) =>
         //Only use ReplicaEndpoints in the connected DC
         val token = tokenGenerator.getTokenFor(key)
         val tokenHash = Math.abs(token.hashCode())

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/DStreamFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/DStreamFunctions.scala
@@ -1,11 +1,11 @@
 package com.datastax.spark.connector.streaming
 
 import com.datastax.spark.connector._
-import com.datastax.spark.connector.cql.{CassandraConnectorConf, CassandraConnector}
+import com.datastax.spark.connector.cql.{CassandraConnector, CassandraConnectorConf}
+import com.datastax.spark.connector.rdd.partitioner.ReplicaPartitioner
 import com.datastax.spark.connector.rdd.{EmptyCassandraRDD, ValidRDDType}
 import com.datastax.spark.connector.rdd.reader.RowReaderFactory
 import com.datastax.spark.connector.writer._
-
 import org.apache.spark._
 import org.apache.spark.SparkContext
 import org.apache.spark.streaming.Duration
@@ -68,9 +68,14 @@ class DStreamFunctions[T](dstream: DStream[T])
     currentType: ClassTag[T],
     rwf: RowWriterFactory[T]): DStream[T] = {
 
-    val replicaLocator = ReplicaLocator[T](connector, keyspaceName, tableName, partitionKeyMapper)
-    dstream.transform(rdd =>
-      rdd.repartitionByCassandraReplica(replicaLocator, keyspaceName, tableName, partitionsPerHost, partitionKeyMapper))
+    val partitioner = new ReplicaPartitioner[T](
+      tableName,
+      keyspaceName,
+      partitionsPerHost,
+      partitionKeyMapper,
+      connector)
+
+    dstream.transform(rdd => rdd.map((_, None)).partitionBy(partitioner).map(_._1))
   }
 
   /**


### PR DESCRIPTION
Previously the behavior of repartition by Cassandra Replica was random
within the bounds of assigining keys to the the correct replicas. This
meant that multiple application of the partitioner could result with
rows in different partitions even if they share the same partition key.

The new behvaior pulls the token determination and replica determination
into the partitioner. This removes the need for the
"keyByCassandraReplica" function for repartitionByCassandraReplica.