### PR TITLE
SPARKC-355: Have all public artifacts use the Shaded Jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ See [Building And Artifacts](doc/12_building_and_artifacts.md)
   - [Partitioner](doc/16_partitioning.md)
   - [Frequently Asked Questions](doc/FAQ.md)
   - [Configuration Parameter Reference Table](doc/reference.md)
+  - [Tips for Developing the Spark Cassandra Connector](doc/developers.md)
 
 ## Online Training
 ### DataStax Academy
@@ -145,8 +146,11 @@ Make sure you have installed and enabled the Scala Plugin.
 Open the project with IntelliJ IDEA and it will automatically create the project structure
 from the provided SBT configuration.
 
+[Tips for Developing the Spark Cassandra Connector](doc/developers.md)
+
 Before contributing your changes to the project, please make sure that all unit tests and integration tests pass.
 Don't forget to add an appropriate entry at the top of CHANGES.txt.
+Create a Jira at the [Spark Cassandra Connector Jira](https://datastax-oss.atlassian.net/projects/SPARKC/issues)
 Finally open a pull-request on GitHub and await review. 
 
 Please prefix pull request description with the JIRA number, for example: "SPARKC-123: Fix the ...".

--- a/doc/developers.md
+++ b/doc/developers.md
@@ -1,0 +1,84 @@
+# Documentation
+
+## Developers Tips
+
+### Getting Started
+
+The Spark Cassandra Connector is built using sbt. There is a premade
+launching script for sbt so it is unneccessary to download it. To invoke
+this script you can run `./sbt/sbt` from a clone of this repository.
+
+For information on setting up your clone please follow the [Github 
+Help](https://help.github.com/articles/cloning-a-repository/)
+
+Once in the sbt shell you will be able to build and run tests for the
+connector without any Spark or Cassandra nodes running. The most common
+commands to use when developing the connector are
+
+1. `test` - Runs the the unit tests for the project.
+2. `it:test` - Runs the integeration tests with embedded C* and Spark
+3. `assembly` - Builds a fat jar for using with --jars in spark submit or spark-shell
+
+The integration tests located in `spark-cassandra-connector/src/it` should
+probably be the first place to look for anyone considering adding code.
+There are many examples of executing a feature of the connector with
+the embedded Cassandra and Spark nodes and are the core of our test 
+coverage.
+
+### Sub-Projects
+
+The connector currently contains several subprojects
+#### spark-cassandra-connector
+This sub project contains all of the actual connector code and is where
+any new features or tests should go. This Scala project also contains the
+Java api and related code.
+
+#### spark-cassandra-connector-embedded
+The code used to start the embedded services used in the integration tests. 
+This contains methods for starting up C* as a thread within the running
+test code.
+
+#### spark-cassandra-connector-doc
+Code for building reference documentation. This uses the code from 
+`spark-cassandra-connector` to determine what belongs in the reference
+file. It should mostly be used for regenerating the reference file after
+new parameters have been added or old parameters have been changed. Tests
+in `spark-cassandra-connector` will throw errors if the reference file is
+not up to date. To fix this run `spark-cassandra-connector-doc/run` to
+update the file. It is still necessary to commit the changed file after
+running this sub-project.
+
+#### spark-cassandra-connector-perf
+Code for performance based tests. Add any performance comparisons needed
+to this project.
+
+### Continuous Testing
+
+It's often useful when implementing new features to have the tests run
+in a loop on code change. Sbt provides a method for this by using the
+`~` operator. With this `~ test` will run the unit tests every time a
+change in the source code is detected. This is often useful to use in
+conjunction with `testOnly` which runs a single test. So if a new feature
+were being added to the integration suite `foo` you may want to run
+`~ it:testOnly foo`. Which would only run the suite you are interested in
+on a loop while you are modifying the connector code.
+
+### Packaging
+
+The `spark-shell` and `spark-submit` are able to use local caches to load
+libraries and this can be taken advantage of by the SCC. For example
+if you wanted to test the maven artifacts produced for your current build
+you could run `publishM2` which would generate the needed artifacts and
+pom in your local cache. You can then reference this from `spark-shell`
+or `spark-submit` using the following code 
+```bash
+./bin/spark-shell --repositories file:/Users/yourUser/.m2/repository --packages com.datastax.spark:spark-cassandra-connector_2.10:1.6.0-14-gcfca49e
+```
+Where you would change the revision `1.6.0-14-gcfca49e` to match the output
+of your publish command. 
+
+This same method should work with `publishLocal`
+after the merging of [SPARK-12666](https://issues.apache.org/jira/browse/SPARK-12666)
+
+
+

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -101,6 +101,7 @@ object Settings extends Build {
     spAppendScalaVersion := true,
     spIncludeMaven := true,
     spIgnoreProvided := true,
+    spShade := true,
     credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
   )
 
@@ -203,7 +204,8 @@ object Settings extends Build {
   lazy val defaultSettings = projectSettings ++ mimaSettings ++ releaseSettings ++ testSettings
 
   lazy val rootSettings = Seq(
-    cleanKeepFiles ++= Seq("resolution-cache", "streams", "spark-archives").map(target.value / _)
+    cleanKeepFiles ++= Seq("resolution-cache", "streams", "spark-archives").map(target.value / _),
+    updateOptions := updateOptions.value.withCachedResolution(true)
   )
 
   lazy val demoSettings = projectSettings ++ noPublish ++ Seq(
@@ -228,7 +230,7 @@ object Settings extends Build {
       cp
     }
   )
-  lazy val assembledSettings = defaultSettings ++ customTasks ++ sparkPackageSettings ++ sbtAssemblySettings
+  lazy val assembledSettings = defaultSettings ++ customTasks ++ sbtAssemblySettings ++ sparkPackageSettings
 
   val testOptionSettings = Seq(
     Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
@@ -339,8 +341,7 @@ object Settings extends Build {
     assemblyShadeRules in assembly := {
       val shadePackage = "shade.com.datastax.spark.connector"
       Seq(
-        ShadeRule.rename("com.google.common.**" -> s"$shadePackage.google.common.@1").inAll,
-        ShadeRule.rename("io.netty.**" -> s"$shadePackage.netty.@1").inAll
+        ShadeRule.rename("com.google.common.**" -> s"$shadePackage.google.common.@1").inAll
       )
     }
   )

--- a/project/SparkCassandraConnectorBuild.scala
+++ b/project/SparkCassandraConnectorBuild.scala
@@ -18,12 +18,14 @@
 import java.io.File
 
 import pl.project13.scala.sbt.JmhPlugin
+import sbtsparkpackage.SparkPackagePlugin.autoImport._
 import sbt.Keys._
 import sbt._
 
 object CassandraSparkBuild extends Build {
   import Settings._
   import sbtassembly.AssemblyPlugin
+  import sbtassembly.AssemblyKeys._
   import sbtsparkpackage.SparkPackagePlugin
 
   val namespace = "spark-cassandra-connector"
@@ -34,7 +36,7 @@ object CassandraSparkBuild extends Build {
     name = "root",
     dir = file("."),
     settings = rootSettings ++ Seq(cassandraServerClasspath := { "" }),
-    contains = Seq(embedded, connector, demos)
+    contains = Seq(embedded, connectorDistribution, demos)
   ).disablePlugins(AssemblyPlugin, SparkPackagePlugin)
 
   lazy val cassandraServerProject = Project(
@@ -57,13 +59,83 @@ object CassandraSparkBuild extends Build {
         "org.scala-lang" % "scala-compiler" % scalaVersion.value))
   ).disablePlugins(AssemblyPlugin, SparkPackagePlugin) configs IntegrationTest
 
-  lazy val connector = CrossScalaVersionsProject(
+  /**
+    * Do not included shaded dependencies so they will not be listed in the Pom created for this
+    * project.
+    *
+    * Run the compile from the shaded project since we are no longer including shaded libs
+    */
+  lazy val connectorDistribution = CrossScalaVersionsProject(
     name = namespace,
-    conf = assembledSettings ++ Seq(libraryDependencies ++= Dependencies.connector ++ Seq(
+    conf = assembledSettings ++ Seq(
+      libraryDependencies ++= Dependencies.connectorDistribution ++ Seq(
         "org.scala-lang" % "scala-reflect"  % scalaVersion.value,
-        "org.scala-lang" % "scala-compiler" % scalaVersion.value % "test,it")) ++ pureCassandraSettings
-    ).copy(dependencies = Seq(embedded % "test->test;it->it,test;")
+        "org.scala-lang" % "scala-compiler" % scalaVersion.value % "test,it"),
+      //Use the assembly which contains all of the libs not just the shaded ones
+      assembly in spPackage := (assembly in shadedConnector).value,
+      //Use the Pom file for this project in spark packages not the assembly pom
+      spMakePom := makePom.value,
+      assembly := (assembly in fullConnector).value,
+      //Use the shaded jar as our packageTarget
+      packageBin := {
+        val shaded = (assembly in shadedConnector).value
+        val targetName = target.value
+        val expected = target.value / s"$namespace-${version.value}.jar"
+        IO.move(shaded, expected)
+        val log = streams.value.log
+        log.info(s"""Shaded jar moved to $expected""".stripMargin)
+        expected
+      },
+      sbt.Keys.`package` := packageBin.value)
+      ++ pureCassandraSettings
+      //Update the distribution tasks to use the shaded jar
+      ++ {for (taskKey <- Seq(publishLocal in Compile, publish in Compile, publishM2 in Compile)) yield {
+      packagedArtifacts in taskKey := {
+        val previous = (packagedArtifacts in Compile).value
+        val shadedJar = (artifact.value.copy(configurations = Seq(Compile)) -> packageBin.value)
+        //Clobber the old build artifact with the shaded jar
+        previous + shadedJar
+      }
+    }}
+  ).copy(dependencies = Seq(embedded % "test->test;it->it,test;")
   ) configs IntegrationTest
+
+  /** Because the distribution project has to mark the shaded jars as provided to remove them from
+    * the distribution dependencies we provide this additional project to build a fat jar which
+    * includes everything. The artifact produced by this project is unshaded while the assembly
+    * remains shaded.
+    */
+  lazy val fullConnector = CrossScalaVersionsProject(
+    name = s"$namespace-full",
+    conf = assembledSettings ++ Seq(
+      libraryDependencies ++= Dependencies.connectorAll
+        ++ Dependencies.shaded
+        ++ Seq(
+        "org.scala-lang" % "scala-reflect"  % scalaVersion.value,
+        "org.scala-lang" % "scala-compiler" % scalaVersion.value % "test,it"),
+      target := target.value / "full"
+    )
+      ++ pureCassandraSettings,
+    base = Some(namespace)
+  ).copy(dependencies = Seq(embedded % "test->test;it->it,test")) configs IntegrationTest
+
+
+  lazy val shadedConnector = CrossScalaVersionsProject(
+    name = s"$namespace-shaded",
+    conf = assembledSettings ++ Seq(
+      libraryDependencies ++= Dependencies.connectorNonShaded
+        ++ Dependencies.shaded
+        ++ Seq(
+        "org.scala-lang" % "scala-reflect"  % scalaVersion.value,
+        "org.scala-lang" % "scala-compiler" % scalaVersion.value % "test,it"),
+      target := target.value / "shaded",
+      test in assembly := {},
+      publishArtifact in (Compile, packageBin) := false)
+      ++ pureCassandraSettings,
+    base = Some(namespace)
+  ).copy(dependencies = Seq(embedded % "test->test;it->it,test;")
+  ) configs IntegrationTest
+
 
   lazy val demos = RootProject(
     name = "demos",
@@ -75,27 +147,27 @@ object CassandraSparkBuild extends Build {
     id = "simple-demos",
     base = demosPath / "simple-demos",
     settings = demoSettings,
-    dependencies = Seq(connector, embedded)
+    dependencies = Seq(connectorDistribution, embedded)
   ).disablePlugins(AssemblyPlugin, SparkPackagePlugin)
 
   lazy val kafkaStreaming = Project(
     id = "kafka-streaming",
     base = demosPath / "kafka-streaming",
     settings = demoSettings ++ Seq(libraryDependencies ++= Seq(Artifacts.Demos.kafka, Artifacts.Demos.kafkaStreaming)),
-    dependencies = Seq(connector, embedded))
+    dependencies = Seq(connectorDistribution, embedded))
       .disablePlugins(AssemblyPlugin, SparkPackagePlugin)
 
   lazy val refDoc = Project(
     id = s"$namespace-doc",
     base = file(s"$namespace-doc"),
     settings = defaultSettings ++ Seq(libraryDependencies ++= Dependencies.spark)
-  ) dependsOn connector
+  ) dependsOn connectorDistribution
 
   lazy val perf = Project(
     id = s"$namespace-perf",
     base = file(s"$namespace-perf"),
     settings = projectSettings,
-    dependencies = Seq(connector, embedded)
+    dependencies = Seq(connectorDistribution, embedded)
   ) enablePlugins(JmhPlugin)
 
   def crossBuildPath(base: sbt.File, v: String): sbt.File = base / s"scala-$v" / "src"
@@ -103,8 +175,9 @@ object CassandraSparkBuild extends Build {
   /* templates */
   def CrossScalaVersionsProject(name: String,
                                 conf: Seq[Def.Setting[_]],
-                                reliesOn: Seq[ClasspathDep[ProjectReference]] = Seq.empty) =
-    Project(id = name, base = file(name), dependencies = reliesOn, settings = conf ++ Seq(
+                                reliesOn: Seq[ClasspathDep[ProjectReference]] = Seq.empty,
+                                base: Option[String] = None) =
+    Project(id = name, base = file(base.getOrElse(name)), dependencies = reliesOn, settings = conf ++ Seq(
       unmanagedSourceDirectories in (Compile, packageBin) +=
         crossBuildPath(baseDirectory.value, scalaBinaryVersion.value),
       unmanagedSourceDirectories in (Compile, doc) +=
@@ -132,8 +205,14 @@ object Artifacts {
     def guavaExclude(): ModuleID =
       module exclude("com.google.guava", "guava")
 
-    def nettyExclude(): ModuleID =
-      module exclude("io.netty", "netty-all")
+    /**We will just include netty-all as a dependency **/
+    def nettyExclude(): ModuleID = module
+      .exclude("io.netty", "netty")
+      .exclude("io.netty", "netty-buffer")
+      .exclude("io.netty", "netty-codec")
+      .exclude("io.netty", "netty-common")
+      .exclude("io.netty", "netty-handler")
+      .exclude("io.netty", "netty-transport")
 
     def glassfishExclude(): ModuleID = {
       module
@@ -150,6 +229,11 @@ object Artifacts {
         .exclude("commons-logging", "commons-logging")
         .exclude("org.apache.curator", "curator-recipes")
 
+    def driverExclusions(): ModuleID = module.guavaExclude().nettyExclude()
+        .exclude("io.dropwizard.metrics", "metrics-core")
+        .exclude("org.slf4j", "slf4j-api")
+
+
     def sparkExclusions(): ModuleID = module.sparkCoreExclusions()
       .exclude("org.apache.spark", s"spark-core_$scalaBinary")
 
@@ -162,7 +246,7 @@ object Artifacts {
       .exclude("org.apache.spark", s"spark-mllib_$scalaBinary")
       .exclude("org.scala-lang", "scala-compiler")
 
-    def kafkaExclusions: ModuleID = module
+    def kafkaExclusions(): ModuleID = module
       .exclude("org.slf4j", "slf4j-simple")
       .exclude("com.sun.jmx", "jmxri")
       .exclude("com.sun.jdmk", "jmxtools")
@@ -172,13 +256,14 @@ object Artifacts {
   val akkaActor           = "com.typesafe.akka"       %% "akka-actor"            % Akka           % "provided"  // ApacheV2
   val akkaRemote          = "com.typesafe.akka"       %% "akka-remote"           % Akka           % "provided"  // ApacheV2
   val akkaSlf4j           = "com.typesafe.akka"       %% "akka-slf4j"            % Akka           % "provided"  // ApacheV2
-  val cassandraDriver     = "com.datastax.cassandra"  % "cassandra-driver-core"  % CassandraDriver                  guavaExclude() // ApacheV2
+  val cassandraDriver     = "com.datastax.cassandra"  % "cassandra-driver-core"  % CassandraDriver driverExclusions() // ApacheV2
   val commonsBeanUtils    = "commons-beanutils"       % "commons-beanutils"      % CommonsBeanUtils                 exclude("commons-logging", "commons-logging") // ApacheV2
   val config              = "com.typesafe"            % "config"                 % Config         % "provided"  // ApacheV2
   val guava               = "com.google.guava"        % "guava"                  % Guava
   val jodaC               = "org.joda"                % "joda-convert"           % JodaC
   val jodaT               = "joda-time"               % "joda-time"              % JodaT
   val lzf                 = "com.ning"                % "compress-lzf"           % Lzf            % "provided"
+  val netty               = "io.netty"                % "netty-all"              % Netty
   val slf4jApi            = "org.slf4j"               % "slf4j-api"              % Slf4j          % "provided"  // MIT
   val jsr166e             = "com.twitter"             % "jsr166e"                % JSR166e                      // Creative Commons
   val airlift             = "io.airlift"              % "airline"                % Airlift
@@ -269,11 +354,51 @@ object Dependencies {
 
   val spark = Seq(sparkCore, sparkStreaming, sparkSql, sparkCatalyst, sparkHive, sparkUnsafe)
 
-  val connector = (testKit ++ metrics ++ jetty ++ logging ++ cassandra ++ spark.map(_ % "provided") ++ Seq(commonsBeanUtils, guava, jodaC, jodaT, lzf, jsr166e))
-      .map (_ exclude(org = "org.slf4j", name = "log4j-over-slf4j"))
+  /**
+    * Dependencies which will be shaded in our distribution artifact and not listed on the
+    * distribution artifact's dependency list.
+    */
+  val shaded = Seq(guava, cassandraDriver)
 
-  val embedded = (logging ++ spark ++ cassandra ++ akka ++ Seq(
-    cassandraServer % "it,test", Embedded.jopt, Embedded.sparkRepl, Embedded.kafka, Embedded.snappy, guava, config)) map (_ exclude(org = "org.slf4j", name = "log4j-over-slf4j"))
+  /**
+    * This is the full dependency list required to build an assembly with all dependencies
+    * required to run the connector not listed as provided except for those which will
+    * be on the classpath because of Spark.
+    */
+  val connectorAll = shaded ++ (testKit ++
+    metrics ++
+    jetty ++
+    logging ++
+    spark.map(_ % "provided") ++
+    Seq(commonsBeanUtils, jodaC, jodaT, lzf, netty, jsr166e)
+    ).map(_ exclude(org = "org.slf4j", name = "log4j-over-slf4j"))
+
+  /**
+    * Mark the shaded dependencies as Provided, this removes them from the artifacts to be downloaded
+    * by build systems. This will avoid downloading a Cassandra Driver which does not have it's guava
+    * references shaded.
+    */
+  val connectorDistribution = (connectorAll.toSet -- shaded.toSet).toSeq ++ shaded.map(_ % "provided")
+
+  /**
+    * When building the shaded jar we want the assembly task to ONLY include the shaded libs, to
+    * accomplish this we set all other dependencies as provided.
+    */
+  val connectorNonShaded = (connectorAll.toSet -- shaded.toSet).toSeq.map { dep =>
+    dep.configurations match {
+      case Some(conf) => dep
+      case _ => dep % "provided"
+    }
+  }
+
+  val embedded = logging ++ spark ++ cassandra ++ akka ++ Seq(
+    cassandraServer % "it,test",
+    Embedded.jopt,
+    Embedded.sparkRepl,
+    Embedded.kafka,
+    Embedded.snappy,
+    guava,
+    config).map(_ exclude(org = "org.slf4j", name = "log4j-over-slf4j"))
 
   val perf = logging ++ spark ++ cassandra
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -42,6 +42,7 @@ object Versions {
   val JOpt            = "3.2"
   val Kafka           = "0.8.2.2"
   val Lzf             = "0.8.4"
+  val Netty           = "4.0.33.Final"
   val CodaHaleMetrics = "3.0.2"
   val ScalaCheck      = "1.12.5"
   val ScalaMock       = "3.2"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,7 +22,9 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
 
-addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.4")
+//SbtAssembly 0.12.0 is included in sbt-spark-package
+resolvers += "Spark Packages Main repo" at "https://dl.bintray.com/spark-packages/maven" 
+addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.5")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.6")
 


### PR DESCRIPTION
High Level Summary:
 Cassandra Java Driver and Shaded Guava are in the release artifacts
 No Shaded Netty (Did not seem to conflict)
 Package, Publish* tasks push shaded artifacts

Details

This patch publishes artifacts as a jar with the Cassandra
Java Driver included and guava shaded. This is a necessity because of
guava conflicts in Spark 2.0. Essentially any references to Guava that
the driver uses must be to a Guava version greater than 16. We
accomplish this by shading all references within the driver which we
also include. This makes it impossible to change the C* java driver
used with the connector. This is not a large issue because any Cassandra
Java Driver without shaded guava on the  classpath will throw incompatible guava errors.

To distribute this artifact the connector project (now connectorDistribution)
has several sibling-projects.

To produce the shadedJar we add shadedConnector. This project marks
all the dependencies of the project as provided except for the shaded
dependencies. This causes its assembly task to produce a jar which only
contains the Connector classes, Shaded Guava, and a Java Driver which
refers to the shaded guava. The assembly of this project is used as the
packageBin method in the connectorDistribution as well as an artifact
in the publish* tasks.

The connector distribution POM now no longer needs compile configuration
for the shaded dependencies since they will already be in the jar. These
deps are marked as provided but but this also removes them from the
assembly task within connectorDistribution.

To fix this we add another project fullConnector. This project contains all of the
dependencies required to run the connector and the shaded libraries are
not marked as provided. This produces an assembly task with everything
needed. The artifact produced by the normal build of this project is
identical to our old `connector` project where the connector.jar
requires seperate guava and the java driver. The assembly task produces
the full shaded jar with all dependencies and is used as the assembly
task in connectorDistribution.