### PR TITLE
Upgrade b1.5 to Spark 1.5.2

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -56,7 +56,7 @@ object Versions {
   // and install in a local Maven repository. This is all done automatically, however it will work
   // only on Unix/OSX operating system. Windows users have to build and install Spark manually if the
   // desired version is not yet published into a public Maven repository.
-  val Spark           = "1.5.1"
+  val Spark           = "1.5.2"
   val SparkJetty      = "8.1.14.v20131031"
   val JSR166e         = "1.1.0"
   val Airlift         = "0.6"


### PR DESCRIPTION
We have had some incompatibilities with Spark 1.5.2 when building the connector against 1.5.1. Changing the build target for b1.5 to 1.5.2