### PR TITLE
SPARKC-320: update to spark 1.5.2

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -56,7 +56,7 @@ object Versions {
   // and install in a local Maven repository. This is all done automatically, however it will work
   // only on Unix/OSX operating system. Windows users have to build and install Spark manually if the
   // desired version is not yet published into a public Maven repository.
-  val Spark           = "1.5.1"
+  val Spark           = "1.5.2"
   val SparkJetty      = "8.1.14.v20131031"
   val JSR166e         = "1.1.0"
   val Airlift         = "0.6"


### PR DESCRIPTION
Connector version 1.5 had java.lang.NoSuchMethodError on Spark 1.5.2, updating the version seems to fix it. 