### PR TITLE
SPARKC-355

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -101,6 +101,7 @@ object Settings extends Build {
     spAppendScalaVersion := true,
     spIncludeMaven := true,
     spIgnoreProvided := true,
+    spShade := true,
     credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
   )
 
@@ -203,7 +204,8 @@ object Settings extends Build {
   lazy val defaultSettings = projectSettings ++ mimaSettings ++ releaseSettings ++ testSettings
 
   lazy val rootSettings = Seq(
-    cleanKeepFiles ++= Seq("resolution-cache", "streams", "spark-archives").map(target.value / _)
+    cleanKeepFiles ++= Seq("resolution-cache", "streams", "spark-archives").map(target.value / _),
+    updateOptions := updateOptions.value.withCachedResolution(true)
   )
 
   lazy val demoSettings = projectSettings ++ noPublish ++ Seq(
@@ -228,7 +230,7 @@ object Settings extends Build {
       cp
     }
   )
-  lazy val assembledSettings = defaultSettings ++ customTasks ++ sparkPackageSettings ++ sbtAssemblySettings
+  lazy val assembledSettings = defaultSettings ++ customTasks ++ sbtAssemblySettings ++ sparkPackageSettings
 
   val testOptionSettings = Seq(
     Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
@@ -339,8 +341,7 @@ object Settings extends Build {
     assemblyShadeRules in assembly := {
       val shadePackage = "shade.com.datastax.spark.connector"
       Seq(
-        ShadeRule.rename("com.google.common.**" -> s"$shadePackage.google.common.@1").inAll,
-        ShadeRule.rename("io.netty.**" -> s"$shadePackage.netty.@1").inAll
+        ShadeRule.rename("com.google.common.**" -> s"$shadePackage.google.common.@1").inAll
       )
     }
   )

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -42,6 +42,7 @@ object Versions {
   val JOpt            = "3.2"
   val Kafka           = "0.8.2.2"
   val Lzf             = "0.8.4"
+  val Netty           = "4.0.33.Final"
   val CodaHaleMetrics = "3.0.2"
   val ScalaCheck      = "1.12.5"
   val ScalaMock       = "3.2"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,11 +22,7 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
 
-addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.4")
-
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.6")
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
+addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.5")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M12")
 


### PR DESCRIPTION
Request cfca49e (Russell Spitzer, 26 hours ago)
    SPARKC-355: Wire publish and publishLocal to the new package task

    With this last change the default connector project is basically a
    distribution project. It contains the shaded marked as provided so pulling
    from maven will not pull the shaded guava or netty. It's publish tasks all
    go through the new packageBin which ends up running the assembly task from
    the Shaded project.

 5b8ee42 (Russell Spitzer, 27 hours ago)
    SPARKC-355: Update to Released Spark Packages

    The `connector` project now only includes the shaded libraries as test,
    this means the resultant POM file wil not cause end users to pull down our
    Guava by default.

 2dbea19 (Russell Spitzer, 5 days ago)
    SPARKC-355: Remove Default Artifact, Publish Only Shaded Jars

    Inorder to make sure there is no confusion about what Jar an end user
    should be including in their build file, the only artifact that will be
    published under the name spark-cassandra-connector will be the shaded jar.
    This means all package and packageBin tasks are essentially noops.

    publishLocal, and publish will now use the Shaded jar as the the
    spark-cassandra-connector artifact.

 177bf38 (Russell Spitzer, 8 days ago)
    SPARKC-355: Add shadedConnector Project

    Adds an additional project which mirrors the normal connector build project
    except it marks ALL libraries except those we are explictly shading as
    provided. This makes it so it's assembly task will only include the shaded
    jars we want and no other dependencies.

    This assembly task which only includes shaded deps is then set as the
    assembly target of spPackages which in coordination with spShade changes
    the spDist task to use the shaded assembly jar as it's target rather than
    the standard assembly jar with all dependencies.

 3a8947a (Russell Spitzer, 8 days ago)
    SPARKC-355: Explicitly use netty-all at a specified version

    To add a bit more explictness to our build, all netty sub components are
    excluded and instead we will rely on the netty-all package for the maximum
    version required by the Cassandra Java Driver. This jar will also be
    shaded.