### PR TITLE
Corrected minor issue in example code

### DIFF
--- a/doc/2_loading.md
+++ b/doc/2_loading.md
@@ -283,7 +283,7 @@ Cassandra Tables which have partitioned with different partition keys.
 ####Join with a generic RDD after repartitioning
 ```scala
 val oddIds = sc.parallelize(0 to 5).filter(_%2==1).map(CustomerID(_))
-val localQueryRDD = oddIds.repartitionByCassandraReplica("test","customer_info").joinWithCassandra("test","customer_info")
+val localQueryRDD = oddIds.repartitionByCassandraReplica("test","customer_info").joinWithCassandraTable("test","customer_info")
 repartitionRDD.collect.foreach(println)
 //(CustomerID(1),CassandraRow{cust_id: 1, address: East Coast, name: Helena})
 //(CustomerID(3),CassandraRow{cust_id: 3, address: Poland, name: Jacek})


### PR DESCRIPTION
On line 286, `joinWithCassandra` should be `joinWithCassandraTable`.