### PR TITLE
SPARKC-413: Avoid overflow on SplitSizeInMB param

### DIFF
--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -171,6 +171,12 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
     result should have length 3
   }
 
+  it should "not overflow on reasonable but large split_size_in_mb" in {
+    sc.cassandraTable(ks, "simple_kv")
+      .withReadConf(ReadConf(splitSizeInMB = 10000))
+      .splitSize should be (10485760000L)
+  }
+
   it should "allow to read a Cassandra table as Array of user-defined case class (nested) objects" in {
     val result = sc.cassandraTable[SampleWithNestedScalaCaseClass#InnerClass](ks, "simple_kv").collect()
     result should have length 3

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableRowReaderProvider.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableRowReaderProvider.scala
@@ -31,7 +31,7 @@ trait CassandraTableRowReaderProvider[R] {
 
   protected def splitCount: Option[Int] = readConf.splitCount
 
-  protected def splitSize: Int = readConf.splitSizeInMB * 1024 * 1024
+  protected[connector] def splitSize: Long = readConf.splitSizeInMB * 1024L * 1024L
 
   protected def fetchSize: Int = readConf.fetchSizeInRows
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraRDDPartitioner.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraRDDPartitioner.scala
@@ -174,7 +174,7 @@ object CassandraRDDPartitioner {
       conn: CassandraConnector,
       tableDef: TableDef,
       splitCount: Option[Int],
-      splitSize: Int): CassandraRDDPartitioner[V, T] = {
+      splitSize: Long): CassandraRDDPartitioner[V, T] = {
 
     val tokenFactory = getTokenFactory(conn)
     new CassandraRDDPartitioner(conn, tableDef, splitCount, splitSize)(tokenFactory)


### PR DESCRIPTION
Previously the split_size parameter was an Integer and was computed by
multiplying split_size_in_mb * 1024 * 1024 which will overflow for
values greater than 2047. Changing this to a Long moves this threshold
to 2097152. Hopefully in 10 years I'll look back and say what a small
amount of ram, 2TB per spark partition.