### PR TITLE
SPARKC-387: Have columntype dependent on C* Protocol Version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,6 @@ before_cache:
 script:
   - "sbt ++$TRAVIS_SCALA_VERSION -Dtravis=true test"
   - "sbt ++$TRAVIS_SCALA_VERSION -Dtravis=true it:test"
+  - "sbt ++$TRAVIS_SCALA_VERSION -Dtest.cassandra.version=2.1.15 -Dtravis=true test"
+  - "sbt ++$TRAVIS_SCALA_VERSION -Dtest.cassandra.version=2.1.15 -Dtravis=true it:test"
   - "sbt ++$TRAVIS_SCALA_VERSION -Dtravis=true assembly"

--- a/spark-cassandra-connector/src/it/resources/2.1/cassandra-default.yaml.template
+++ b/spark-cassandra-connector/src/it/resources/2.1/cassandra-default.yaml.template
@@ -421,7 +421,7 @@ native_transport_port: ${native_transport_port}
 # native_transport_max_concurrent_connections_per_ip: -1
 
 # Whether to start the thrift rpc server.
-start_rpc: true
+start_rpc: false
 
 # The address or interface to bind the Thrift RPC service and native transport
 # server to.

--- a/spark-cassandra-connector/src/it/resources/2.1/cassandra-password-auth.yaml.template
+++ b/spark-cassandra-connector/src/it/resources/2.1/cassandra-password-auth.yaml.template
@@ -421,7 +421,7 @@ native_transport_port: ${native_transport_port}
 # native_transport_max_concurrent_connections_per_ip: -1
 
 # Whether to start the thrift rpc server.
-start_rpc: true
+start_rpc: false
 
 # The address or interface to bind the Thrift RPC service and native transport
 # server to.

--- a/spark-cassandra-connector/src/it/resources/2.1/cassandra-ssl.yaml.template
+++ b/spark-cassandra-connector/src/it/resources/2.1/cassandra-ssl.yaml.template
@@ -62,7 +62,7 @@ batchlog_replay_throttle_in_kb: 1024
 # - PasswordAuthenticator relies on username/password pairs to authenticate
 #   users. It keeps usernames and hashed passwords in system_auth.credentials table.
 #   Please increase system_auth keyspace replication factor if you use this authenticator.
-authenticator: PasswordAuthenticator
+authenticator: AllowAllAuthenticator
 
 # Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
 # Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthorizer,
@@ -421,7 +421,7 @@ native_transport_port: ${native_transport_port}
 # native_transport_max_concurrent_connections_per_ip: -1
 
 # Whether to start the thrift rpc server.
-start_rpc: true
+start_rpc: false
 
 # The address or interface to bind the Thrift RPC service and native transport
 # server to.
@@ -779,14 +779,12 @@ server_encryption_options:
     # protocol: TLS
     # algorithm: SunX509
     # store_type: JKS
-    cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA]
+    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
     # require_client_auth: false
 
 # enable or disable client/server encryption.
 client_encryption_options:
     enabled: true
-    # If enabled and optional is set to true encrypted and unencrypted connections are handled.
-    optional: false
     keystore: ${keystore_path}
     keystore_password: connector
     # require_client_auth: false
@@ -797,7 +795,7 @@ client_encryption_options:
     # protocol: TLS
     # algorithm: SunX509
     # store_type: JKS
-    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
+    cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA]
 
 # internode_compression controls whether traffic between nodes is
 # compressed.

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/CassandraJavaUtilSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/CassandraJavaUtilSpec.scala
@@ -16,7 +16,7 @@ class CassandraJavaUtilSpec extends SparkCassandraITFlatSpecBase with BeforeAndA
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultConf)
 
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
 
   conn.withSessionDo { session =>
     createKeyspace(session)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraConnectorSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraConnectorSpec.scala
@@ -12,7 +12,7 @@ class CassandraConnectorSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultConf)
 
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
 
   val createKeyspaceCql = keyspaceCql(ks)
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraPartitionKeyWhereSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraPartitionKeyWhereSpec.scala
@@ -11,7 +11,7 @@ class CassandraPartitionKeyWhereSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultConf)
 
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
 
   conn.withSessionDo { session =>
     createKeyspace(session)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraSSLConnectorSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/CassandraSSLConnectorSpec.scala
@@ -10,7 +10,7 @@ class CassandraSSLConnectorSpec extends SparkCassandraITFlatSpecBase {
 
   // TODO: Add a test so that CassandraConnector is configured for SSL through SparkConf
 
-  val conn = CassandraConnector(
+  override val conn = CassandraConnector(
     hosts = Set(EmbeddedCassandra.getHost(0)),
     port = EmbeddedCassandra.getPort(0),
     cassandraSSLConf = CassandraSSLConf(

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/SchemaSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/cql/SchemaSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.Inspectors._
 class SchemaSpec extends SparkCassandraITWordSpecBase {
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
 
   conn.withSessionDo { session =>
     createKeyspace(session)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/doc/DocExamples.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/doc/DocExamples.scala
@@ -8,6 +8,8 @@ import com.datastax.spark.connector.types.CassandraOption
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.writer.WriteConf
 
+import com.datastax.driver.core.ProtocolVersion._
+
 import scala.concurrent.Future
 
 case class RandomListSelector[T](list: Seq[T]) {
@@ -22,7 +24,7 @@ class DocExamples extends SparkCassandraITFlatSpecBase {
 
   val numrows: Long = 1000
 
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
   override val ks = "doc_example"
 
   conn.withSessionDo { session =>
@@ -84,13 +86,13 @@ class DocExamples extends SparkCassandraITFlatSpecBase {
     ).saveToCassandra(ks, "purchases")
   }
 
-  "Docs" should "demonstrate copying a table without deletes" in {
+  "Docs" should "demonstrate copying a table without deletes" in skipIfProtocolVersionLT(V4){
     sc.cassandraTable[(Int, CassandraOption[Int], CassandraOption[Int])](ks, "tab1")
       .saveToCassandra(ks, "tab2")
     sc.cassandraTable[(Int, Int, Int)](ks, "tab2").collect should contain((1, 5, 1))
   }
 
-  it should "demonstrate only deleting some records" in {
+  it should "demonstrate only deleting some records" in skipIfProtocolVersionLT(V4){
     sc.parallelize(1 to 6).map(x => (x, x, x)).saveToCassandra(ks, "tab1")
     sc.parallelize(1 to 6).map(x => x match {
       case x if (x >= 5) => (x, CassandraOption.Null, CassandraOption.Unset)
@@ -109,7 +111,7 @@ class DocExamples extends SparkCassandraITFlatSpecBase {
       (6, None, Some(6)))
   }
 
-  it should "demonstrate converting Options to CassandraOptions" in {
+  it should "demonstrate converting Options to CassandraOptions" in skipIfProtocolVersionLT(V4){
     import com.datastax.spark.connector.types.CassandraOption
     //Setup original data (1, 1, 1) --> (6, 6, 6)
     sc.parallelize(1 to 6).map(x => (x, x, x)).saveToCassandra(ks, "tab1")
@@ -134,7 +136,7 @@ class DocExamples extends SparkCassandraITFlatSpecBase {
 
   }
 
-  it should "show using a write conf to ignore nulls" in {
+  it should "show using a write conf to ignore nulls" in skipIfProtocolVersionLT(V4){
     //Setup original data (1, 1, 1) --> (6, 6, 6)
     sc.parallelize(1 to 6).map(x => (x, x, x)).saveToCassandra(ks, "tab1")
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaPairRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaPairRDDSpec.scala
@@ -18,7 +18,7 @@ class CassandraJavaPairRDDSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultConf)
 
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
 
   conn.withSessionDo { session =>
     try {

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraJavaRDDSpec.scala
@@ -12,6 +12,9 @@ import com.datastax.spark.connector.embedded._
 import com.datastax.spark.connector.japi.CassandraJavaUtil._
 import com.datastax.spark.connector.japi.CassandraRow
 import com.datastax.spark.connector.types.TypeConverter
+
+import com.datastax.driver.core.ProtocolVersion._
+
 import org.apache.commons.lang3.tuple
 import org.apache.spark.api.java.function.{Function => JFunction}
 
@@ -22,7 +25,7 @@ class CassandraJavaRDDSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultConf)
 
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
 
   conn.withSessionDo { session =>
     createKeyspace(session)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -14,6 +14,8 @@ import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.mapper.DefaultColumnMapper
 import com.datastax.spark.connector.types.{CassandraOption, TypeConverter}
 
+import com.datastax.driver.core.ProtocolVersion._
+
 case class KeyValue(key: Int, group: Long, value: String)
 case class KeyValueWithConversion(key: String, group: Int, value: Long)
 case class CustomerId(id: String)
@@ -57,7 +59,7 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultConf)
 
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
   val bigTableRowCount = 100000
 
   conn.withSessionDo { session =>
@@ -65,7 +67,7 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
 
     awaitAll(
       Future {
-        if (versionGreaterThanOrEquals(2,2)) {
+        skipIfProtocolVersionLT(V4) {
           println(s"Found version $cassandraMajorVersion  $cassandraMinorVersion")
           session.execute( s"""CREATE TABLE $ks.short_value (key INT, value SMALLINT, PRIMARY KEY (key))""")
           session.execute( s"""INSERT INTO $ks.short_value (key, value) VALUES (1,100)""")
@@ -134,7 +136,7 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
         session.execute(s"""CREATE TABLE "MixedSpace"."MoxedCAs" (key INT PRIMARY KEY, value INT)""")
       },
       Future {
-        if (versionGreaterThanOrEquals(2, 2)) {
+        skipIfProtocolVersionLT(V4) {
           session.execute(
             s"""
                |CREATE TABLE $ks.user(
@@ -187,8 +189,11 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
       },
 
       Future {
-        session.execute(s"CREATE TABLE $ks.date_test (key int primary key, dd date)")
-        session.execute(s"INSERT INTO $ks.date_test (key, dd) VALUES (1, '1930-05-31')")
+        info("Making table with Date Type")
+        skipIfProtocolVersionLT(V4) {
+          session.execute(s"CREATE TABLE $ks.date_test (key int primary key, dd date)")
+          session.execute(s"INSERT INTO $ks.date_test (key, dd) VALUES (1, '1930-05-31')")
+        }
       }
     )
   }
@@ -891,7 +896,7 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
     result should have length 0
   }
 
-  it should "suggest similar tables or views if the table doesn't exist" in {
+  it should "suggest similar tables or views if the table doesn't exist" in skipIfProtocolVersionLT(V4){
     val ioe = the [IOException] thrownBy sc.cassandraTable(ks, "user_by_county").collect()
     val message = ioe.getMessage
     message should include (s"$ks.user_by_country")
@@ -968,14 +973,14 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
     dataColumns.count shouldBe 1
   }
 
-  it should "be able to read SMALLINT columns from" in {
+  it should "be able to read SMALLINT columns from" in skipIfProtocolVersionLT(V4) {
     val result = sc.cassandraTable[(Int, Short)](ks, "short_value").collect
     result should contain ((1, 100))
     result should contain ((2, 200))
     result should contain ((3, 300))
   }
 
-  it should "be able to read a Materialized View" in  {
+  it should "be able to read a Materialized View" in skipIfProtocolVersionLT(V4){
     val result = sc.cassandraTable[(String, Int, String, String, String)](ks, "user_by_country")
       .where("country='US'")
       .collect
@@ -985,7 +990,7 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
     )
   }
 
-  it should "throw an exception when trying to write to a Materialized View" in {
+  it should "throw an exception when trying to write to a Materialized View" in skipIfProtocolVersionLT(V4){
     intercept[IllegalArgumentException] {
       sc.parallelize(Seq(("US", 1, "John", "DOE", "jdoe"))).saveToCassandra(ks, "user_by_country")
     }
@@ -1038,7 +1043,7 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
     }
   }
 
-  it should "write Java dates as C* date type" in {
+  it should "write Java dates as C* date type" in skipIfProtocolVersionLT(V4){
     val rows = List(
       (6, new java.sql.Date(new Date().getTime)),
       (7, new Date()),
@@ -1054,7 +1059,7 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
     resultSet.one().getLong(0) should be(rows.size)
   }
 
-  it should "read C* row with dates as Java dates" in {
+  it should "read C* row with dates as Java dates" in skipIfProtocolVersionLT(V4){
     val expected: LocalDate = new LocalDate(1930, 5, 31) // note this is Joda
     val row = sc.cassandraTable(ks, "date_test").where("key = 1").first
 
@@ -1063,7 +1068,7 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
     row.get[LocalDate]("dd") should be(expected)
   }
 
-  it should "read LocalDate as tuple value with given type" in {
+  it should "read LocalDate as tuple value with given type" in skipIfProtocolVersionLT(V4){
     val expected: LocalDate = new LocalDate(1930, 5, 31) // note this is Joda
     val date = sc.cassandraTable[(Int, Date)](ks, "date_test").where("key = 1").first._2
     val localDate = sc.cassandraTable[(Int, LocalDate)](ks, "date_test").where("key = 1").first._2

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/PartitionedCassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/PartitionedCassandraRDDSpec.scala
@@ -25,7 +25,7 @@ class PartitionedCassandraRDDSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultConf.set("spark.cassandra.input.consistency.level", "ONE"))
 
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
   val rowCount = 100
 
   conn.withSessionDo { session =>

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
@@ -30,7 +30,7 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultConf.set("spark.cassandra.input.consistency.level", "ONE"))
 
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
   val tableName = "key_value"
   val otherTable = "other_table"
   val wideTable = "wide_table"

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartitionGeneratorSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartitionGeneratorSpec.scala
@@ -13,7 +13,7 @@ class CassandraPartitionGeneratorSpec
   extends SparkCassandraITFlatSpecBase with Inspectors  {
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
 
   conn.withSessionDo { session =>
     createKeyspace(session)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/partitioner/DataSizeEstimatesSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/partitioner/DataSizeEstimatesSpec.scala
@@ -13,7 +13,7 @@ import com.datastax.spark.connector.testkit.SharedEmbeddedCassandra
 class DataSizeEstimatesSpec extends SparkCassandraITFlatSpecBase {
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
 
   conn.withSessionDo { session =>
     createKeyspace(session)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/partitioner/TokenGeneratorSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/partitioner/TokenGeneratorSpec.scala
@@ -16,7 +16,7 @@ class TokenGeneratorSpec extends SparkCassandraITFlatSpecBase {
   case class ComplexKey(key1: Int, key2: Int, key3: String)
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
 
   val simpleKeys = Seq(1, -500, 2801, 4000000, -95500).map(SimpleKey(_))
   val complexKey = simpleKeys.map{ case SimpleKey(x) => ComplexKey(x, x, x.toString)}

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/typeTests/AbstractDateTypeTest.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/typeTests/AbstractDateTypeTest.scala
@@ -5,10 +5,8 @@ import java.text.SimpleDateFormat
 import java.util.{TimeZone, Date => UtilDate}
 
 import scala.reflect.ClassTag
-
 import org.joda.time.{DateTime, DateTimeZone, LocalDate => JodaLocalDate}
-
-import com.datastax.driver.core.{Row, LocalDate => DriverLocalDate}
+import com.datastax.driver.core.{ProtocolVersion, Row, LocalDate => DriverLocalDate}
 import com.datastax.spark.connector.rdd.reader.RowReaderFactory
 import com.datastax.spark.connector.types.TypeConverter
 import com.datastax.spark.connector.writer.RowWriterFactory
@@ -27,6 +25,8 @@ abstract class AbstractDateTypeTest[TestType: ClassTag](
     rowWriterCollection: RowWriterFactory[(TestType, Set[TestType], List[TestType], Map[String, TestType], Map[TestType, String])],
     rowWriterNull: RowWriterFactory[(TestType, TestType, Null, Null, Null, Null)])
   extends AbstractTypeTest[TestType, DriverLocalDate] {
+
+  override def minPV: ProtocolVersion = ProtocolVersion.V4
 
   TimeZone.setDefault(testTimeZone)
   DateTimeZone.setDefault(DateTimeZone.forTimeZone(testTimeZone))

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/typeTests/CounterTypeTest.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/typeTests/CounterTypeTest.scala
@@ -16,7 +16,7 @@ class CounterTypeTest  extends SparkCassandraITFlatSpecBase  {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultConf)
 
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
 
   override def beforeAll() {
     //Create Cql3 Keypsace and Data

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/typeTests/SmallIntTypeTest.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/typeTests/SmallIntTypeTest.scala
@@ -1,8 +1,9 @@
 package com.datastax.spark.connector.rdd.typeTests
 
-import com.datastax.driver.core.Row
+import com.datastax.driver.core.{ProtocolVersion, Row}
 
 class SmallIntTypeTest extends AbstractTypeTest[Short, java.lang.Short]{
+  override val minPV = ProtocolVersion.V4
   override protected val typeName: String = "smallint"
 
   override protected val typeData: Seq[Short] = (1 to 10).map(_.toShort)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/typeTests/TimeTypeTest.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/typeTests/TimeTypeTest.scala
@@ -1,10 +1,13 @@
 package com.datastax.spark.connector.rdd.typeTests
 
-import com.datastax.driver.core.Row
+import com.datastax.driver.core.{ProtocolVersion, Row}
+import com.datastax.driver.core.ProtocolVersion._
 import com.datastax.spark.connector._
 import java.util.Date
 
 class TimeTypeTest extends AbstractTypeTest[Long, java.lang.Long] {
+
+  override val minPV = ProtocolVersion.V4
 
   override def getDriverColumn(row: Row, colName: String): Long = row.getTime(colName)
 
@@ -13,7 +16,7 @@ class TimeTypeTest extends AbstractTypeTest[Long, java.lang.Long] {
   override protected val typeData: Seq[Long] = 1L to 5L
   override protected val addData: Seq[Long] = 6L to 10L
 
-  "Time Types" should "be writable as dates" in {
+  "Time Types" should "be writable as dates" in skipIfProtocolVersionLT(V4) {
     val dates = (100 to 500 by 100).map(new Date(_))
     val times = dates.map(_.getTime)
     sc.parallelize(

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/typeTests/TinyIntTypeTest.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/typeTests/TinyIntTypeTest.scala
@@ -1,8 +1,9 @@
 package com.datastax.spark.connector.rdd.typeTests
 
-import com.datastax.driver.core.Row
+import com.datastax.driver.core.{ProtocolVersion, Row}
 
 class TinyIntTypeTest extends AbstractTypeTest[Int, java.lang.Byte] {
+  override val minPV = ProtocolVersion.V4
   override protected val typeName: String = "tinyint"
 
   override protected val typeData: Seq[Int] =Seq(1, 2, 3, 4, 5)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/repl/CassandraRDDReplSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/repl/CassandraRDDReplSpec.scala
@@ -9,7 +9,7 @@ class CassandraRDDReplSpec extends SparkCassandraITFlatSpecBase with SparkRepl {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(null)
 
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
 
   conn.withSessionDo { session =>
     createKeyspace(session)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameDateBehaviors.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameDateBehaviors.scala
@@ -9,6 +9,7 @@ import org.joda.time.DateTimeZone
 import org.scalatest.FlatSpec
 
 import com.datastax.driver.core.LocalDate
+import com.datastax.driver.core.ProtocolVersion._
 import com.datastax.spark.connector.SparkCassandraITSpecBase
 import com.datastax.spark.connector.cql.CassandraConnector
 
@@ -18,10 +19,10 @@ trait CassandraDataFrameDateBehaviors extends SparkCassandraITSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultConf)
 
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
   val sqlContext: SQLContext = new SQLContext(sc)
 
-  def dataFrame(timeZone: TimeZone): Unit = {
+  def dataFrame(timeZone: TimeZone): Unit = skipIfProtocolVersionLT(V4){
 
     TimeZone.setDefault(timeZone)
     DateTimeZone.setDefault(DateTimeZone.forTimeZone(timeZone))

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSpec.scala
@@ -2,18 +2,28 @@ package com.datastax.spark.connector.sql
 
 import java.io.IOException
 
+import com.datastax.driver.core.DataType
+import com.datastax.driver.core.ProtocolVersion._
+
 import scala.collection.JavaConversions._
 import scala.concurrent.Future
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
 import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.util.RetryUtil
+
 import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.cassandra._
+
+import org.joda.time.LocalDate
+
+case class RowWithV4Types(key: Int, a: Byte, b: Short, c: java.sql.Date)
 
 class CassandraDataFrameSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultConf)
 
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
 
   val sqlContext: SQLContext = new SQLContext(sc)
 
@@ -54,6 +64,15 @@ class CassandraDataFrameSpec extends SparkCassandraITFlatSpecBase {
         session.execute(s"CREATE TABLE $ks.tuple_test1 (id int, t Tuple<text, int>, PRIMARY KEY (id))")
         session.execute(s"CREATE TABLE $ks.tuple_test2 (id int, t Tuple<text, int>, PRIMARY KEY (id))")
         session.execute(s"INSERT INTO $ks.tuple_test1 (id, t) VALUES (1, ('xyz', 3))")
+      },
+
+      Future {
+        info ("Setting up Date Tables")
+        skipIfProtocolVersionLT(V4) {
+        session.execute(s"create table $ks.date_test (key int primary key, dd date)")
+        session.execute(s"create table $ks.date_test2 (key int primary key, dd date)")
+        session.execute(s"insert into $ks.date_test (key, dd) values (1, '1930-05-31')")
+        }
       }
     )
   }
@@ -192,4 +211,55 @@ class CassandraDataFrameSpec extends SparkCassandraITFlatSpecBase {
       session.execute(s"select count(1) from $ks.tuple_test2").one().getLong(0) should be (1)
     }
   }
+
+  it should "read and write C* LocalDate columns" in skipIfProtocolVersionLT(V4){
+    val df = sqlContext
+      .read
+      .format("org.apache.spark.sql.cassandra")
+      .options(Map("table" -> "date_test", "keyspace" -> ks, "cluster" -> "ClusterOne"))
+      .load
+
+    df.count should be (1)
+    df.first.getDate(1) should be (new LocalDate(1930, 5, 31).toDate)
+
+    df.write
+      .format("org.apache.spark.sql.cassandra")
+      .options(Map("table" -> "date_test2", "keyspace" -> ks, "cluster" -> "ClusterOne"))
+      .save
+
+    conn.withSessionDo { session =>
+      session.execute(s"select count(1) from $ks.date_test2").one().getLong(0) should be (1)
+    }
+  }
+
+  it should "be able to write to ProtocolVersion 3 Tables correctly with V4 Types" in skipIfProtocolVersionGTE(V4){
+
+    val table = "newtypetable"
+
+    val rdd = sc.parallelize(1 to 100).map( x =>
+      RowWithV4Types(x, Byte.MinValue, Short.MinValue, java.sql.Date.valueOf("2016-08-03")))
+
+    val df = sqlContext.createDataFrame(rdd)
+    df.createCassandraTable(ks, table)
+
+    val tableColumns = RetryUtil.TryUntilValid(
+      conn.withClusterDo(_.getMetadata.getKeyspace(ks).getTable(table)).getColumns.map(_.getType))
+
+    tableColumns should contain theSameElementsInOrderAs(
+      Seq(DataType.cint(), DataType.cint(), DataType.cint(), DataType.timestamp()))
+
+    df.write.cassandraFormat(table, ks).save()
+
+    val  rows = sqlContext
+      .read
+      .cassandraFormat(table, ks)
+      .load()
+      .collect
+      .map(row => (row.getInt(1), row.getInt(2), row.getTimestamp(3).toString))
+
+    val firstRow = rows(0)
+    firstRow should be((Byte.MinValue.toInt, Short.MinValue.toInt, "2016-08-03 00:00:00.0"))
+  }
+
+
 }

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
@@ -21,7 +21,7 @@ class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase with Logging 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultConf)
 
-  val conn = CassandraConnector(defaultConf)
+  override lazy val conn = CassandraConnector(defaultConf)
   conn.withSessionDo { session =>
     createKeyspace(session)
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLClusterLevelSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraSQLClusterLevelSpec.scala
@@ -13,7 +13,7 @@ class CassandraSQLClusterLevelSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template", "cassandra-default.yaml.template"))
   useSparkConf(defaultConf)
 
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
 
   val conf2 = defaultConf
     .set("spark.cassandra.connection.host", getHost(1).getHostAddress)
@@ -69,7 +69,7 @@ class CassandraSQLClusterLevelSpec extends SparkCassandraITFlatSpecBase {
       ConnectionHostParam.option(getHost(1).getHostAddress) ++ ConnectionPortParam.option(getPort(1)))
   }
 
-  it should "allow to join tables from different clusters" in {
+  "SqlContext" should "allow to join tables from different clusters" in {
     cc.read.cassandraFormat("test1", ks, cluster1).load().registerTempTable("c1_test1")
     cc.read.cassandraFormat("test2", ks, cluster2).load().registerTempTable("c2_test2")
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/util/MultiThreadedSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/util/MultiThreadedSpec.scala
@@ -13,7 +13,7 @@ class MultiThreadedSpec extends SparkCassandraITFlatSpecBase with AsyncAssertion
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultConf)
 
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
   val count = 1000
 
   val tab = "mt_test"

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/BoundStatementBuilderSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/BoundStatementBuilderSpec.scala
@@ -8,7 +8,7 @@ import com.datastax.spark.connector.types.{CassandraOption, Unset}
 
 class BoundStatementBuilderSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
 
   conn.withSessionDo { session =>
     createKeyspace(session, ks)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/GroupingBatchBuilderSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/GroupingBatchBuilderSpec.scala
@@ -13,7 +13,7 @@ import com.datastax.spark.connector.{BatchSize, BytesInBatch, RowsInBatch, Spark
 class GroupingBatchBuilderSpec extends SparkCassandraITFlatSpecBase {
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
 
   conn.withSessionDo { session =>
     createKeyspace(session)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/RoutingKeyGeneratorSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/RoutingKeyGeneratorSpec.scala
@@ -9,7 +9,7 @@ import scala.concurrent.Future
 class RoutingKeyGeneratorSpec extends SparkCassandraITFlatSpecBase {
 
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
 
   conn.withSessionDo { session =>
     createKeyspace(session)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterColumnNamesSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterColumnNamesSpec.scala
@@ -10,7 +10,7 @@ class TableWriterColumnNamesSpec extends SparkCassandraITAbstractSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultConf)
 
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
 
   case class KeyValue(key: Int, group: Long)
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
@@ -6,6 +6,8 @@ import scala.collection.JavaConversions._
 import scala.concurrent.Future
 
 import com.datastax.driver.core.ProtocolVersion
+import com.datastax.driver.core.ProtocolVersion._
+
 import com.datastax.spark.connector.{SomeColumns, _}
 import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.mapper.DefaultColumnMapper
@@ -35,7 +37,7 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultConf)
 
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
 
   conn.withSessionDo { session =>
     createKeyspace(session)
@@ -124,6 +126,15 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase {
     val rows = Seq((1, 1L, "value1"), (2, 2L, "value2"), (3, 3L, "value3"))
     sc.parallelize(rows).saveAsCassandraTableEx(table, SomeColumns("key", "group", "value"))
     verifyKeyValueTable("new_kv_table")
+  }
+
+  it should "write an RDD of PV4 Tuples to PV3 without breaking" in skipIfProtocolVersionGTE(V4){
+    val rows = Seq((Byte.MinValue, Short.MinValue, java.sql.Date.valueOf("2016-08-03")))
+    sc.parallelize(rows).saveAsCassandraTable(ks, "pv3")
+
+    sc.cassandraTable[(Int, Int, String)](ks, "pv3").collect should contain
+      theSameElementsAs(Seq(Byte.MinValue.toInt, Short.MinValue.toInt, "2016-08-03 00:00:00.0"))
+
   }
 
   it should "write RDD of tuples applying proper data type conversions" in {

--- a/spark-cassandra-connector/src/it/scala/org/apache/spark/sql/CassandraPrunedFilteredScanSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/org/apache/spark/sql/CassandraPrunedFilteredScanSpec.scala
@@ -13,7 +13,7 @@ import scala.concurrent.Future
 class CassandraPrunedFilteredScanSpec extends SparkCassandraITFlatSpecBase with Logging  {
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultConf)
-  val conn = CassandraConnector(defaultConf)
+  override val conn = CassandraConnector(defaultConf)
   val sqlContext: SQLContext = new SQLContext(sc)
 
   val cassandraFormat = "org.apache.spark.sql.cassandra"

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/DataFrameFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/DataFrameFunctions.scala
@@ -23,7 +23,10 @@ class DataFrameFunctions(dataFrame: DataFrame) extends Serializable {
   implicit
     connector: CassandraConnector = CassandraConnector(sparkContext.getConf)): Unit = {
 
-    val rawTable = TableDef.fromDataFrame(dataFrame, keyspaceName, tableName)
+    val protocolVersion = connector.
+      withClusterDo(_.getConfiguration.getProtocolOptions.getProtocolVersion)
+
+    val rawTable = TableDef.fromDataFrame(dataFrame, keyspaceName, tableName, protocolVersion)
     val columnMapping = rawTable.columnByName
 
     val columnNames = columnMapping.keys.toSet

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
@@ -92,7 +92,9 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
     rwf: RowWriterFactory[T],
     columnMapper: ColumnMapper[T]): Unit = {
 
-    val table = TableDef.fromType[T](keyspaceName, tableName)
+    val protocolVersion = connector.withClusterDo(_.getConfiguration.getProtocolOptions.getProtocolVersion)
+
+    val table = TableDef.fromType[T](keyspaceName, tableName, protocolVersion)
     saveAsCassandraTableEx(table, columns, writeConf)
   }
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
@@ -5,10 +5,8 @@ import java.net.InetAddress
 
 import scala.collection.JavaConversions._
 import scala.language.reflectiveCalls
-
 import org.apache.spark.{Logging, SparkConf}
-
-import com.datastax.driver.core.{Cluster, Host, Session}
+import com.datastax.driver.core.{Cluster, Host, ProtocolVersion, Session}
 import com.datastax.spark.connector.cql.CassandraConnectorConf.CassandraSSLConf
 import com.datastax.spark.connector.util.SerialShutdownHooks
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -6,11 +6,9 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.Try
 import scala.util.control.NonFatal
-
 import org.apache.spark.{Logging, SparkConf}
-
 import com.datastax.driver.core.ProtocolOptions
-import com.datastax.spark.connector.util.{ConfigParameter, ConfigCheck}
+import com.datastax.spark.connector.util.{ConfigCheck, ConfigParameter}
 
 /** Stores configuration of a connection to Cassandra.
   * Provides information about cluster nodes, ports and optional credentials for authentication. */
@@ -261,6 +259,7 @@ object CassandraConnectorConf extends Logging {
     } yield hostAddress
     
     val port = conf.getInt(ConnectionPortParam.name, ConnectionPortParam.default)
+
     val authConf = AuthConf.fromSparkConf(conf)
     val keepAlive = conf.getInt(KeepAliveMillisParam.name, KeepAliveMillisParam.default)
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Schema.scala
@@ -208,11 +208,19 @@ object TableDef {
 
   /** Constructs a table definition based on the mapping provided by
     * appropriate [[com.datastax.spark.connector.mapper.ColumnMapper]] for the given type. */
-  def fromType[T : ColumnMapper](keyspaceName: String, tableName: String): TableDef =
-    implicitly[ColumnMapper[T]].newTable(keyspaceName, tableName)
+  def fromType[T : ColumnMapper](
+    keyspaceName: String,
+    tableName: String,
+    protocolVersion: ProtocolVersion = ProtocolVersion.NEWEST_SUPPORTED): TableDef =
+    implicitly[ColumnMapper[T]].newTable(keyspaceName, tableName, protocolVersion)
 
-  def fromDataFrame(dataFrame: DataFrame, keyspaceName: String, tableName: String): TableDef =
-    new DataFrameColumnMapper(dataFrame.schema).newTable(keyspaceName, tableName)
+  def fromDataFrame(
+    dataFrame: DataFrame,
+    keyspaceName: String,
+    tableName: String,
+    protocolVersion: ProtocolVersion): TableDef =
+
+    new DataFrameColumnMapper(dataFrame.schema).newTable(keyspaceName, tableName, protocolVersion)
 }
 
 /** A Cassandra keyspace metadata that can be serialized. */

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/ColumnMapper.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/ColumnMapper.scala
@@ -1,5 +1,6 @@
 package com.datastax.spark.connector.mapper
 
+import com.datastax.driver.core.ProtocolVersion
 import com.datastax.spark.connector.ColumnRef
 import com.datastax.spark.connector.cql.{StructDef, TableDef}
 
@@ -37,7 +38,10 @@ trait ColumnMapper[T] {
   def columnMapForWriting(struct: StructDef, selectedColumns: IndexedSeq[ColumnRef]): ColumnMapForWriting
 
   /** Provides a definition of the table that class `T` could be saved to. */
-  def newTable(keyspaceName: String, tableName: String): TableDef
+  def newTable(
+    keyspaceName: String,
+    tableName: String,
+    protocolVersion: ProtocolVersion = ProtocolVersion.NEWEST_SUPPORTED): TableDef
 
 }
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/DataFrameColumnMapper.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/DataFrameColumnMapper.scala
@@ -1,5 +1,6 @@
 package com.datastax.spark.connector.mapper
 
+import com.datastax.driver.core.ProtocolVersion
 import com.datastax.spark.connector.ColumnRef
 import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.types.ColumnType
@@ -12,10 +13,14 @@ class DataFrameColumnMapper[T](structType: StructType) extends ColumnMapper[T] {
   override def columnMapForReading(struct: StructDef,
                                    selectedColumns: IndexedSeq[ColumnRef]): ColumnMapForReading = ???
 
-  override def newTable(keyspaceName: String, tableName: String): TableDef = {
+  override def newTable(
+    keyspaceName: String,
+    tableName: String,
+    protocolVersion: ProtocolVersion = ProtocolVersion.NEWEST_SUPPORTED): TableDef = {
+
     val columns = structType.zipWithIndex.map { case (field, i) => {
       val columnRole = if (i == 0) PartitionKeyColumn else RegularColumn
-      ColumnDef(field.name, columnRole, ColumnType.fromSparkSqlType(field.dataType))
+      ColumnDef(field.name, columnRole, ColumnType.fromSparkSqlType(field.dataType, protocolVersion))
     }}
 
     TableDef(keyspaceName, tableName, Seq(columns.head), Seq.empty, columns.tail)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/JavaBeanColumnMapper.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/JavaBeanColumnMapper.scala
@@ -2,8 +2,9 @@ package com.datastax.spark.connector.mapper
 
 import java.lang.reflect.Method
 
+import com.datastax.driver.core.ProtocolVersion
 import com.datastax.spark.connector.ColumnRef
-import com.datastax.spark.connector.cql.{TableDef, StructDef}
+import com.datastax.spark.connector.cql.{StructDef, TableDef}
 
 import scala.reflect.ClassTag
 
@@ -52,7 +53,10 @@ class JavaBeanColumnMapper[T : ClassTag](columnNameOverride: Map[String, String]
   override protected def allowsNull = true
 
   // TODO: Implement
-  override def newTable(keyspaceName: String, tableName: String): TableDef = ???
+  override def newTable(
+    keyspaceName: String,
+    tableName: String,
+    protocolVersion: ProtocolVersion = ProtocolVersion.NEWEST_SUPPORTED): TableDef = ???
 }
 
 object JavaBeanColumnMapper {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/ColumnType.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/ColumnType.scala
@@ -2,26 +2,17 @@ package com.datastax.spark.connector.types
 
 import java.net.InetAddress
 import java.nio.ByteBuffer
-import java.util.{UUID, Date}
+import java.util.{Date, UUID}
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.sql.catalyst.ReflectionLock.SparkReflectionLock
-
-import com.datastax.driver.core.{TupleType => DriverTupleType, UserType => DriverUserType, DataType}
+import com.datastax.driver.core.{DataType, ProtocolVersion, TupleType => DriverTupleType, UserType => DriverUserType}
+import com.datastax.driver.core.ProtocolVersion._
 import com.datastax.spark.connector.util.{ConfigParameter, ReflectionUtil, Symbols}
 
 import scala.collection.JavaConversions._
 import scala.reflect.runtime.universe._
-
-import org.apache.spark.sql.types.{
-  DataType => SparkSqlDataType,
-  DateType => SparkSqlDateType,
-  FloatType => SparkSqlFloatType,
-  DoubleType => SparkSqlDoubleType,
-  DecimalType => SparkSqlDecimalType,
-  BooleanType => SparkSqlBooleanType,
-  TimestampType => SparkSqlTimestampType,
-  MapType => SparkSqlMapType, _}
+import org.apache.spark.sql.types.{BooleanType => SparkSqlBooleanType, DataType => SparkSqlDataType, DateType => SparkSqlDateType, DecimalType => SparkSqlDecimalType, DoubleType => SparkSqlDoubleType, FloatType => SparkSqlFloatType, MapType => SparkSqlMapType, TimestampType => SparkSqlTimestampType, _}
 
 /** Serializable representation of column data type. */
 trait ColumnType[T] extends Serializable {
@@ -64,6 +55,9 @@ object ColumnTypeConf {
 }
 
 object ColumnType {
+
+  val protocolVersionOrdering = implicitly[Ordering[ProtocolVersion]]
+  import protocolVersionOrdering._
 
   private[connector] val primitiveTypeMap = Map[DataType, ColumnType[_]](
     DataType.text() -> TextType,
@@ -127,13 +121,15 @@ object ColumnType {
   }
 
   /** Returns natural Cassandra type for representing data of the given Spark SQL type */
-  def fromSparkSqlType(dataType: SparkSqlDataType): ColumnType[_] = {
+  def fromSparkSqlType(
+    dataType: SparkSqlDataType,
+    protocolVersion: ProtocolVersion = ProtocolVersion.NEWEST_SUPPORTED): ColumnType[_] = {
 
     def unsupportedType() = throw new IllegalArgumentException(s"Unsupported type: $dataType")
 
     dataType match {
-      case ByteType => IntType
-      case ShortType => IntType
+      case ByteType => if (protocolVersion >= V4) TinyIntType else IntType
+      case ShortType => if (protocolVersion >= V4) SmallIntType else IntType
       case IntegerType => IntType
       case LongType => BigIntType
       case SparkSqlFloatType => FloatType
@@ -142,7 +138,7 @@ object ColumnType {
       case BinaryType => BlobType
       case SparkSqlBooleanType => BooleanType
       case SparkSqlTimestampType => TimestampType
-      case SparkSqlDateType => DateType
+      case SparkSqlDateType => if (protocolVersion >= V4) DateType else TimestampType
       case SparkSqlDecimalType() => DecimalType
       case ArrayType(sparkSqlElementType, containsNull) =>
         val argType = fromSparkSqlType(sparkSqlElementType)
@@ -157,7 +153,9 @@ object ColumnType {
   }
 
   /** Returns natural Cassandra type for representing data of the given Scala type */
-  def fromScalaType(dataType: Type): ColumnType[_] = {
+  def fromScalaType(
+    dataType: Type,
+    protocolVersion: ProtocolVersion = ProtocolVersion.NEWEST_SUPPORTED): ColumnType[_] = {
 
     def unsupportedType() = throw new IllegalArgumentException(s"Unsupported type: $dataType")
 
@@ -166,10 +164,10 @@ object ColumnType {
     else if (dataType =:= typeOf[java.lang.Integer]) IntType
     else if (dataType =:= typeOf[Long]) BigIntType
     else if (dataType =:= typeOf[java.lang.Long]) BigIntType
-    else if (dataType =:= typeOf[Short]) SmallIntType
-    else if (dataType =:= typeOf[java.lang.Short]) SmallIntType
-    else if (dataType =:= typeOf[Byte]) TinyIntType
-    else if (dataType =:= typeOf[java.lang.Byte]) TinyIntType
+    else if (dataType =:= typeOf[Short]) if (protocolVersion >= V4) SmallIntType else IntType
+    else if (dataType =:= typeOf[java.lang.Short]) if (protocolVersion >= V4) SmallIntType else IntType
+    else if (dataType =:= typeOf[Byte]) if (protocolVersion >=  V4) TinyIntType else IntType
+    else if (dataType =:= typeOf[java.lang.Byte]) if (protocolVersion >= V4) TinyIntType else IntType
     else if (dataType =:= typeOf[Float]) FloatType
     else if (dataType =:= typeOf[java.lang.Float]) FloatType
     else if (dataType =:= typeOf[Double]) DoubleType
@@ -183,7 +181,7 @@ object ColumnType {
     else if (dataType =:= typeOf[String]) VarCharType
     else if (dataType =:= typeOf[InetAddress]) InetType
     else if (dataType =:= typeOf[Date]) TimestampType
-    else if (dataType =:= typeOf[java.sql.Date]) TimestampType
+    else if (dataType =:= typeOf[java.sql.Date]) if (protocolVersion >= V4) DateType else TimestampType
     else if (dataType =:= typeOf[org.joda.time.DateTime]) TimestampType
     else if (dataType =:= typeOf[UUID]) UUIDType
     else if (dataType =:= typeOf[ByteBuffer]) BlobType

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/RetryUtil.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/RetryUtil.scala
@@ -1,0 +1,21 @@
+package com.datastax.spark.connector.util
+
+import scala.annotation.tailrec
+import scala.util.{Failure, Success, Try}
+
+object RetryUtil {
+
+  @tailrec
+  def TryUntilValid[T]( f: => T, tries: Int = 3, sleepBetweenTriesInMS: Long = 1000): T = {
+    Try{ f } match {
+      case Success(x) => x
+      case _ if tries > 1 => {
+        Thread.sleep(sleepBetweenTriesInMS)
+        TryUntilValid(f, tries - 1, sleepBetweenTriesInMS)
+      }
+      case Failure(x) => throw x
+    }
+  }
+
+
+}

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/ColumnTypeSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/ColumnTypeSpec.scala
@@ -2,20 +2,13 @@ package com.datastax.spark.connector.types
 
 import java.net.InetAddress
 import java.nio.ByteBuffer
-import java.util.{UUID, Date}
+import java.util.{Date, UUID}
 
-import org.apache.spark.sql.types.{
-  BooleanType => SparkSqlBooleanType,
-  FloatType => SparkSqlFloatType,
-  DoubleType => SparkSqlDoubleType,
-  TimestampType => SparkSqlTimestampType,
-  DateType => SparkSqlDateType,
-  MapType => SparkSqlMapType,
-  DecimalType => SparkSqlDecimalType,
-  _}
+import com.datastax.driver.core.ProtocolVersion
+import org.apache.spark.sql.types.{BooleanType => SparkSqlBooleanType, DateType => SparkSqlDateType, DecimalType => SparkSqlDecimalType, DoubleType => SparkSqlDoubleType, FloatType => SparkSqlFloatType, MapType => SparkSqlMapType, TimestampType => SparkSqlTimestampType, _}
 
 import scala.reflect.runtime.universe._
-import org.scalatest.{WordSpec, GivenWhenThen, Matchers}
+import org.scalatest.{GivenWhenThen, Matchers, WordSpec}
 
 class ColumnTypeSpec extends WordSpec with Matchers with GivenWhenThen {
 
@@ -72,11 +65,26 @@ class ColumnTypeSpec extends WordSpec with Matchers with GivenWhenThen {
       "given a java.lang.Byte should return a TinyIntType" in {
         assert (ColumnType.fromScalaType(typeOf[java.lang.Byte]) === TinyIntType)
       }
+      "given a java.lang.Short and PV3 should return a IntType" in {
+        assert (ColumnType.fromScalaType(typeOf[java.lang.Short], ProtocolVersion.V3) === IntType)
+      }
+      "given a Short and PV3 should return a IntType" in {
+        assert (ColumnType.fromScalaType(typeOf[Short], ProtocolVersion.V3) === IntType)
+      }
+      "given a Byte and PV3 should return a IntType" in {
+        assert (ColumnType.fromScalaType(typeOf[Byte], ProtocolVersion.V3) === IntType)
+      }
+      "given a java.lang.Byte and PV3 should return a IntType" in {
+        assert (ColumnType.fromScalaType(typeOf[java.lang.Byte], ProtocolVersion.V3) === IntType)
+      }
       "given a java.util.Date should return TimestampType" in {
         assert (ColumnType.fromScalaType(typeOf[java.util.Date]) === TimestampType)
       }
-      "given a java.sql.Date should return TimestampType" in {
-        assert (ColumnType.fromScalaType(typeOf[java.sql.Date]) === TimestampType)
+      "given a java.sql.Date should return DateType" in {
+        assert (ColumnType.fromScalaType(typeOf[java.sql.Date]) === DateType)
+      }
+      "given a java.sql.Date and a pre V4 Protcol version should return a TimestampType" in {
+        assert (ColumnType.fromScalaType(typeOf[java.sql.Date], ProtocolVersion.V3) === TimestampType)
       }
       "given a org.joda.time.DateTime should return TimestampType" in {
         assert (ColumnType.fromScalaType(typeOf[org.joda.time.DateTime]) === TimestampType)
@@ -109,11 +117,17 @@ class ColumnTypeSpec extends WordSpec with Matchers with GivenWhenThen {
 
     "allow to obtain a proper ColumnType from Spark SQL type" when {
 
-      "given a ByteType should return IntType" in {
-        assert (ColumnType.fromSparkSqlType(ByteType) === IntType)
+      "given a ByteType should return TinyIntType" in {
+        assert (ColumnType.fromSparkSqlType(ByteType) === TinyIntType)
       }
-      "given a ShortType should return IntType" in {
-        assert (ColumnType.fromSparkSqlType(ShortType) === IntType)
+      "given a ShortType should return SmallIntType" in {
+        assert (ColumnType.fromSparkSqlType(ShortType) === SmallIntType)
+      }
+      "given a ByteType and PV3 should return IntType" in {
+        assert (ColumnType.fromSparkSqlType(ByteType, ProtocolVersion.V3) === IntType)
+      }
+      "given a ShortType and PV3 should return IntType" in {
+        assert (ColumnType.fromSparkSqlType(ShortType, ProtocolVersion.V3) === IntType)
       }
       "given a BooleanType should return BooleanType" in {
         assert (ColumnType.fromSparkSqlType(SparkSqlBooleanType) === BooleanType)
@@ -141,6 +155,9 @@ class ColumnTypeSpec extends WordSpec with Matchers with GivenWhenThen {
       }
       "given a SparkSqlDateType should return DateType" in {
         assert (ColumnType.fromSparkSqlType(SparkSqlDateType) === DateType)
+      }
+      "given a SparkSqlDateType and PV3 should return TimestampType" in {
+        assert (ColumnType.fromSparkSqlType(SparkSqlDateType, ProtocolVersion.V3) === TimestampType)
       }
       "given a BinaryType should return BlobType" in {
         assert (ColumnType.fromSparkSqlType(BinaryType) === BlobType)


### PR DESCRIPTION
There is an error where the connector will attempt to use types that are not valid for the C* version which is connected to. This patch makes all Type decisions protocol version aware to fix backwards compatibility.