### PR TITLE
SPARKC-312: Implementing FilterOptimizer

### DIFF
--- a/spark-cassandra-connector/src/it/scala/org/apache/spark/sql/CassandraPrunedFilteredScanSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/org/apache/spark/sql/CassandraPrunedFilteredScanSpec.scala
@@ -32,6 +32,12 @@ class CassandraPrunedFilteredScanSpec extends SparkCassandraITFlatSpecBase with 
             s"""CREATE TABLE IF NOT EXISTS $ks.fields
                 |(k INT, a TEXT, b TEXT, c TEXT, d TEXT, e TEXT, PRIMARY KEY (k)) """
                 .stripMargin)
+        },
+        Future {
+          session.execute(
+            s"""CREATE TABLE IF NOT EXISTS $ks.metrics
+                |(k TEXT, a INT, b INT, c INT, PRIMARY KEY (k, a, b)) """
+              .stripMargin)
         }
       )
     }
@@ -39,6 +45,7 @@ class CassandraPrunedFilteredScanSpec extends SparkCassandraITFlatSpecBase with 
 
   val colorOptions = Map("keyspace" -> ks, "table" -> "colors")
   val fieldsOptions = Map("keyspace" -> ks, "table" -> "fields")
+  val metricsOptions = Map("keyspace" -> ks, "table" -> "metrics")
   val withPushdown = Map("pushdown" -> "true")
   val withoutPushdown = Map("pushdown" -> "false")
 
@@ -74,6 +81,16 @@ class CassandraPrunedFilteredScanSpec extends SparkCassandraITFlatSpecBase with 
     cts.get.selectedColumnNames should contain theSameElementsAs Seq("b", "c", "d")
   }
 
+  it should "optimize table scan if all filters can be pushed down" in {
+    val fieldsDF = sqlContext.read.format(cassandraFormat).options(metricsOptions ++ withPushdown).load()
+    val df = fieldsDF.filter("a = 5 and (b > 5 or b < 3)")
+    val executionPlan = df.queryExecution.executedPlan
+    val cts = findAllCassandraTableScanRDD(executionPlan)
+    cts.nonEmpty shouldBe true
+    cts.head.where shouldBe CqlWhereClause(Seq(""""a" = ? AND "b" > ?"""), List(5, 5))
+    cts.last.where shouldBe CqlWhereClause(Seq(""""a" = ? AND "b" < ?"""), List(5, 3))
+  }
+
   def findCassandraTableScanRDD(sparkPlan: SparkPlan): Option[CassandraTableScanRDD[_]] = {
     def _findCassandraTableScanRDD(rdd: RDD[_]): Option[CassandraTableScanRDD[_]] = {
       rdd match {
@@ -89,6 +106,24 @@ class CassandraPrunedFilteredScanSpec extends SparkCassandraITFlatSpecBase with 
       case filter: FilterExec => findCassandraTableScanRDD(filter.child)
       case wsc: WholeStageCodegenExec => findCassandraTableScanRDD(wsc.child)
       case _ => None
+    }
+  }
+
+  def findAllCassandraTableScanRDD(sparkPlan: SparkPlan): List[CassandraTableScanRDD[_]] = {
+    def _findAllCassandraTableScanRDD(rdd: RDD[_]): List[CassandraTableScanRDD[_]] = {
+      rdd match {
+        case ctsrdd: CassandraTableScanRDD[_] => List(ctsrdd)
+        case other: RDD[_] => other.dependencies.iterator
+          .flatMap(dep => _findAllCassandraTableScanRDD(dep.rdd)).toList
+      }
+    }
+
+    sparkPlan match {
+      case prdd: RDDScanExec => _findAllCassandraTableScanRDD(prdd.rdd)
+      case prdd: RowDataSourceScanExec => _findAllCassandraTableScanRDD(prdd.rdd)
+      case filter: FilterExec => findAllCassandraTableScanRDD(filter.child)
+      case wsc: WholeStageCodegenExec => findAllCassandraTableScanRDD(wsc.child)
+      case _ => List.empty
     }
   }
 

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/FiltersOptimizer.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/FiltersOptimizer.scala
@@ -1,0 +1,88 @@
+package org.apache.spark.sql.cassandra
+
+import org.apache.spark.sql.sources._
+
+
+/**
+  * Optimizer will try to transform pushdown filter into `sum of products`.
+  * So that the filter like
+  * '(field1 < 3 OR field1 > 7) AND (field2 = 'val1' OR field2 = 'val2')'
+  * will become equivalent
+  * 'field1 < 3 AND field2 = "val1" OR field1 < 3 AND field2 = "val2" OR
+  * field1 > 7 AND field2 = "val1" OR field1 > 7 AND field2 = "val2"'
+  */
+class FiltersOptimizer(filters: Array[Filter]) {
+
+  private val fullFilterAst =
+    if (filters.nonEmpty) Some(filters.reduce((left, right) => And(left, right))) else None
+
+  private def dist(predL: Filter, predR: Filter): Filter = (predL, predR) match {
+    case (Or(l, r), p) => Or(dist(l, p), dist(r, p))
+    case (p, Or(l, r)) => Or(dist(p, l), dist(p, r))
+    case (l, r) => And(l, r)
+  }
+
+  /** The 'toNNF' function converts expressions to negation normal form. This
+    * function is total: it's defined for all expressions, not just those which
+    * only use negation, conjunction and disjunction, although all expressions in
+    * negation normal form do in fact only use those connectives.
+    *
+    * Then de Morgan's laws are applied to convert negated
+    * conjunctions and disjunctions into the conjunction or disjunction of the
+    * negation of their conjuncts: ¬(φ ∧ ψ) is converted to (¬φ ∨ ¬ψ)
+    * while ¬(φ ∨ ψ) becomes (¬φ ∧ ¬ψ).
+    */
+  private val toNNF: Filter => Filter = {
+    case a@(EqualTo(_, _) | EqualNullSafe(_, _) | GreaterThan(_, _) |
+            GreaterThanOrEqual(_, _) | LessThan(_, _) | LessThanOrEqual(_, _) |
+            In(_, _) | IsNull(_) | IsNotNull(_) |
+            StringStartsWith(_, _) | StringEndsWith(_, _) | StringContains(_, _)) => a
+    case a@Not(EqualTo(_, _) | EqualNullSafe(_, _) | In(_, _) |
+               StringStartsWith(_, _) | StringEndsWith(_, _) | StringContains(_, _)) => a
+    case Not(GreaterThan(a, v)) => LessThanOrEqual(a, v)
+    case Not(LessThanOrEqual(a, v)) => GreaterThan(a, v)
+    case Not(LessThan(a, v)) => GreaterThanOrEqual(a, v)
+    case Not(GreaterThanOrEqual(a, v)) => LessThan(a, v)
+    case Not(IsNull(a)) => IsNotNull(a)
+    case Not(IsNotNull(a)) => IsNull(a)
+    case Not(Not(p)) => p
+    case And(l, r) => And(toNNF(l), toNNF(r))
+    case Not(And(l, r)) => toNNF(Or(Not(l), Not(r)))
+    case Or(l, r) => Or(toNNF(l), toNNF(r))
+    case Not(Or(l, r)) => toNNF(And(Not(l), Not(r)))
+  }
+
+  /** The 'toDNF' function converts expressions to disjunctive normal form: a
+    * disjunction of clauses, where a clause is a conjunction of literals
+    * (variables and negated variables).
+    *
+    * The conversion is carried out by first converting the expression into
+    * negation normal form, and then applying the distributive law.
+    */
+  private val toDNF: Filter => Filter = {
+    case And(l, r) => dist(toDNF(l), toDNF(r))
+    case Or(l, r) => Or(toDNF(l), toDNF(r))
+    case p => p
+  }
+
+  /**
+    * Traverse over disjunctive parts of AST
+    */
+  private val traverse: Filter => List[Filter] = {
+    case Or(l, r) => traverse(l) ++ traverse(r)
+    case a => a :: Nil
+  }
+
+  private val andToArray: Filter => Array[Filter] = {
+    case And(l, r) => andToArray(l) ++ andToArray(r)
+    case a => Array(a)
+  }
+
+  private val groupAnd: List[Filter] => List[Array[Filter]] = _.map(andToArray)
+
+  def build(): List[Array[Filter]] = fullFilterAst match {
+    case Some(ast) => (toNNF andThen toDNF andThen traverse andThen groupAnd).apply(ast)
+    case None => List.empty
+  }
+
+}


### PR DESCRIPTION
FilterOptimizer will to transform `where` clause to equivalent disjunction normal form. 
For example where clause `a = 5 and (b > 5 or b < 3)` can be transformed to equivalent `a = 5 and b > 5 or a =5 and b < 3`, so now we can create two different table scans with where clause `a = 5 and b > 5` and `a =5 andb < 3` and union them.