### PR TITLE
SPARKC-318: Fix mapping a column with null value

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
@@ -50,7 +50,7 @@ trait TypeConverter[T] extends Serializable {
 }
 
 /** Handles nullable types and converts any null to null. */
-trait NullableTypeConverter[T <: AnyRef] extends TypeConverter[T] {
+trait NullableTypeConverter[T] extends TypeConverter[T] {
   override def convert(obj: Any): T =
     if (obj != null)
       super.convert(obj)
@@ -60,7 +60,8 @@ trait NullableTypeConverter[T <: AnyRef] extends TypeConverter[T] {
 
 /** Chains together several converters converting to the same type.
   * This way you can extend functionality of any converter to support new input types. */
-class ChainedTypeConverter[T](converters: TypeConverter[T]*) extends TypeConverter[T] {
+class ChainedTypeConverter[T](converters: TypeConverter[T]*) extends NullableTypeConverter[T] {
+  def testAnyVal[T](x: T)(implicit evidence: T <:< AnyVal = null) = evidence != null
   def targetTypeTag = converters.head.targetTypeTag
   def convertPF = converters.map(_.convertPF).reduceLeft(_ orElse _)
 }


### PR DESCRIPTION
[[SPARKC-318]](https://datastax-oss.atlassian.net/browse/SPARKC-318) - Failed to convert column X of Y.Z to java.lang.Long: null
