### PR TITLE
SPARKC-405: Disallow TimeUUID Predicate Pushdown

### DIFF
--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/PredicatePushDown.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/PredicatePushDown.scala
@@ -73,8 +73,8 @@ class PredicatePushDown[Predicate : PredicateOps](predicates: Set[Predicate], ta
     * for this call.
     */
   val timeUUIDNonEqual = {
-    val timeUUIDCols = table.columns.filter( x => x.columnType == TimeUUIDType)
-    timeUUIDCols.flatMap( col => rangePredicatesByName.get(col.columnName))
+    val timeUUIDCols = table.columns.filter(x => x.columnType == TimeUUIDType)
+    timeUUIDCols.flatMap(col => rangePredicatesByName.get(col.columnName))
   }
   require(timeUUIDNonEqual.isEmpty,
     s"""


### PR DESCRIPTION
Timeuuids are compared differently in Spark and in Cassandra. In
Cassandra Timeuuids are compared bas on the Time portion of the binary
data. In Spark they are compared lexically (in byte order). In Spark <
1.6 all filters in Dataframes are applied twice, once at the DataSource
and once in Spark. This double application would be done using both of
the above comparitors leading to incorrect results. We will now throw
exceptions if we sense an end user is trying to perform one of these
impossible comparisons.