### PR TITLE
Requesting a pull to datastax:b1.6 from datastax:SPARKC-397

### DIFF
--- a/doc/5_saving.md
+++ b/doc/5_saving.md
@@ -395,6 +395,20 @@ rdd.saveToCassandra("test", "tab", writeConf = WriteConf(ttl = TTLOption.perRow(
 
 the TTL for the 1st row will be 100, TTL for the 2nd row will be 200 and TTL for the 3rd row will be 300.
 
+### Preventing nulls in TTL and Writetime
+
+When using the `perRow` function it is important to know that `null` is not allowed as a bound
+parameter for TTL or WRITETIME columns.
+
+On Cassandra 2.2 and greater, the way to avoid `null`s is to use `CassandraOption`s in the `placeholder`
+parameter. This will leave the WRITETIME and TTL clauses unbound and they will behave as if those
+clauses were not included.
+
+For Cassandra versions before 2.2 the connector can automatically change null
+TTLs to the table's default ttl and change null WRITETIMEs to the current time on the executor at
+the time of binding. These behaviors can be overridden by passing a second parameter to perRow,
+specifying the desired default.
+
 ## Saving rows only if they does not already exist
 
 Spark Cassandra Connector always writes or updates data without checking if they already exist.

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
@@ -14,7 +14,9 @@ import com.datastax.spark.connector.types._
 case class KeyValue(key: Int, group: Long, value: String)
 case class KeyValueWithTransient(key: Int, group: Long, value: String, @transient transientField: String)
 case class KeyValueWithTTL(key: Int, group: Long, value: String, ttl: Int)
+case class KeyValueWithNullableTTL(key: Int, group: Long, value: String, ttl: java.lang.Integer)
 case class KeyValueWithTimestamp(key: Int, group: Long, value: String, timestamp: Long)
+case class KeyValueWithNullableTS(key: Int, group: Long, value: String, timestamp: java.lang.Long)
 case class KeyValueWithConversion(key: String, group: Int, value: String)
 case class ClassWithWeirdProps(devil: String, cat: Int, value: String)
 case class Address(street: String, city: String, zip: Int)
@@ -571,10 +573,51 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase {
     }
   }
 
+  it should "write RDD of case class objects with null TTLS setting them to the table default" in {
+    conn.withSessionDo(_.execute(s"""TRUNCATE $ks.key_value"""))
+    val col = Seq(
+      KeyValueWithNullableTTL(1, 1L, "value1", null),
+      KeyValueWithNullableTTL(2, 2L, "value2", 200),
+      KeyValueWithNullableTTL(3, 3L, "value3", 300))
+    sc.parallelize(col).saveToCassandra(ks, "key_value", writeConf = WriteConf(ttl = TTLOption.perRow("ttl")))
+
+    verifyKeyValueTable("key_value")
+
+    val resultMap = conn.withSessionDo { session =>
+      val result = session.execute(s"""SELECT key, TTL(value) FROM $ks.key_value""").all()
+      result should have size 3
+      result.map( row => (row.getInt(0), row.getInt(1))).toMap
+      }
+
+    resultMap(1) should be (0)
+  }
+
+  it should "write RDD of case class objects with null TTLS setting them to a user default" in {
+    conn.withSessionDo(_.execute(s"""TRUNCATE $ks.key_value"""))
+    val col = Seq(
+      KeyValueWithNullableTTL(1, 1L, "value1", null),
+      KeyValueWithNullableTTL(2, 2L, "value2", 200),
+      KeyValueWithNullableTTL(3, 3L, "value3", 300))
+    sc.parallelize(col).saveToCassandra(ks, "key_value", writeConf = WriteConf(ttl = TTLOption.perRow("ttl", Some(55))))
+
+    verifyKeyValueTable("key_value")
+
+    val resultMap = conn.withSessionDo { session =>
+      val result = session.execute(s"""SELECT key, TTL(value) FROM $ks.key_value""").all()
+      result should have size 3
+      result.map( row => (row.getInt(0), row.getInt(1))).toMap
+      }
+
+    resultMap(1) should be (55)
+  }
+
   it should "write RDD of case class objects with per-row timestamp" in {
     conn.withSessionDo(_.execute(s"""TRUNCATE $ks.key_value"""))
     val ts = System.currentTimeMillis() - 1000L
-    val col = Seq(KeyValueWithTimestamp(1, 1L, "value1", ts * 1000L + 100L), KeyValueWithTimestamp(2, 2L, "value2", ts * 1000L + 200L), KeyValueWithTimestamp(3, 3L, "value3", ts * 1000L + 300L))
+    val col = Seq(
+      KeyValueWithTimestamp(1, 1L, "value1", ts * 1000L + 100L),
+      KeyValueWithTimestamp(2, 2L, "value2", ts * 1000L + 200L),
+      KeyValueWithTimestamp(3, 3L, "value3", ts * 1000L + 300L))
     sc.parallelize(col).saveToCassandra(ks, "key_value", writeConf = WriteConf(timestamp = TimestampOption.perRow("timestamp")))
 
     verifyKeyValueTable("key_value")
@@ -587,6 +630,53 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase {
       })
     }
   }
+
+  it should "write RDD of case class objects with per-row timestamp with nulls" in {
+    conn.withSessionDo(_.execute(s"""TRUNCATE $ks.key_value"""))
+    val ts = System.currentTimeMillis() - 1000L
+    val col = Seq(
+      KeyValueWithNullableTS(1, 1L, "value1", null),
+      KeyValueWithNullableTS(2, 2L, "value2", ts * 1000L + 200L),
+      KeyValueWithNullableTS(3, 3L, "value3", ts * 1000L + 300L))
+    sc.parallelize(col).saveToCassandra(
+      ks,
+      "key_value",
+      writeConf = WriteConf(timestamp = TimestampOption.perRow("timestamp")))
+
+    verifyKeyValueTable("key_value")
+
+    val resultMap = conn.withSessionDo { session =>
+      val result = session.execute(s"""SELECT key, WRITETIME(value) FROM $ks.key_value""").all()
+      result.map( row => (row.getInt(0), row.getLong(1))).toMap
+      }
+
+    resultMap(1) should be < System.currentTimeMillis() * 1000L
+    resultMap(1) should be > (System.currentTimeMillis() - 10000L) * 1000L
+  }
+
+  it should "write RDD of case class objects with per-row timestamp with nulls and a default" in {
+    conn.withSessionDo(_.execute(s"""TRUNCATE $ks.key_value"""))
+    val ts = System.currentTimeMillis() - 1000L
+    val col = Seq(
+      KeyValueWithNullableTS(1, 1L, "value1", null),
+      KeyValueWithNullableTS(2, 2L, "value2", ts * 1000L + 200L),
+      KeyValueWithNullableTS(3, 3L, "value3", ts * 1000L + 300L))
+    sc.parallelize(col).saveToCassandra(
+      ks,
+      "key_value",
+      writeConf = WriteConf(timestamp = TimestampOption.perRow("timestamp", Some(55L))))
+
+    verifyKeyValueTable("key_value")
+
+    val resultMap = conn.withSessionDo { session =>
+      val result = session.execute(s"""SELECT key, WRITETIME(value) FROM $ks.key_value""").all()
+      result.map( row => (row.getInt(0), row.getLong(1))).toMap
+      }
+
+    resultMap(1) should be (55L)
+  }
+
+
 
   it should "write RDD of case class objects with per-row TTL with custom mapping" in {
     conn.withSessionDo(_.execute(s"""TRUNCATE $ks.key_value"""))

--- a/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/CassandraJavaUtil.java
+++ b/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/CassandraJavaUtil.java
@@ -1710,11 +1710,11 @@ public class CassandraJavaUtil {
     }
 
     public static TTL ttl(String columnName) {
-        return new TTL(columnName, Option.<String>empty());
+        return new TTL(columnName, Option.<String>empty(), Option.<Object>empty());
     }
 
     public static WriteTime writeTime(String columnName) {
-        return new WriteTime(columnName, Option.<String>empty());
+        return new WriteTime(columnName, Option.<String>empty(), Option.<Object>empty());
     }
 
     public static ColumnRef[] toSelectableColumnRefs(String... columnNames) {

--- a/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/RDDAndDStreamCommonJavaFunctions.java
+++ b/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/RDDAndDStreamCommonJavaFunctions.java
@@ -8,6 +8,7 @@ import com.datastax.spark.connector.writer.*;
 import org.apache.spark.SparkConf;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
+import scala.Option;
 
 import java.io.Serializable;
 import java.util.Date;
@@ -401,12 +402,29 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
          * Returns a copy of this builder with the new write configuration which has write timestamp set
          * to a placeholder which will be filled-in by mapper.
          *
+         * If the value in the placeholder column is null then the current timestamp on the executor
+         * will be used.
+         *
          * <p>If the same instance is passed as the one which is currently set, no copy of this builder is created.</p>
          *
          * @return this instance or copy to allow method invocation chaining
          */
         public WriterBuilder withPerRowTimestamp(String placeholder) {
-            return withTimestamp(TimestampOption$.MODULE$.perRow(placeholder));
+            return withTimestamp(TimestampOption$.MODULE$.perRow(placeholder, Option.empty()));
+        }
+
+        /**
+         * Returns a copy of this builder with the new write configuration which has write timestamp set
+         * to a placeholder which will be filled-in by mapper.
+         *
+         * DefaultTimestamp will be applied if the placeholder value is null
+         *
+         * <p>If the same instance is passed as the one which is currently set, no copy of this builder is created.</p>
+         *
+         * @return this instance or copy to allow method invocation chaining
+         */
+        public WriterBuilder withPerRowTimestamp(String placeholder, Long defaultTimestamp) {
+            return withTimestamp(TimestampOption$.MODULE$.perRow(placeholder, Option.<Object>apply(defaultTimestamp)));
         }
 
 
@@ -468,12 +486,28 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
          * Returns a copy of this builder with the new write configuration which has TTL set to a placeholder
          * which will be filled-in by mapper.
          *
+         * If a value in the placeholder column is null the Table's Default TTL will be used.
+         *
          * <p>If the same instance is passed as the one which is currently set, no copy of this builder is created.</p>
          *
          * @return this instance or copy to allow method invocation chaining
          */
         public WriterBuilder withPerRowTTL(String placeholder) {
-            return withTTL(TTLOption$.MODULE$.perRow(placeholder));
+            return withTTL(TTLOption$.MODULE$.perRow(placeholder, Option.empty()));
+        }
+
+        /**
+         * Returns a copy of this builder with the new write configuration which has TTL set to a placeholder
+         * which will be filled-in by mapper.
+         *
+         * DefaultTTL will be applied if the given placeholder is null
+         *
+         * <p>If the same instance is passed as the one which is currently set, no copy of this builder is created.</p>
+         *
+         * @return this instance or copy to allow method invocation chaining
+         */
+        public WriterBuilder withPerRowTTL(String placeholder, Integer defaultTTL) {
+            return withTTL(TTLOption$.MODULE$.perRow(placeholder, Option.<Object>apply(defaultTTL)));
         }
 
         /**

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
@@ -348,4 +348,21 @@ object Schema extends Logging {
         throw new IOException(errorMessage)
       }
     }
+
+  /**
+    * Get default TTL for Table
+    */
+  def ttlFromCassandra(
+    connector: CassandraConnector,
+    keyspaceName: String,
+    tableName: String) : Option[Int] = {
+
+    tableFromCassandra(connector, keyspaceName, tableName) // Checks for existence of table
+    Try(connector.withClusterDo(
+      _.getMetadata
+      .getKeyspace(keyspaceName)
+      .getTable(tableName)
+      .getOptions
+      .getDefaultTimeToLive)).toOption
+  }
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/DefaultColumnMapper.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/DefaultColumnMapper.scala
@@ -105,7 +105,7 @@ class DefaultColumnMapper[T : TypeTag](columnNameOverride: Map[String, String] =
     // Check if we have all the required columns:
     val mappedColumns = getterMap.values.toSet
     val unmappedColumns = selectedColumns.filterNot(mappedColumns)
-    require(unmappedColumns.isEmpty, s"Columns not found in $tpe: [${unmappedColumns.mkString(", ")}]")
+    require(unmappedColumns.isEmpty, s"Columns not found in $tpe: [${unmappedColumns.mkString(", ")}] : Found columns ${columns} ")
 
     SimpleColumnMapForWriting(getterMap)
   }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableRowReaderProvider.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableRowReaderProvider.scala
@@ -58,11 +58,11 @@ trait CassandraTableRowReaderProvider[R] {
         case ColumnName(columnName, _) =>
           if (!allColumnNames.contains(column.columnName))
             throw new IOException(s"Column $column not found in table $keyspaceName.$tableName")
-        case TTL(columnName, _) =>
+        case TTL(columnName, _, _) =>
           if (!regularColumnNames.contains(columnName))
             throw new IOException(s"TTL can be obtained only for regular columns, " +
               s"but column $columnName is not a regular column in table $keyspaceName.$tableName.")
-        case WriteTime(columnName, _) =>
+        case WriteTime(columnName, _, _) =>
           if (!regularColumnNames.contains(columnName))
             throw new IOException(s"TTL can be obtained only for regular columns, " +
               s"but column $columnName is not a regular column in table $keyspaceName.$tableName.")

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/GettableDataToMappedTypeConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/GettableDataToMappedTypeConverter.scala
@@ -120,7 +120,7 @@ private[connector] class GettableDataToMappedTypeConverter[T : TypeTag : ColumnM
   /** Returns the type of the column, basing on the struct definition. */
   private def columnType(columnRef: ColumnRef): ColumnType[_] = {
     columnRef match {
-      case TTL(_, _) | WriteTime(_, _) | RowCountRef =>
+      case TTL(_, _, _) | WriteTime(_, _, _) | RowCountRef =>
         BigIntType
       case c:ColumnRef =>
         structDef.columnByName(c.columnName).columnType

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/CassandraRowWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/CassandraRowWriter.scala
@@ -6,7 +6,7 @@ import com.datastax.spark.connector.cql.TableDef
 /** A [[RowWriter]] that can write [[CassandraRow]] objects.*/
 class CassandraRowWriter(table: TableDef, selectedColumns: IndexedSeq[ColumnRef]) extends RowWriter[CassandraRow] {
 
-  override val columnNames = selectedColumns.map(_.columnName)
+  override val columnRefs = selectedColumns
 
   private val columns = columnNames.map(table.columnByName).toIndexedSeq
   private val converters = columns.map(_.columnType.converterToCassandra)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/DefaultRowWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/DefaultRowWriter.scala
@@ -15,7 +15,7 @@ class DefaultRowWriter[T : TypeTag : ColumnMapper](
   extends RowWriter[T] {
 
   private val converter = MappedToGettableDataConverter[T](table, selectedColumns)
-  override val columnNames = selectedColumns.map(_.columnName)
+  override val columnRefs = selectedColumns
 
   override def readColumnValues(data: T, buffer: Array[Any]) = {
     val row = converter.convert(data)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/RowWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/RowWriter.scala
@@ -1,14 +1,28 @@
 package com.datastax.spark.connector.writer
 
+import com.datastax.spark.connector.ColumnRef
+
 
 /** `RowWriter` knows how to extract column names and values from custom row objects
   * and how to convert them to values that can be written to Cassandra.
   * `RowWriter` is required to apply any user-defined data type conversion. */
 trait RowWriter[T] extends Serializable {
 
+  /**
+    * ColumnRef objects for all the columns that this `RowWriter` will write.
+    */
+  def columnRefs: Seq[ColumnRef]
+
   /** List of columns this `RowWriter` is going to write.
     * Used to construct appropriate INSERT or UPDATE statement. */
-  def columnNames: Seq[String]
+  final lazy val columnNames: Seq[String] = columnRefs.map(_.columnName)
+
+  /**
+    * Mapping back to column refs from column names
+    */
+  final lazy val columnNameToRef: Map[String, ColumnRef] = columnRefs
+    .map( ref => (ref.columnName, ref))
+    .toMap
 
   /** Extracts column values from `data` object and writes them into the given buffer
     * in the same order as they are listed in the columnNames sequence. */

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/RowWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/RowWriter.scala
@@ -9,20 +9,13 @@ import com.datastax.spark.connector.ColumnRef
 trait RowWriter[T] extends Serializable {
 
   /**
-    * ColumnRef objects for all the columns that this `RowWriter` will write.
+    * ColumnRef objects for all the columns that this `RowWriter` will write. Column Names are used
+    * to construct appropriate INSERT or UPDATE statements and metadata controls more obscure
+    * binding behavior (No Null/ Unbound TTL on C* 2.1 )
     */
-  def columnRefs: Seq[ColumnRef]
+  def columnRefs: IndexedSeq[ColumnRef]
 
-  /** List of columns this `RowWriter` is going to write.
-    * Used to construct appropriate INSERT or UPDATE statement. */
-  final lazy val columnNames: Seq[String] = columnRefs.map(_.columnName)
-
-  /**
-    * Mapping back to column refs from column names
-    */
-  final lazy val columnNameToRef: Map[String, ColumnRef] = columnRefs
-    .map( ref => (ref.columnName, ref))
-    .toMap
+  lazy val columnNames: IndexedSeq[String] = columnRefs.map(_.columnName)
 
   /** Extracts column values from `data` object and writes them into the given buffer
     * in the same order as they are listed in the columnNames sequence. */

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/SqlRowWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/SqlRowWriter.scala
@@ -12,7 +12,7 @@ import org.apache.spark.sql.Row
 class SqlRowWriter(val table: TableDef, val selectedColumns: IndexedSeq[ColumnRef])
   extends RowWriter[Row] {
 
-  override val columnNames = selectedColumns.map(_.columnName)
+  override val columnRefs = selectedColumns
   private val columns = columnNames.map(table.columnByName)
   private val columnTypes = columns.map(_.columnType)
   private val converters = columns.map(_.columnType.converterToCassandra)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -42,13 +42,13 @@ class TableWriter[T] private (
     val ifNotExistsSpec = if (writeConf.ifNotExists) "IF NOT EXISTS " else ""
 
     val ttlSpec = writeConf.ttl match {
-      case TTLOption(PerRowWriteOptionValue(placeholder)) => Some(s"TTL :$placeholder")
+      case TTLOption(PerRowWriteOptionValue(placeholder, _)) => Some(s"TTL :$placeholder")
       case TTLOption(StaticWriteOptionValue(value)) => Some(s"TTL $value")
       case _ => None
     }
 
     val timestampSpec = writeConf.timestamp match {
-      case TimestampOption(PerRowWriteOptionValue(placeholder)) => Some(s"TIMESTAMP :$placeholder")
+      case TimestampOption(PerRowWriteOptionValue(placeholder, _)) => Some(s"TIMESTAMP :$placeholder")
       case TimestampOption(StaticWriteOptionValue(value)) => Some(s"TIMESTAMP $value")
       case _ => None
     }
@@ -267,9 +267,12 @@ object TableWriter {
     val tableDef = Schema.tableFromCassandra(connector, keyspaceName, tableName)
     val selectedColumns = columnNames.selectFrom(tableDef)
     val optionColumns = writeConf.optionsAsColumns(keyspaceName, tableName)
+    val optionRefs = writeConf.optionsAsColumnRef(
+      Schema.ttlFromCassandra(connector, keyspaceName, tableName))
+
     val rowWriter = implicitly[RowWriterFactory[T]].rowWriter(
       tableDef.copy(regularColumns = tableDef.regularColumns ++ optionColumns),
-      selectedColumns ++ optionColumns.map(_.ref))
+      selectedColumns ++ optionRefs)
 
     checkColumns(tableDef, selectedColumns)
     new TableWriter[T](connector, tableDef, selectedColumns, rowWriter, writeConf)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteOption.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteOption.scala
@@ -44,6 +44,11 @@ object TTLOption {
 
   def constant(ttl: ScalaDuration): TTLOption = if (ttl.isFinite()) constant(ttl.toSeconds.toInt) else forever
 
+  /**
+    *  Assigns the TTL based on the value in the placeholder column. If the value in the column is
+    *  null the Table's default will be used unless valueIfNull is specified.
+    *  On Cassandra >= 2.2 use a CassandraOption in the placeholder column to leave the TTL unbound.
+    */
   def perRow(placeholder: String, valueIfNull: Option[Int] = None): TTLOption =
     TTLOption(PerRowWriteOptionValue[Int](placeholder, valueIfNull))
 
@@ -62,6 +67,12 @@ object TimestampOption {
 
   def constant(timestamp: DateTime): TimestampOption = constant(timestamp.getMillis * 1000L)
 
+  /**
+    * Assigns the Timestamp for the write based on the value in the placeholder column. If the value
+    * in the column is null then the current timestamp of the executor on insert will be used
+    * unless the valueIfNull is specified. On Cassandra >= 2.2 use a CassandraOption to leave the
+    * Timestamp unbound.
+    */
   def perRow(placeholder: String, valueIfNull: Option[Long] = None): TimestampOption =
     TimestampOption(PerRowWriteOptionValue(placeholder, valueIfNull))
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteOption.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteOption.scala
@@ -10,7 +10,7 @@ sealed trait WriteOptionValue[+T]
 
 case class StaticWriteOptionValue[T](value: T) extends WriteOptionValue[T]
 
-case class PerRowWriteOptionValue[T](placeholder: String) extends WriteOptionValue[T]
+case class PerRowWriteOptionValue[T](placeholder: String, valueIfNull: Option[T]) extends WriteOptionValue[T]
 
 sealed trait WriteOption[+T]
 
@@ -44,7 +44,8 @@ object TTLOption {
 
   def constant(ttl: ScalaDuration): TTLOption = if (ttl.isFinite()) constant(ttl.toSeconds.toInt) else forever
 
-  def perRow(placeholder: String): TTLOption = TTLOption(PerRowWriteOptionValue[Int](placeholder))
+  def perRow(placeholder: String, valueIfNull: Option[Int] = None): TTLOption =
+    TTLOption(PerRowWriteOptionValue[Int](placeholder, valueIfNull))
 
 }
 
@@ -61,6 +62,6 @@ object TimestampOption {
 
   def constant(timestamp: DateTime): TimestampOption = constant(timestamp.getMillis * 1000L)
 
-  def perRow(placeholder: String): TimestampOption =
-    TimestampOption(PerRowWriteOptionValue(placeholder))
+  def perRow(placeholder: String, valueIfNull: Option[Long] = None): TimestampOption =
+    TimestampOption(PerRowWriteOptionValue(placeholder, valueIfNull))
 }


### PR DESCRIPTION
6d39d73 (Russell Spitzer, 80 seconds ago)
    SPARKC-397: Docs for null TTL and WRITETIME behavior

 2d77829 (Russell Spitzer, 13 minutes ago)
    SPARKC-397: Prevent Null Pointer Exceptions on TTL and WriteTime

    Both TTL and WriteTime cannot be set to null and for C* < 2.2 there is no
    way to leave the parameter unbound. To avoid null pointers we provide the
    following defaults unless modified by the end user.

    TTL is set to the table default_ttl WriteTime is set to currentTimeMillis *
    1000L on Insertion

    This has required some rather extensive refactoring which has changed
    several interfaces. The general thread is pass information via a ColumnRef
    down to the BoundStatementBuilder where it can read the metadata provided
    and take evasive manuevers when it sees a NULL in a non-nullable parameter.

    WriteOption has been extended so that perRow now also allows for an
    additional valueIfNull parameter which can be used to override the defaults
    specified above.

    Parallel extensions where made to the Java interface to allow for the same
    access from java.

 7abb242 (Russell Spitzer, 29 hours ago)
    SPARKC-397: Refactor RowWriter to Carry ColumnRef Information

    Previously only the string names of the columns were possessed by the
    underlying RowWriter. This made it impossible to change bind behavior based
    on the ColumnRef Type. This modification allows for us to act differently
    based on the underlying columnref created by the User.