### PR TITLE
SPARKC-433: Fix 'ORDER BY' and 'LIMIT' order in query

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/AbstractCassandraJoin.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/AbstractCassandraJoin.scala
@@ -127,7 +127,7 @@ private[rdd] trait AbstractCassandraJoin[L, R] {
     val query =
       s"SELECT $columns " +
         s"FROM $quotedKeyspaceName.$quotedTableName " +
-        s"WHERE $filter $limitClause $orderBy"
+        s"WHERE $filter $orderBy $limitClause"
     logDebug(s"Query : $query")
     query
   }


### PR DESCRIPTION
LIMIT should be after ORDER BY