### PR TITLE
SPARKC-181 -Adding support for left joins

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 2.0.0 M1
+ * Added support for left outer joins with C* table (SPARKC-181)
  * Removed CassandraSqlContext and underscore based options (SPARKC-399)
  * Upgrade to Spark 2.0.0-preview (SPARKC-396)
     - Removed Twitter demo because there is no spark-streaming-twitter package available anymore

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
@@ -152,7 +152,7 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
   /**
     * Uses the data from [[org.apache.spark.rdd.RDD RDD]] to left join with a Cassandra table without
     * retrieving the entire table.
-    * Any RDD which can be used to saveToCassandra can be used to joinWithCassandra as well as any
+    * Any RDD which can be used to saveToCassandra can be used to leftJoinWithCassandra as well as any
     * RDD which only specifies the partition Key of a Cassandra Table. This method executes single
     * partition requests against the Cassandra Table and accepts the functional modifiers that a
     * normal [[com.datastax.spark.connector.rdd.CassandraTableScanRDD]] takes.

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
@@ -7,7 +7,7 @@ import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.mapper.ColumnMapper
 import com.datastax.spark.connector.rdd.partitioner.{CassandraPartitionedRDD, ReplicaPartitioner}
 import com.datastax.spark.connector.rdd.reader._
-import com.datastax.spark.connector.rdd.{ReadConf, CassandraJoinRDD, SpannedRDD, ValidRDDType}
+import com.datastax.spark.connector.rdd.{ReadConf, CassandraJoinRDD, CassandraLeftJoinRDD, SpannedRDD, ValidRDDType}
 import com.datastax.spark.connector.writer.{ReplicaLocator, _}
 import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext._
@@ -138,6 +138,52 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
     rwf: RowWriterFactory[T]): CassandraJoinRDD[T, R] = {
 
     new CassandraJoinRDD[T, R](
+      rdd,
+      keyspaceName,
+      tableName,
+      connector,
+      columnNames = selectedColumns,
+      joinColumns = joinColumns,
+      readConf = ReadConf.fromSparkConf(rdd.sparkContext.getConf)
+    )
+  }
+
+
+  /**
+    * Uses the data from [[org.apache.spark.rdd.RDD RDD]] to left join with a Cassandra table without
+    * retrieving the entire table.
+    * Any RDD which can be used to saveToCassandra can be used to joinWithCassandra as well as any
+    * RDD which only specifies the partition Key of a Cassandra Table. This method executes single
+    * partition requests against the Cassandra Table and accepts the functional modifiers that a
+    * normal [[com.datastax.spark.connector.rdd.CassandraTableScanRDD]] takes.
+    *
+    * By default this method only uses the Partition Key for joining but any combination of columns
+    * which are acceptable to C* can be used in the join. Specify columns using joinColumns as a parameter
+    * or the on() method.
+    *
+    * Example With Prior Repartitioning: {{{
+    * val source = sc.parallelize(keys).map(x => new KVRow(x))
+    * val repart = source.repartitionByCassandraReplica(keyspace, tableName, 10)
+    * val someCass = repart.leftJoinWithCassandraTable(keyspace, tableName)
+    * }}}
+    *
+    * Example Joining on Clustering Columns: {{{
+    * val source = sc.parallelize(keys).map(x => (x, x * 100))
+    * val someCass = source.leftJoinWithCassandraTable(keyspace, wideTable).on(SomeColumns("key", "group"))
+    * }}}
+    **/
+  def leftJoinWithCassandraTable[R](
+    keyspaceName: String, tableName: String,
+    selectedColumns: ColumnSelector = AllColumns,
+    joinColumns: ColumnSelector = PartitionKeyColumns)(
+  implicit
+    connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+    newType: ClassTag[R], rrf: RowReaderFactory[R],
+    ev: ValidRDDType[R],
+    currentType: ClassTag[T],
+    rwf: RowWriterFactory[T]): CassandraLeftJoinRDD[T, R] = {
+
+    new CassandraLeftJoinRDD[T, R](
       rdd,
       keyspaceName,
       tableName,

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/AbstractCassandraJoin.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/AbstractCassandraJoin.scala
@@ -1,0 +1,186 @@
+package com.datastax.spark.connector.rdd
+
+import com.datastax.driver.core.Session
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.util.CqlWhereParser.{EqPredicate, InListPredicate, InPredicate, RangePredicate}
+import com.datastax.spark.connector.util.Quote._
+import com.datastax.spark.connector.util.{CountingIterator, CqlWhereParser}
+import com.datastax.spark.connector.writer._
+import org.apache.spark.metrics.InputMetricsUpdater
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{Partition, TaskContext}
+
+/**
+ * This trait contains shared methods from [[com.datastax.spark.connector.rdd.CassandraJoinRDD]] and
+ * [[com.datastax.spark.connector.rdd.CassandraLeftJoinRDD]] to avoid code duplication.
+ *
+ * @tparam L item type on the left side of the join (any RDD)
+ * @tparam R item type on the right side of the join (fetched from Cassandra)
+ */
+private[rdd] trait AbstractCassandraJoin[L, R] {
+
+  self: CassandraRDD[(L, R)] with CassandraTableRowReaderProvider[_] =>
+
+  val left: RDD[L]
+  val joinColumns: ColumnSelector
+  val manualRowWriter: Option[RowWriter[L]]
+  implicit val rowWriterFactory: RowWriterFactory[L]
+
+  private[rdd] def fetchIterator(
+    session: Session,
+    bsb: BoundStatementBuilder[L],
+    lastIt: Iterator[L]
+  ): Iterator[(L, R)]
+
+  lazy val rowWriter = manualRowWriter match {
+    case Some(_rowWriter) => _rowWriter
+    case None => implicitly[RowWriterFactory[L]].rowWriter(tableDef, joinColumnNames.toIndexedSeq)
+  }
+
+  lazy val joinColumnNames: Seq[ColumnRef] = joinColumns match {
+    case AllColumns => throw new IllegalArgumentException(
+      "Unable to join against all columns in a Cassandra Table. Only primary key columns allowed."
+    )
+    case PartitionKeyColumns =>
+      tableDef.partitionKey.map(col => col.columnName: ColumnRef)
+    case SomeColumns(cs @ _*) =>
+      checkColumnsExistence(cs)
+      cs.map {
+        case c: ColumnRef => c
+        case _ => throw new IllegalArgumentException(
+          "Unable to join against unnamed columns. No CQL Functions allowed."
+        )
+      }
+  }
+
+  /**
+   * This method will create the RowWriter required before the RDD is serialized.
+   * This is called during getPartitions
+   */
+  protected def checkValidJoin(): Seq[ColumnRef] = {
+    val partitionKeyColumnNames = tableDef.partitionKey.map(_.columnName).toSet
+    val primaryKeyColumnNames = tableDef.primaryKey.map(_.columnName).toSet
+    val colNames = joinColumnNames.map(_.columnName).toSet
+
+    // Initialize RowWriter and Query to be used for accessing Cassandra
+    rowWriter.columnNames
+    singleKeyCqlQuery.length
+
+    def checkSingleColumn(column: ColumnRef): Unit = {
+      require(
+        primaryKeyColumnNames.contains(column.columnName),
+        s"Can't pushdown join on column $column because it is not part of the PRIMARY KEY"
+      )
+    }
+
+    // Make sure we have all of the clustering indexes between the 0th position and the max requested
+    // in the join:
+    val chosenClusteringColumns = tableDef.clusteringColumns
+      .filter(cc => colNames.contains(cc.columnName))
+    if (!tableDef.clusteringColumns.startsWith(chosenClusteringColumns)) {
+      val maxCol = chosenClusteringColumns.last
+      val maxIndex = maxCol.componentIndex.get
+      val requiredColumns = tableDef.clusteringColumns.takeWhile(_.componentIndex.get <= maxIndex)
+      val missingColumns = requiredColumns.toSet -- chosenClusteringColumns.toSet
+      throw new IllegalArgumentException(
+        s"Can't pushdown join on column $maxCol without also specifying [ $missingColumns ]"
+      )
+    }
+    val missingPartitionKeys = partitionKeyColumnNames -- colNames
+    require(
+      missingPartitionKeys.isEmpty,
+      s"Can't join without the full partition key. Missing: [ $missingPartitionKeys ]"
+    )
+
+    joinColumnNames.foreach(checkSingleColumn)
+    joinColumnNames
+  }
+
+  //We need to make sure we get selectedColumnRefs before serialization so that our RowReader is
+  //built
+  lazy val singleKeyCqlQuery: (String) = {
+    val whereClauses = where.predicates.flatMap(CqlWhereParser.parse)
+    val joinColumns = joinColumnNames.map(_.columnName)
+    val joinColumnPredicates = whereClauses.collect {
+      case EqPredicate(c, _) if joinColumns.contains(c) => c
+      case InPredicate(c) if joinColumns.contains(c) => c
+      case InListPredicate(c, _) if joinColumns.contains(c) => c
+      case RangePredicate(c, _, _) if joinColumns.contains(c) => c
+    }.toSet
+
+    require(
+      joinColumnPredicates.isEmpty,
+      s"""Columns specified in both the join on clause and the where clause.
+          |Partition key columns are always part of the join clause.
+          |Columns in both: ${joinColumnPredicates.mkString(", ")}""".stripMargin
+    )
+
+    logDebug("Generating Single Key Query Prepared Statement String")
+    logDebug(s"SelectedColumns : $selectedColumnRefs -- JoinColumnNames : $joinColumnNames")
+    val columns = selectedColumnRefs.map(_.cql).mkString(", ")
+    val joinWhere = joinColumnNames.map(_.columnName).map(name => s"${quote(name)} = :$name")
+    val limitClause = limit.map(limit => s"LIMIT $limit").getOrElse("")
+    val orderBy = clusteringOrder.map(_.toCql(tableDef)).getOrElse("")
+    val filter = (where.predicates ++ joinWhere).mkString(" AND ")
+    val quotedKeyspaceName = quote(keyspaceName)
+    val quotedTableName = quote(tableName)
+    val query =
+      s"SELECT $columns " +
+        s"FROM $quotedKeyspaceName.$quotedTableName " +
+        s"WHERE $filter $limitClause $orderBy"
+    logDebug(s"Query : $query")
+    query
+  }
+
+  private def boundStatementBuilder(session: Session): BoundStatementBuilder[L] = {
+    val protocolVersion = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersion
+    val stmt = session.prepare(singleKeyCqlQuery).setConsistencyLevel(consistencyLevel)
+    new BoundStatementBuilder[L](rowWriter, stmt, where.values, protocolVersion = protocolVersion)
+  }
+
+  /**
+   * When computing a CassandraPartitionKeyRDD the data is selected via single CQL statements
+   * from the specified C* Keyspace and Table. This will be preformed on whatever data is
+   * available in the previous RDD in the chain.
+   */
+  override def compute(split: Partition, context: TaskContext): Iterator[(L, R)] = {
+    val session = connector.openSession()
+    val bsb = boundStatementBuilder(session)
+    val metricsUpdater = InputMetricsUpdater(context, readConf)
+    val rowIterator = fetchIterator(session, bsb, left.iterator(split, context))
+    val countingIterator = new CountingIterator(rowIterator, limit)
+
+    context.addTaskCompletionListener { (context) =>
+      val duration = metricsUpdater.finish() / 1000000000d
+      logDebug(
+        f"Fetched ${countingIterator.count} rows " +
+          f"from $keyspaceName.$tableName " +
+          f"for partition ${split.index} in $duration%.3f s."
+      )
+      session.close()
+    }
+    countingIterator
+  }
+
+  override protected def getPartitions: Array[Partition] = {
+    verify()
+    checkValidJoin()
+    left.partitions
+  }
+
+  override def getPreferredLocations(split: Partition): Seq[String] = left.preferredLocations(split)
+
+  override def toEmptyCassandraRDD: EmptyCassandraRDD[(L, R)] =
+    new EmptyCassandraRDD[(L, R)](
+      sc = left.sparkContext,
+      keyspaceName = keyspaceName,
+      tableName = tableName,
+      columnNames = columnNames,
+      where = where,
+      limit = limit,
+      clusteringOrder = clusteringOrder,
+      readConf = readConf
+    )
+
+}
+

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
@@ -1,20 +1,14 @@
 package com.datastax.spark.connector.rdd
 
-import org.apache.spark.metrics.InputMetricsUpdater
-
 import com.datastax.driver.core.{ResultSet, Session}
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.rdd.reader._
-import com.datastax.spark.connector.util.CqlWhereParser.{EqPredicate, InListPredicate, InPredicate, RangePredicate}
-import com.datastax.spark.connector.util.{CountingIterator, CqlWhereParser}
 import com.datastax.spark.connector.writer._
-import com.datastax.spark.connector.util.Quote._
-import org.apache.spark.rdd.RDD
-import org.apache.spark.{Partition, TaskContext}
-import scala.reflect.ClassTag
-
 import com.google.common.util.concurrent.{FutureCallback, Futures, SettableFuture}
+import org.apache.spark.rdd.RDD
+
+import scala.reflect.ClassTag
 
 /**
  * An [[org.apache.spark.rdd.RDD RDD]] that will do a selecting join between `left` RDD and the specified
@@ -26,7 +20,7 @@ import com.google.common.util.concurrent.{FutureCallback, Futures, SettableFutur
  * @tparam R item type on the right side of the join (fetched from Cassandra)
  */
 class CassandraJoinRDD[L, R] private[connector](
-    left: RDD[L],
+    override val left: RDD[L],
     val keyspaceName: String,
     val tableName: String,
     val connector: CassandraConnector,
@@ -37,14 +31,15 @@ class CassandraJoinRDD[L, R] private[connector](
     val clusteringOrder: Option[ClusteringOrder] = None,
     val readConf: ReadConf = ReadConf(),
     manualRowReader: Option[RowReader[R]] = None,
-    manualRowWriter: Option[RowWriter[L]] = None)(
+    override val manualRowWriter: Option[RowWriter[L]] = None)(
   implicit
     val leftClassTag: ClassTag[L],
     val rightClassTag: ClassTag[R],
     @transient val rowWriterFactory: RowWriterFactory[L],
     @transient val rowReaderFactory: RowReaderFactory[R])
   extends CassandraRDD[(L, R)](left.sparkContext, left.dependencies)
-  with CassandraTableRowReaderProvider[R] {
+  with CassandraTableRowReaderProvider[R]
+  with AbstractCassandraJoin[L, R] {
 
   override type Self = CassandraJoinRDD[L, R]
 
@@ -52,7 +47,7 @@ class CassandraJoinRDD[L, R] private[connector](
 
   override lazy val rowReader: RowReader[R] = manualRowReader match {
     case Some(rr) => rr
-    case None => rowReaderFactory.rowReader (tableDef, columnNames.selectFrom (tableDef) )
+    case None => rowReaderFactory.rowReader(tableDef, columnNames.selectFrom(tableDef))
   }
 
   override protected def copy(
@@ -61,7 +56,8 @@ class CassandraJoinRDD[L, R] private[connector](
     limit: Option[Long] = limit,
     clusteringOrder: Option[ClusteringOrder] = None,
     readConf: ReadConf = readConf,
-    connector: CassandraConnector = connector): Self = {
+    connector: CassandraConnector = connector
+  ): Self = {
 
     new CassandraJoinRDD[L, R](
       left = left,
@@ -73,21 +69,8 @@ class CassandraJoinRDD[L, R] private[connector](
       where = where,
       limit = limit,
       clusteringOrder = clusteringOrder,
-      readConf = readConf)
-  }
-
-  lazy val joinColumnNames: Seq[ColumnRef] = joinColumns match {
-    case AllColumns => throw new IllegalArgumentException(
-      "Unable to join against all columns in a Cassandra Table. Only primary key columns allowed.")
-    case PartitionKeyColumns =>
-      tableDef.partitionKey.map(col => col.columnName: ColumnRef)
-    case SomeColumns(cs @ _*) =>
-      checkColumnsExistence(cs)
-      cs.map {
-        case c: ColumnRef => c
-        case _ => throw new IllegalArgumentException(
-          "Unable to join against unnamed columns. No CQL Functions allowed.")
-      }
+      readConf = readConf
+    )
   }
 
   override def cassandraCount(): Long = {
@@ -108,52 +91,10 @@ class CassandraJoinRDD[L, R] private[connector](
         where = where,
         limit = limit,
         clusteringOrder = clusteringOrder,
-        readConf= readConf)
+        readConf = readConf
+      )
 
     counts.map(_._2).reduce(_ + _)
-  }
-
-  /** This method will create the RowWriter required before the RDD is serialized.
-    * This is called during getPartitions */
-  protected def checkValidJoin(): Seq[ColumnRef] = {
-    val partitionKeyColumnNames = tableDef.partitionKey.map(_.columnName).toSet
-    val primaryKeyColumnNames = tableDef.primaryKey.map(_.columnName).toSet
-    val colNames = joinColumnNames.map(_.columnName).toSet
-
-    // Initialize RowWriter and Query to be used for accessing Cassandra
-    rowWriter.columnNames
-    singleKeyCqlQuery.length
-
-    def checkSingleColumn(column: ColumnRef): Unit = {
-      require(
-        primaryKeyColumnNames.contains(column.columnName),
-        s"Can't pushdown join on column $column because it is not part of the PRIMARY KEY")
-    }
-
-    // Make sure we have all of the clustering indexes between the 0th position and the max requested
-    // in the join:
-    val chosenClusteringColumns = tableDef.clusteringColumns
-      .filter(cc => colNames.contains(cc.columnName))
-    if (!tableDef.clusteringColumns.startsWith(chosenClusteringColumns)) {
-      val maxCol = chosenClusteringColumns.last
-      val maxIndex = maxCol.componentIndex.get
-      val requiredColumns = tableDef.clusteringColumns.takeWhile(_.componentIndex.get <= maxIndex)
-      val missingColumns = requiredColumns.toSet -- chosenClusteringColumns.toSet
-      throw new IllegalArgumentException(
-        s"Can't pushdown join on column $maxCol without also specifying [ $missingColumns ]")
-    }
-    val missingPartitionKeys = partitionKeyColumnNames -- colNames
-    require(
-      missingPartitionKeys.isEmpty,
-      s"Can't join without the full partition key. Missing: [ $missingPartitionKeys ]")
-
-    joinColumnNames.foreach(checkSingleColumn)
-    joinColumnNames
-  }
-
-  lazy val rowWriter = manualRowWriter match {
-    case Some(rowWriter) => rowWriter
-    case None => implicitly[RowWriterFactory[L]].rowWriter (tableDef, joinColumnNames.toIndexedSeq)
   }
 
   def on(joinColumns: ColumnSelector): CassandraJoinRDD[L, R] = {
@@ -167,81 +108,19 @@ class CassandraJoinRDD[L, R] private[connector](
       where = where,
       limit = limit,
       clusteringOrder = clusteringOrder,
-      readConf = readConf)
-  }
-
-  //We need to make sure we get selectedColumnRefs before serialization so that our RowReader is
-  //built
-  lazy val singleKeyCqlQuery: (String) = {
-    val whereClauses = where.predicates.flatMap(CqlWhereParser.parse)
-    val joinColumns = joinColumnNames.map(_.columnName)
-    val joinColumnPredicates = whereClauses.collect {
-      case EqPredicate(c, _) if joinColumns.contains(c) => c
-      case InPredicate(c) if joinColumns.contains(c) => c
-      case InListPredicate(c, _) if joinColumns.contains(c) => c
-      case RangePredicate(c, _, _) if joinColumns.contains(c) => c
-    }.toSet
-
-    require(
-      joinColumnPredicates.isEmpty,
-      s"""Columns specified in both the join on clause and the where clause.
-         |Partition key columns are always part of the join clause.
-         |Columns in both: ${joinColumnPredicates.mkString(", ")}""".stripMargin
+      readConf = readConf
     )
-
-    logDebug("Generating Single Key Query Prepared Statement String")
-    logDebug(s"SelectedColumns : $selectedColumnRefs -- JoinColumnNames : $joinColumnNames")
-    val columns = selectedColumnRefs.map(_.cql).mkString(", ")
-    val joinWhere = joinColumnNames.map(_.columnName).map(name => s"${quote(name)} = :$name")
-    val limitClause = limit.map(limit => s"LIMIT $limit").getOrElse("")
-    val orderBy = clusteringOrder.map(_.toCql(tableDef)).getOrElse("")
-    val filter = (where.predicates ++ joinWhere).mkString(" AND ")
-    val quotedKeyspaceName = quote(keyspaceName)
-    val quotedTableName = quote(tableName)
-    val query =
-      s"SELECT $columns " +
-        s"FROM $quotedKeyspaceName.$quotedTableName " +
-        s"WHERE $filter $limitClause $orderBy"
-    logDebug(s"Query : $query")
-    query
-  }
-
-  private[rdd] def boundStatementBuilder(session: Session): BoundStatementBuilder[L] = {
-    val protocolVersion = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersion
-    val stmt = session.prepare(singleKeyCqlQuery).setConsistencyLevel(consistencyLevel)
-    new BoundStatementBuilder[L](rowWriter, stmt, where.values, protocolVersion = protocolVersion)
-  }
-
-  /**
-   * When computing a CassandraPartitionKeyRDD the data is selected via single CQL statements
-   * from the specified C* Keyspace and Table. This will be preformed on whatever data is
-   * available in the previous RDD in the chain.
-   */
-  override def compute(split: Partition, context: TaskContext): Iterator[(L, R)] = {
-    val session = connector.openSession()
-    val bsb = boundStatementBuilder(session)
-    val metricsUpdater = InputMetricsUpdater(context, readConf)
-    val rowIterator = fetchIterator(session, bsb, left.iterator(split, context))
-    val countingIterator = new CountingIterator(rowIterator, limit)
-
-    context.addTaskCompletionListener { (context) =>
-      val duration = metricsUpdater.finish() / 1000000000d
-      logDebug(
-        f"Fetched ${countingIterator.count} rows " +
-          f"from $keyspaceName.$tableName " +
-          f"for partition ${split.index} in $duration%.3f s.")
-      session.close()
-    }
-    countingIterator
   }
 
   private[rdd] def fetchIterator(
     session: Session,
     bsb: BoundStatementBuilder[L],
-    leftIterator: Iterator[L]): Iterator[(L, R)] = {
+    leftIterator: Iterator[L]
+  ): Iterator[(L, R)] = {
     val columnNames = selectedColumnRefs.map(_.selectedAs).toIndexedSeq
     val rateLimiter = new RateLimiter(
-      readConf.throughputJoinQueryPerSec, readConf.throughputJoinQueryPerSec)
+      readConf.throughputJoinQueryPerSec, readConf.throughputJoinQueryPerSec
+    )
 
     def pairWithRight(left: L): SettableFuture[Iterator[(L, R)]] = {
       val resultFuture = SettableFuture.create[Iterator[(L, R)]]
@@ -251,7 +130,7 @@ class CassandraJoinRDD[L, R] private[connector](
       Futures.addCallback(queryFuture, new FutureCallback[ResultSet] {
         def onSuccess(rs: ResultSet) {
           val resultSet = new PrefetchingResultSetIterator(rs, fetchSize)
-          val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames,rs);
+          val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames, rs);
           val rightSide = resultSet.map(rowReader.read(_, columnMetaData))
           resultFuture.set(leftSide.zip(rightSide))
         }
@@ -268,33 +147,14 @@ class CassandraJoinRDD[L, R] private[connector](
     queryFutures.iterator.flatMap(_.get)
   }
 
-  override protected def getPartitions: Array[Partition] = {
-    verify()
-    checkValidJoin()
-    left.partitions
-  }
-
-  override def getPreferredLocations(split: Partition): Seq[String] = left.preferredLocations(split)
-
-  override def toEmptyCassandraRDD: EmptyCassandraRDD[(L, R)] =
-    new EmptyCassandraRDD[(L, R)](
-      sc = left.sparkContext,
-      keyspaceName = keyspaceName,
-      tableName = tableName,
-      columnNames = columnNames,
-      where = where,
-      limit = limit,
-      clusteringOrder = clusteringOrder,
-      readConf = readConf)
-
   /**
    * Turns this CassandraJoinRDD into a factory for converting other RDD's after being serialized
    * This method is for streaming operations as it allows us to Serialize a template JoinRDD
    * and the use that serializable template in the DStream closure. This gives us a fully serializable
    * joinWithCassandra operation
    */
-  private[connector] def applyToRDD( left:RDD[L]): CassandraJoinRDD[L,R] =  {
-    new CassandraJoinRDD[L,R](
+  private[connector] def applyToRDD(left: RDD[L]): CassandraJoinRDD[L, R] = {
+    new CassandraJoinRDD[L, R](
       left,
       keyspaceName,
       tableName,

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
@@ -56,12 +56,12 @@ class CassandraLeftJoinRDD[L, R] private[connector](
   }
 
   override protected def copy(
-                               columnNames: ColumnSelector = columnNames,
-                               where: CqlWhereClause = where,
-                               limit: Option[Long] = limit,
-                               clusteringOrder: Option[ClusteringOrder] = None,
-                               readConf: ReadConf = readConf,
-                               connector: CassandraConnector = connector): Self = {
+    columnNames: ColumnSelector = columnNames,
+    where: CqlWhereClause = where,
+    limit: Option[Long] = limit,
+    clusteringOrder: Option[ClusteringOrder] = None,
+    readConf: ReadConf = readConf,
+    connector: CassandraConnector = connector): Self = {
 
     new CassandraLeftJoinRDD[L, R](
       left = left,
@@ -108,7 +108,7 @@ class CassandraLeftJoinRDD[L, R] private[connector](
         where = where,
         limit = limit,
         clusteringOrder = clusteringOrder,
-        readConf= readConf)
+        readConf = readConf)
 
     counts.map(_._2.getOrElse(0L)).reduce( _ + _ )
   }
@@ -291,10 +291,10 @@ class CassandraLeftJoinRDD[L, R] private[connector](
       readConf = readConf)
 
   /**
-    * Turns this CassandraJoinRDD into a factory for converting other RDD's after being serialized
+    * Turns this CassandraLeftJoinRDD into a factory for converting other RDD's after being serialized
     * This method is for streaming operations as it allows us to Serialize a template JoinRDD
     * and the use that serializable template in the DStream closure. This gives us a fully serializable
-    * joinWithCassandra operation
+    * leftJoinWithCassandra operation
     */
   private[connector] def applyToRDD( left:RDD[L]): CassandraLeftJoinRDD[L,R] =  {
     new CassandraLeftJoinRDD[L,R](

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
@@ -1,32 +1,26 @@
 package com.datastax.spark.connector.rdd
 
-import org.apache.spark.metrics.InputMetricsUpdater
-
 import com.datastax.driver.core.{ResultSet, Session}
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.rdd.reader._
-import com.datastax.spark.connector.util.CqlWhereParser.{EqPredicate, InListPredicate, InPredicate, RangePredicate}
-import com.datastax.spark.connector.util.{CountingIterator, CqlWhereParser}
 import com.datastax.spark.connector.writer._
-import com.datastax.spark.connector.util.Quote._
+import com.google.common.util.concurrent.{FutureCallback, Futures, SettableFuture}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.{Partition, TaskContext}
+
 import scala.reflect.ClassTag
 
-import com.google.common.util.concurrent.{FutureCallback, Futures, SettableFuture}
-
 /**
-  * An [[org.apache.spark.rdd.RDD RDD]] that will do a selecting join between `left` RDD and the specified
-  * Cassandra Table This will perform individual selects to retrieve the rows from Cassandra and will take
-  * advantage of RDDs that have been partitioned with the
-  * [[com.datastax.spark.connector.rdd.partitioner.ReplicaPartitioner]]
-  *
-  * @tparam L item type on the left side of the join (any RDD)
-  * @tparam R item type on the right side of the join (fetched from Cassandra)
-  */
+ * An [[org.apache.spark.rdd.RDD RDD]] that will do a selecting join between `left` RDD and the specified
+ * Cassandra Table This will perform individual selects to retrieve the rows from Cassandra and will take
+ * advantage of RDDs that have been partitioned with the
+ * [[com.datastax.spark.connector.rdd.partitioner.ReplicaPartitioner]]
+ *
+ * @tparam L item type on the left side of the join (any RDD)
+ * @tparam R item type on the right side of the join (fetched from Cassandra)
+ */
 class CassandraLeftJoinRDD[L, R] private[connector](
-    left: RDD[L],
+    override val left: RDD[L],
     val keyspaceName: String,
     val tableName: String,
     val connector: CassandraConnector,
@@ -37,14 +31,15 @@ class CassandraLeftJoinRDD[L, R] private[connector](
     val clusteringOrder: Option[ClusteringOrder] = None,
     val readConf: ReadConf = ReadConf(),
     manualRowReader: Option[RowReader[R]] = None,
-    manualRowWriter: Option[RowWriter[L]] = None)(
+    override val manualRowWriter: Option[RowWriter[L]] = None)(
   implicit
     val leftClassTag: ClassTag[L],
     val rightClassTag: ClassTag[R],
     @transient val rowWriterFactory: RowWriterFactory[L],
     @transient val rowReaderFactory: RowReaderFactory[R])
   extends CassandraRDD[(L, Option[R])](left.sparkContext, left.dependencies)
-    with CassandraTableRowReaderProvider[R] {
+  with CassandraTableRowReaderProvider[R]
+  with AbstractCassandraJoin[L, Option[R]] {
 
   override type Self = CassandraLeftJoinRDD[L, R]
 
@@ -52,7 +47,7 @@ class CassandraLeftJoinRDD[L, R] private[connector](
 
   override lazy val rowReader: RowReader[R] = manualRowReader match {
     case Some(rr) => rr
-    case None => rowReaderFactory.rowReader (tableDef, columnNames.selectFrom (tableDef) )
+    case None => rowReaderFactory.rowReader(tableDef, columnNames.selectFrom(tableDef))
   }
 
   override protected def copy(
@@ -61,7 +56,8 @@ class CassandraLeftJoinRDD[L, R] private[connector](
     limit: Option[Long] = limit,
     clusteringOrder: Option[ClusteringOrder] = None,
     readConf: ReadConf = readConf,
-    connector: CassandraConnector = connector): Self = {
+    connector: CassandraConnector = connector
+  ): Self = {
 
     new CassandraLeftJoinRDD[L, R](
       left = left,
@@ -73,21 +69,8 @@ class CassandraLeftJoinRDD[L, R] private[connector](
       where = where,
       limit = limit,
       clusteringOrder = clusteringOrder,
-      readConf = readConf)
-  }
-
-  lazy val joinColumnNames: Seq[ColumnRef] = joinColumns match {
-    case AllColumns => throw new IllegalArgumentException(
-      "Unable to join against all columns in a Cassandra Table. Only primary key columns allowed.")
-    case PartitionKeyColumns =>
-      tableDef.partitionKey.map(col => col.columnName: ColumnRef)
-    case SomeColumns(cs @ _*) =>
-      checkColumnsExistence(cs)
-      cs.map {
-        case c: ColumnRef => c
-        case _ => throw new IllegalArgumentException(
-          "Unable to join against unnamed columns. No CQL Functions allowed.")
-      }
+      readConf = readConf
+    )
   }
 
   override def cassandraCount(): Long = {
@@ -108,52 +91,10 @@ class CassandraLeftJoinRDD[L, R] private[connector](
         where = where,
         limit = limit,
         clusteringOrder = clusteringOrder,
-        readConf = readConf)
+        readConf = readConf
+      )
 
-    counts.map(_._2.getOrElse(0L)).reduce( _ + _ )
-  }
-
-  /** This method will create the RowWriter required before the RDD is serialized.
-    * This is called during getPartitions */
-  protected def checkValidJoin(): Seq[ColumnRef] = {
-    val partitionKeyColumnNames = tableDef.partitionKey.map(_.columnName).toSet
-    val primaryKeyColumnNames = tableDef.primaryKey.map(_.columnName).toSet
-    val colNames = joinColumnNames.map(_.columnName).toSet
-
-    // Initialize RowWriter and Query to be used for accessing Cassandra
-    rowWriter.columnNames
-    singleKeyCqlQuery.length
-
-    def checkSingleColumn(column: ColumnRef): Unit = {
-      require(
-        primaryKeyColumnNames.contains(column.columnName),
-        s"Can't pushdown join on column $column because it is not part of the PRIMARY KEY")
-    }
-
-    // Make sure we have all of the clustering indexes between the 0th position and the max requested
-    // in the join:
-    val chosenClusteringColumns = tableDef.clusteringColumns
-      .filter(cc => colNames.contains(cc.columnName))
-    if (!tableDef.clusteringColumns.startsWith(chosenClusteringColumns)) {
-      val maxCol = chosenClusteringColumns.last
-      val maxIndex = maxCol.componentIndex.get
-      val requiredColumns = tableDef.clusteringColumns.takeWhile(_.componentIndex.get <= maxIndex)
-      val missingColumns = requiredColumns.toSet -- chosenClusteringColumns.toSet
-      throw new IllegalArgumentException(
-        s"Can't pushdown join on column $maxCol without also specifying [ $missingColumns ]")
-    }
-    val missingPartitionKeys = partitionKeyColumnNames -- colNames
-    require(
-      missingPartitionKeys.isEmpty,
-      s"Can't join without the full partition key. Missing: [ $missingPartitionKeys ]")
-
-    joinColumnNames.foreach(checkSingleColumn)
-    joinColumnNames
-  }
-
-  lazy val rowWriter = manualRowWriter match {
-    case Some(_rowWriter) => _rowWriter
-    case None => implicitly[RowWriterFactory[L]].rowWriter (tableDef, joinColumnNames.toIndexedSeq)
+    counts.map(_._2.getOrElse(0L)).reduce(_ + _)
   }
 
   def on(joinColumns: ColumnSelector): CassandraLeftJoinRDD[L, R] = {
@@ -167,81 +108,42 @@ class CassandraLeftJoinRDD[L, R] private[connector](
       where = where,
       limit = limit,
       clusteringOrder = clusteringOrder,
-      readConf = readConf)
-  }
-
-  //We need to make sure we get selectedColumnRefs before serialization so that our RowReader is
-  //built
-  lazy val singleKeyCqlQuery: (String) = {
-    val whereClauses = where.predicates.flatMap(CqlWhereParser.parse)
-    val joinColumns = joinColumnNames.map(_.columnName)
-    val joinColumnPredicates = whereClauses.collect {
-      case EqPredicate(c, _) if joinColumns.contains(c) => c
-      case InPredicate(c) if joinColumns.contains(c) => c
-      case InListPredicate(c, _) if joinColumns.contains(c) => c
-      case RangePredicate(c, _, _) if joinColumns.contains(c) => c
-    }.toSet
-
-    require(
-      joinColumnPredicates.isEmpty,
-      s"""Columns specified in both the join on clause and the where clause.
-          |Partition key columns are always part of the join clause.
-          |Columns in both: ${joinColumnPredicates.mkString(", ")}""".stripMargin
+      readConf = readConf
     )
-
-    logDebug("Generating Single Key Query Prepared Statement String")
-    logDebug(s"SelectedColumns : $selectedColumnRefs -- JoinColumnNames : $joinColumnNames")
-    val columns = selectedColumnRefs.map(_.cql).mkString(", ")
-    val joinWhere = joinColumnNames.map(_.columnName).map(name => s"${quote(name)} = :$name")
-    val limitClause = limit.map(limit => s"LIMIT $limit").getOrElse("")
-    val orderBy = clusteringOrder.map(_.toCql(tableDef)).getOrElse("")
-    val filter = (where.predicates ++ joinWhere).mkString(" AND ")
-    val quotedKeyspaceName = quote(keyspaceName)
-    val quotedTableName = quote(tableName)
-    val query =
-      s"SELECT $columns " +
-        s"FROM $quotedKeyspaceName.$quotedTableName " +
-        s"WHERE $filter $limitClause $orderBy"
-    logDebug(s"Query : $query")
-    query
-  }
-
-  private[rdd] def boundStatementBuilder(session: Session): BoundStatementBuilder[L] = {
-    val protocolVersion = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersion
-    val stmt = session.prepare(singleKeyCqlQuery).setConsistencyLevel(consistencyLevel)
-    new BoundStatementBuilder[L](rowWriter, stmt, where.values, protocolVersion = protocolVersion)
   }
 
   /**
-    * When computing a CassandraPartitionKeyRDD the data is selected via single CQL statements
-    * from the specified C* Keyspace and Table. This will be preformed on whatever data is
-    * available in the previous RDD in the chain.
-    */
-  override def compute(split: Partition, context: TaskContext): Iterator[(L, Option[R])] = {
-    val session = connector.openSession()
-    val bsb = boundStatementBuilder(session)
-    val metricsUpdater = InputMetricsUpdater(context, readConf)
-    val rowIterator = fetchIterator(session, bsb, left.iterator(split, context))
-    val countingIterator = new CountingIterator(rowIterator, limit)
-
-    context.addTaskCompletionListener { (context) =>
-      val duration = metricsUpdater.finish() / 1000000000d
-      logDebug(
-        f"Fetched ${countingIterator.count} rows " +
-          f"from $keyspaceName.$tableName " +
-          f"for partition ${split.index} in $duration%.3f s.")
-      session.close()
-    }
-    countingIterator
+   * Turns this CassandraLeftJoinRDD into a factory for converting other RDD's after being serialized
+   * This method is for streaming operations as it allows us to Serialize a template JoinRDD
+   * and the use that serializable template in the DStream closure. This gives us a fully serializable
+   * leftJoinWithCassandra operation
+   */
+  private[connector] def applyToRDD(left: RDD[L]): CassandraLeftJoinRDD[L, R] = {
+    new CassandraLeftJoinRDD[L, R](
+      left,
+      keyspaceName,
+      tableName,
+      connector,
+      columnNames,
+      joinColumns,
+      where,
+      limit,
+      clusteringOrder,
+      readConf,
+      Some(rowReader),
+      Some(rowWriter)
+    )
   }
 
   private[rdd] def fetchIterator(
-                                  session: Session,
-                                  bsb: BoundStatementBuilder[L],
-                                  leftIterator: Iterator[L]): Iterator[(L, Option[R])] = {
+    session: Session,
+    bsb: BoundStatementBuilder[L],
+    leftIterator: Iterator[L]
+  ): Iterator[(L, Option[R])] = {
     val columnNames = selectedColumnRefs.map(_.selectedAs).toIndexedSeq
     val rateLimiter = new RateLimiter(
-      readConf.throughputJoinQueryPerSec, readConf.throughputJoinQueryPerSec)
+      readConf.throughputJoinQueryPerSec, readConf.throughputJoinQueryPerSec
+    )
 
     def pairWithRight(left: L): SettableFuture[Iterator[(L, Option[R])]] = {
       val resultFuture = SettableFuture.create[Iterator[(L, Option[R])]]
@@ -251,7 +153,7 @@ class CassandraLeftJoinRDD[L, R] private[connector](
       Futures.addCallback(queryFuture, new FutureCallback[ResultSet] {
         def onSuccess(rs: ResultSet) {
           val resultSet = new PrefetchingResultSetIterator(rs, fetchSize)
-          val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames,rs)
+          val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames, rs)
           val rightSide = resultSet.isEmpty match {
             case true => Iterator.single(None)
             case false => resultSet.map(r => Some(rowReader.read(r, columnMetaData)))
@@ -269,47 +171,5 @@ class CassandraLeftJoinRDD[L, R] private[connector](
       pairWithRight(left)
     }).toList
     queryFutures.iterator.flatMap(_.get)
-  }
-
-  override protected def getPartitions: Array[Partition] = {
-    verify()
-    checkValidJoin()
-    left.partitions
-  }
-
-  override def getPreferredLocations(split: Partition): Seq[String] = left.preferredLocations(split)
-
-  override def toEmptyCassandraRDD: EmptyCassandraRDD[(L, Option[R])] =
-    new EmptyCassandraRDD[(L, Option[R])](
-      sc = left.sparkContext,
-      keyspaceName = keyspaceName,
-      tableName = tableName,
-      columnNames = columnNames,
-      where = where,
-      limit = limit,
-      clusteringOrder = clusteringOrder,
-      readConf = readConf)
-
-  /**
-    * Turns this CassandraLeftJoinRDD into a factory for converting other RDD's after being serialized
-    * This method is for streaming operations as it allows us to Serialize a template JoinRDD
-    * and the use that serializable template in the DStream closure. This gives us a fully serializable
-    * leftJoinWithCassandra operation
-    */
-  private[connector] def applyToRDD( left:RDD[L]): CassandraLeftJoinRDD[L,R] =  {
-    new CassandraLeftJoinRDD[L,R](
-      left,
-      keyspaceName,
-      tableName,
-      connector,
-      columnNames,
-      joinColumns,
-      where,
-      limit,
-      clusteringOrder,
-      readConf,
-      Some(rowReader),
-      Some(rowWriter)
-    )
   }
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
@@ -1,0 +1,315 @@
+package com.datastax.spark.connector.rdd
+
+import org.apache.spark.metrics.InputMetricsUpdater
+
+import com.datastax.driver.core.{ResultSet, Session}
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.cql._
+import com.datastax.spark.connector.rdd.reader._
+import com.datastax.spark.connector.util.CqlWhereParser.{EqPredicate, InListPredicate, InPredicate, RangePredicate}
+import com.datastax.spark.connector.util.{CountingIterator, CqlWhereParser}
+import com.datastax.spark.connector.writer._
+import com.datastax.spark.connector.util.Quote._
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{Partition, TaskContext}
+import scala.reflect.ClassTag
+
+import com.google.common.util.concurrent.{FutureCallback, Futures, SettableFuture}
+
+/**
+  * An [[org.apache.spark.rdd.RDD RDD]] that will do a selecting join between `left` RDD and the specified
+  * Cassandra Table This will perform individual selects to retrieve the rows from Cassandra and will take
+  * advantage of RDDs that have been partitioned with the
+  * [[com.datastax.spark.connector.rdd.partitioner.ReplicaPartitioner]]
+  *
+  * @tparam L item type on the left side of the join (any RDD)
+  * @tparam R item type on the right side of the join (fetched from Cassandra)
+  */
+class CassandraLeftJoinRDD[L, R] private[connector](
+    left: RDD[L],
+    val keyspaceName: String,
+    val tableName: String,
+    val connector: CassandraConnector,
+    val columnNames: ColumnSelector = AllColumns,
+    val joinColumns: ColumnSelector = PartitionKeyColumns,
+    val where: CqlWhereClause = CqlWhereClause.empty,
+    val limit: Option[Long] = None,
+    val clusteringOrder: Option[ClusteringOrder] = None,
+    val readConf: ReadConf = ReadConf(),
+    manualRowReader: Option[RowReader[R]] = None,
+    manualRowWriter: Option[RowWriter[L]] = None)(
+  implicit
+    val leftClassTag: ClassTag[L],
+    val rightClassTag: ClassTag[R],
+    @transient val rowWriterFactory: RowWriterFactory[L],
+    @transient val rowReaderFactory: RowReaderFactory[R])
+  extends CassandraRDD[(L, Option[R])](left.sparkContext, left.dependencies)
+    with CassandraTableRowReaderProvider[R] {
+
+  override type Self = CassandraLeftJoinRDD[L, R]
+
+  override protected val classTag = rightClassTag
+
+  override lazy val rowReader: RowReader[R] = manualRowReader match {
+    case Some(rr) => rr
+    case None => rowReaderFactory.rowReader (tableDef, columnNames.selectFrom (tableDef) )
+  }
+
+  override protected def copy(
+                               columnNames: ColumnSelector = columnNames,
+                               where: CqlWhereClause = where,
+                               limit: Option[Long] = limit,
+                               clusteringOrder: Option[ClusteringOrder] = None,
+                               readConf: ReadConf = readConf,
+                               connector: CassandraConnector = connector): Self = {
+
+    new CassandraLeftJoinRDD[L, R](
+      left = left,
+      keyspaceName = keyspaceName,
+      tableName = tableName,
+      connector = connector,
+      columnNames = columnNames,
+      joinColumns = joinColumns,
+      where = where,
+      limit = limit,
+      clusteringOrder = clusteringOrder,
+      readConf = readConf)
+  }
+
+  lazy val joinColumnNames: Seq[ColumnRef] = joinColumns match {
+    case AllColumns => throw new IllegalArgumentException(
+      "Unable to join against all columns in a Cassandra Table. Only primary key columns allowed.")
+    case PartitionKeyColumns =>
+      tableDef.partitionKey.map(col => col.columnName: ColumnRef)
+    case SomeColumns(cs @ _*) =>
+      checkColumnsExistence(cs)
+      cs.map {
+        case c: ColumnRef => c
+        case _ => throw new IllegalArgumentException(
+          "Unable to join against unnamed columns. No CQL Functions allowed.")
+      }
+  }
+
+  override def cassandraCount(): Long = {
+    columnNames match {
+      case SomeColumns(_) =>
+        logWarning("You are about to count rows but an explicit projection has been specified.")
+      case _ =>
+    }
+
+    val counts =
+      new CassandraLeftJoinRDD[L, Long](
+        left = left,
+        connector = connector,
+        keyspaceName = keyspaceName,
+        tableName = tableName,
+        columnNames = SomeColumns(RowCountRef),
+        joinColumns = joinColumns,
+        where = where,
+        limit = limit,
+        clusteringOrder = clusteringOrder,
+        readConf= readConf)
+
+    counts.map(_._2.getOrElse(0L)).reduce( _ + _ )
+  }
+
+  /** This method will create the RowWriter required before the RDD is serialized.
+    * This is called during getPartitions */
+  protected def checkValidJoin(): Seq[ColumnRef] = {
+    val partitionKeyColumnNames = tableDef.partitionKey.map(_.columnName).toSet
+    val primaryKeyColumnNames = tableDef.primaryKey.map(_.columnName).toSet
+    val colNames = joinColumnNames.map(_.columnName).toSet
+
+    // Initialize RowWriter and Query to be used for accessing Cassandra
+    rowWriter.columnNames
+    singleKeyCqlQuery.length
+
+    def checkSingleColumn(column: ColumnRef): Unit = {
+      require(
+        primaryKeyColumnNames.contains(column.columnName),
+        s"Can't pushdown join on column $column because it is not part of the PRIMARY KEY")
+    }
+
+    // Make sure we have all of the clustering indexes between the 0th position and the max requested
+    // in the join:
+    val chosenClusteringColumns = tableDef.clusteringColumns
+      .filter(cc => colNames.contains(cc.columnName))
+    if (!tableDef.clusteringColumns.startsWith(chosenClusteringColumns)) {
+      val maxCol = chosenClusteringColumns.last
+      val maxIndex = maxCol.componentIndex.get
+      val requiredColumns = tableDef.clusteringColumns.takeWhile(_.componentIndex.get <= maxIndex)
+      val missingColumns = requiredColumns.toSet -- chosenClusteringColumns.toSet
+      throw new IllegalArgumentException(
+        s"Can't pushdown join on column $maxCol without also specifying [ $missingColumns ]")
+    }
+    val missingPartitionKeys = partitionKeyColumnNames -- colNames
+    require(
+      missingPartitionKeys.isEmpty,
+      s"Can't join without the full partition key. Missing: [ $missingPartitionKeys ]")
+
+    joinColumnNames.foreach(checkSingleColumn)
+    joinColumnNames
+  }
+
+  lazy val rowWriter = manualRowWriter match {
+    case Some(_rowWriter) => _rowWriter
+    case None => implicitly[RowWriterFactory[L]].rowWriter (tableDef, joinColumnNames.toIndexedSeq)
+  }
+
+  def on(joinColumns: ColumnSelector): CassandraLeftJoinRDD[L, R] = {
+    new CassandraLeftJoinRDD[L, R](
+      left = left,
+      connector = connector,
+      keyspaceName = keyspaceName,
+      tableName = tableName,
+      columnNames = columnNames,
+      joinColumns = joinColumns,
+      where = where,
+      limit = limit,
+      clusteringOrder = clusteringOrder,
+      readConf = readConf)
+  }
+
+  //We need to make sure we get selectedColumnRefs before serialization so that our RowReader is
+  //built
+  lazy val singleKeyCqlQuery: (String) = {
+    val whereClauses = where.predicates.flatMap(CqlWhereParser.parse)
+    val joinColumns = joinColumnNames.map(_.columnName)
+    val joinColumnPredicates = whereClauses.collect {
+      case EqPredicate(c, _) if joinColumns.contains(c) => c
+      case InPredicate(c) if joinColumns.contains(c) => c
+      case InListPredicate(c, _) if joinColumns.contains(c) => c
+      case RangePredicate(c, _, _) if joinColumns.contains(c) => c
+    }.toSet
+
+    require(
+      joinColumnPredicates.isEmpty,
+      s"""Columns specified in both the join on clause and the where clause.
+          |Partition key columns are always part of the join clause.
+          |Columns in both: ${joinColumnPredicates.mkString(", ")}""".stripMargin
+    )
+
+    logDebug("Generating Single Key Query Prepared Statement String")
+    logDebug(s"SelectedColumns : $selectedColumnRefs -- JoinColumnNames : $joinColumnNames")
+    val columns = selectedColumnRefs.map(_.cql).mkString(", ")
+    val joinWhere = joinColumnNames.map(_.columnName).map(name => s"${quote(name)} = :$name")
+    val limitClause = limit.map(limit => s"LIMIT $limit").getOrElse("")
+    val orderBy = clusteringOrder.map(_.toCql(tableDef)).getOrElse("")
+    val filter = (where.predicates ++ joinWhere).mkString(" AND ")
+    val quotedKeyspaceName = quote(keyspaceName)
+    val quotedTableName = quote(tableName)
+    val query =
+      s"SELECT $columns " +
+        s"FROM $quotedKeyspaceName.$quotedTableName " +
+        s"WHERE $filter $limitClause $orderBy"
+    logDebug(s"Query : $query")
+    query
+  }
+
+  private[rdd] def boundStatementBuilder(session: Session): BoundStatementBuilder[L] = {
+    val protocolVersion = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersion
+    val stmt = session.prepare(singleKeyCqlQuery).setConsistencyLevel(consistencyLevel)
+    new BoundStatementBuilder[L](rowWriter, stmt, where.values, protocolVersion = protocolVersion)
+  }
+
+  /**
+    * When computing a CassandraPartitionKeyRDD the data is selected via single CQL statements
+    * from the specified C* Keyspace and Table. This will be preformed on whatever data is
+    * available in the previous RDD in the chain.
+    */
+  override def compute(split: Partition, context: TaskContext): Iterator[(L, Option[R])] = {
+    val session = connector.openSession()
+    val bsb = boundStatementBuilder(session)
+    val metricsUpdater = InputMetricsUpdater(context, readConf)
+    val rowIterator = fetchIterator(session, bsb, left.iterator(split, context))
+    val countingIterator = new CountingIterator(rowIterator, limit)
+
+    context.addTaskCompletionListener { (context) =>
+      val duration = metricsUpdater.finish() / 1000000000d
+      logDebug(
+        f"Fetched ${countingIterator.count} rows " +
+          f"from $keyspaceName.$tableName " +
+          f"for partition ${split.index} in $duration%.3f s.")
+      session.close()
+    }
+    countingIterator
+  }
+
+  private[rdd] def fetchIterator(
+                                  session: Session,
+                                  bsb: BoundStatementBuilder[L],
+                                  leftIterator: Iterator[L]): Iterator[(L, Option[R])] = {
+    val columnNames = selectedColumnRefs.map(_.selectedAs).toIndexedSeq
+    val rateLimiter = new RateLimiter(
+      readConf.throughputJoinQueryPerSec, readConf.throughputJoinQueryPerSec)
+
+    def pairWithRight(left: L): SettableFuture[Iterator[(L, Option[R])]] = {
+      val resultFuture = SettableFuture.create[Iterator[(L, Option[R])]]
+      val leftSide = Iterator.continually(left)
+
+      val queryFuture = session.executeAsync(bsb.bind(left))
+      Futures.addCallback(queryFuture, new FutureCallback[ResultSet] {
+        def onSuccess(rs: ResultSet) {
+          val resultSet = new PrefetchingResultSetIterator(rs, fetchSize)
+          val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames,rs)
+          val rightSide = resultSet.isEmpty match {
+            case true => Iterator.single(None)
+            case false => resultSet.map(r => Some(rowReader.read(r, columnMetaData)))
+          }
+          resultFuture.set(leftSide.zip(rightSide))
+        }
+        def onFailure(throwable: Throwable) {
+          resultFuture.setException(throwable)
+        }
+      })
+      resultFuture
+    }
+    val queryFutures = leftIterator.map(left => {
+      rateLimiter.maybeSleep(1)
+      pairWithRight(left)
+    }).toList
+    queryFutures.iterator.flatMap(_.get)
+  }
+
+  override protected def getPartitions: Array[Partition] = {
+    verify()
+    checkValidJoin()
+    left.partitions
+  }
+
+  override def getPreferredLocations(split: Partition): Seq[String] = left.preferredLocations(split)
+
+  override def toEmptyCassandraRDD: EmptyCassandraRDD[(L, Option[R])] =
+    new EmptyCassandraRDD[(L, Option[R])](
+      sc = left.sparkContext,
+      keyspaceName = keyspaceName,
+      tableName = tableName,
+      columnNames = columnNames,
+      where = where,
+      limit = limit,
+      clusteringOrder = clusteringOrder,
+      readConf = readConf)
+
+  /**
+    * Turns this CassandraJoinRDD into a factory for converting other RDD's after being serialized
+    * This method is for streaming operations as it allows us to Serialize a template JoinRDD
+    * and the use that serializable template in the DStream closure. This gives us a fully serializable
+    * joinWithCassandra operation
+    */
+  private[connector] def applyToRDD( left:RDD[L]): CassandraLeftJoinRDD[L,R] =  {
+    new CassandraLeftJoinRDD[L,R](
+      left,
+      keyspaceName,
+      tableName,
+      connector,
+      columnNames,
+      joinColumns,
+      where,
+      limit,
+      clusteringOrder,
+      readConf,
+      Some(rowReader),
+      Some(rowWriter)
+    )
+  }
+}


### PR DESCRIPTION
This a rebased version (so to compile against the latest version of the connector) of https://github.com/datastax/spark-cassandra-connector/pull/832

Like https://github.com/datastax/spark-cassandra-connector/pull/832 there is quite a lot of code duplication. Unlike https://github.com/datastax/spark-cassandra-connector/pull/832 it relies on executeAsync for better performance.