### PR TITLE
SPARKC-390: Replace org.apache.spark.Logging with internal Logging Trait

### DIFF
--- a/spark-cassandra-connector-demos/kafka-streaming/src/main/scala/com/datastax/spark/connector/demo/KafkaStreamingScala211App.scala
+++ b/spark-cassandra-connector-demos/kafka-streaming/src/main/scala/com/datastax/spark/connector/demo/KafkaStreamingScala211App.scala
@@ -1,6 +1,6 @@
 package com.datastax.spark.connector.demo
 
-import org.apache.spark.Logging
+import com.datastax.spark.connector.util.Logging
 
 object KafkaStreamingScala211App extends App with Logging {
 

--- a/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/CassandraRunner.scala
+++ b/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/CassandraRunner.scala
@@ -6,10 +6,9 @@ import scala.collection.JavaConversions._
 import scala.util.Try
 
 import org.apache.commons.io.FileUtils
-import org.apache.spark.Logging
 
 private[connector] class CassandraRunner(val configTemplate: String, props: Map[String, String])
-  extends Embedded with Logging {
+  extends Embedded {
 
   import java.io.{File, FileOutputStream, IOException}
 

--- a/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/DynamicCassandraPorts.scala
+++ b/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/DynamicCassandraPorts.scala
@@ -6,8 +6,6 @@ import java.nio.file.{FileAlreadyExistsException, Files, Paths}
 import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}
 
-import org.apache.spark.Logging
-
 case class DynamicCassandraPorts(basePort: Int) extends CassandraPorts {
 
   import DynamicCassandraPorts._
@@ -24,7 +22,7 @@ case class DynamicCassandraPorts(basePort: Int) extends CassandraPorts {
 }
 
 
-object DynamicCassandraPorts extends Logging {
+object DynamicCassandraPorts {
   val MaxInstances = 5
 
   val RPC_OFFSET = 0

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceNoPushdownSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceNoPushdownSpec.scala
@@ -1,6 +1,6 @@
 package com.datastax.spark.connector.sql
 
-import org.apache.spark.Logging
+import com.datastax.spark.connector.util.Logging
 import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.sql.SaveMode._
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.BeforeAndAfterEach
 
 import scala.concurrent.Future
 
-import org.apache.spark.Logging
+import com.datastax.spark.connector.util.Logging
 import org.apache.spark.sql.SaveMode._
 import org.apache.spark.sql.cassandra.{
   AnalyzedPredicates,

--- a/spark-cassandra-connector/src/it/scala/org/apache/spark/sql/CassandraPrunedFilteredScanSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/org/apache/spark/sql/CassandraPrunedFilteredScanSpec.scala
@@ -3,7 +3,7 @@ package org.apache.spark.sql
 import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.rdd.{CqlWhereClause, CassandraTableScanRDD}
-import org.apache.spark.Logging
+import com.datastax.spark.connector.util.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.{Filter, SparkPlan, PhysicalRDD}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/LocalNodeFirstLoadBalancingPolicy.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/LocalNodeFirstLoadBalancingPolicy.scala
@@ -11,7 +11,6 @@ import scala.collection.JavaConversions._
 import scala.util.Random
 
 import com.datastax.spark.connector.util.Logging
-import com.datastax.spark.connector.util.Logging
 
 /** Selects local node first and then nodes in local DC in random order. Never selects nodes from other DCs.
   * For writes, if a statement has a routing key set, this LBP is token aware - it prefers the nodes which

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/LocalNodeFirstLoadBalancingPolicy.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/LocalNodeFirstLoadBalancingPolicy.scala
@@ -10,7 +10,8 @@ import java.net.{InetAddress, NetworkInterface}
 import scala.collection.JavaConversions._
 import scala.util.Random
 
-import org.apache.spark.Logging
+import com.datastax.spark.connector.util.Logging
+import com.datastax.spark.connector.util.Logging
 
 /** Selects local node first and then nodes in local DC in random order. Never selects nodes from other DCs.
   * For writes, if a statement has a routing key set, this LBP is token aware - it prefers the nodes which

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/PreparedStatementCache.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/PreparedStatementCache.scala
@@ -1,7 +1,7 @@
 package com.datastax.spark.connector.cql
 
 import com.datastax.driver.core.{RegularStatement, Session, Cluster, PreparedStatement}
-import org.apache.spark.Logging
+import com.datastax.spark.connector.util.Logging
 
 import scala.collection.concurrent.TrieMap
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
@@ -4,7 +4,7 @@ import java.io.IOException
 
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.mapper.{ColumnMapper, DataFrameColumnMapper}
-import org.apache.spark.Logging
+import com.datastax.spark.connector.util.Logging
 import org.apache.spark.sql.DataFrame
 
 import scala.collection.JavaConversions._

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartitionGenerator.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartitionGenerator.scala
@@ -7,7 +7,7 @@ import scala.language.existentials
 import scala.reflect.ClassTag
 import scala.util.Try
 
-import org.apache.spark.Logging
+import com.datastax.spark.connector.util.Logging
 
 import com.datastax.driver.core.{Metadata, TokenRange => DriverTokenRange}
 import com.datastax.spark.connector.ColumnSelector

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/DataSizeEstimates.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/DataSizeEstimates.scala
@@ -2,7 +2,7 @@ package com.datastax.spark.connector.rdd.partitioner
 
 import scala.collection.JavaConversions._
 
-import org.apache.spark.Logging
+import com.datastax.spark.connector.util.Logging
 
 import com.datastax.driver.core.exceptions.InvalidQueryException
 import com.datastax.spark.connector.cql.CassandraConnector

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/TokenGenerator.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/TokenGenerator.scala
@@ -4,7 +4,7 @@ import com.datastax.driver.core.{Token, MetadataHook}
 import com.datastax.spark.connector.cql.{CassandraConnector, TableDef}
 import com.datastax.spark.connector.util.PatitionKeyTools._
 import com.datastax.spark.connector.writer.{BoundStatementBuilder, RoutingKeyGenerator, RowWriter}
-import org.apache.spark.Logging
+import com.datastax.spark.connector.util.Logging
 
 /**
   * A utility class for determining the token of a given key. Uses a bound statement to determine

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/AnyObjectFactory.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/AnyObjectFactory.scala
@@ -7,7 +7,7 @@ import scala.util.{Failure, Success, Try}
 
 import org.apache.commons.lang3.reflect.ConstructorUtils
 import org.apache.spark.sql.catalyst.ReflectionLock.SparkReflectionLock
-import org.apache.spark.Logging
+import com.datastax.spark.connector.util.Logging
 import com.google.common.primitives.Primitives
 import com.thoughtworks.paranamer.AdaptiveParanamer
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/CqlWhereParser.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/CqlWhereParser.scala
@@ -3,8 +3,6 @@ package com.datastax.spark.connector.util
 import java.util.UUID
 import scala.util.parsing.combinator.RegexParsers
 
-import org.apache.spark.Logging
-
 object CqlWhereParser extends RegexParsers with Logging {
 
   sealed trait RelationalOperator

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/Logging.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/Logging.scala
@@ -14,7 +14,7 @@ import org.slf4j.{Logger, LoggerFactory}
 trait Logging {
   // Make the log field transient so that objects with Logging can
   // be serialized and used on another machine
-  @transient private var log_ : Logger = null
+  @transient private var _log : Logger = null
 
   // Method to get the logger name for this object
   protected def logName = {
@@ -24,10 +24,10 @@ trait Logging {
 
   // Method to get or create the logger for this object
   protected def log: Logger = {
-    if (log_ == null) {
-      log_ = LoggerFactory.getLogger(logName)
+    if (_log == null) {
+      _log = LoggerFactory.getLogger(logName)
     }
-    log_
+    _log
   }
 
   // Log methods that take only a String

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/Logging.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/Logging.scala
@@ -1,0 +1,80 @@
+package com.datastax.spark.connector.util
+
+import org.slf4j.{Logger, LoggerFactory}
+
+/**
+  * Utility trait for classes that want to log data. Creates a SLF4J logger for the class and allows
+  * logging messages at different levels using methods that only evaluate parameters lazily if the
+  * log level is enabled.
+  *
+  *
+  * This is a copy of what Spark Previously held in org.apache.spark.Logging. That class is
+  * now private so we will expose similar functionality here.
+  */
+trait Logging {
+  // Make the log field transient so that objects with Logging can
+  // be serialized and used on another machine
+  @transient private var log_ : Logger = null
+
+  // Method to get the logger name for this object
+  protected def logName = {
+    // Ignore trailing $'s in the class names for Scala objects
+    this.getClass.getName.stripSuffix("$")
+  }
+
+  // Method to get or create the logger for this object
+  protected def log: Logger = {
+    if (log_ == null) {
+      log_ = LoggerFactory.getLogger(logName)
+    }
+    log_
+  }
+
+  // Log methods that take only a String
+  protected def logInfo(msg: => String) {
+    if (log.isInfoEnabled) log.info(msg)
+  }
+
+  protected def logDebug(msg: => String) {
+    if (log.isDebugEnabled) log.debug(msg)
+  }
+
+  protected def logTrace(msg: => String) {
+    if (log.isTraceEnabled) log.trace(msg)
+  }
+
+  protected def logWarning(msg: => String) {
+    if (log.isWarnEnabled) log.warn(msg)
+  }
+
+  protected def logError(msg: => String) {
+    if (log.isErrorEnabled) log.error(msg)
+  }
+
+  // Log methods that take Throwables (Exceptions/Errors) too
+  protected def logInfo(msg: => String, throwable: Throwable) {
+    if (log.isInfoEnabled) log.info(msg, throwable)
+  }
+
+  protected def logDebug(msg: => String, throwable: Throwable) {
+    if (log.isDebugEnabled) log.debug(msg, throwable)
+  }
+
+  protected def logTrace(msg: => String, throwable: Throwable) {
+    if (log.isTraceEnabled) log.trace(msg, throwable)
+  }
+
+  protected def logWarning(msg: => String, throwable: Throwable) {
+    if (log.isWarnEnabled) log.warn(msg, throwable)
+  }
+
+  protected def logError(msg: => String, throwable: Throwable) {
+    if (log.isErrorEnabled) log.error(msg, throwable)
+  }
+
+  protected def isTraceEnabled(): Boolean = {
+    log.isTraceEnabled
+  }
+}
+
+

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/SerialShutdownHooks.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/SerialShutdownHooks.scala
@@ -2,8 +2,6 @@ package com.datastax.spark.connector.util
 
 import scala.collection.mutable
 
-import org.apache.spark.Logging
-
 private[connector] object SerialShutdownHooks extends Logging {
 
   private val hooks = mutable.Map[String, () => Unit]()


### PR DESCRIPTION
Spark 2.0 moves the logging trait to be fully internal this means the
connector can no longer use it. To avoid conflicts we extract the trait
as we were using it so that the 1.6 and future versions of the connector
will work with Spark 2.0.