### PR TITLE
SPARKC-419: Fix partitioner on Integer.MIN_VALUE

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/ReplicaPartitioner.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/ReplicaPartitioner.scala
@@ -52,7 +52,9 @@ implicit
   private val indexMap = for ((ip, partitions) <- hostMap; partition <- partitions) yield (partition, ip)
   // 0->IP1, 1-> IP1, ...
 
-  private def randomHost(index: Int): InetAddress = hosts(index % hosts.length)
+  private def absModulo(dividend: Int, divisor: Int) : Int = Math.abs(dividend % divisor)
+
+  private def randomHost(index: Int): InetAddress = hosts(absModulo(index, hosts.length))
 
   /**
    * Given a set of endpoints, pick a random endpoint, and then a random partition owned by that
@@ -73,10 +75,10 @@ implicit
 
         val replicaSetInDC = (hostSet & replicas).toVector
         if (replicaSetInDC.nonEmpty) {
-          val endpoint = replicaSetInDC(tokenHash % replicaSetInDC.size)
-          hostMap(endpoint)(tokenHash % partitionsPerReplicaSet)
+          val endpoint = replicaSetInDC(absModulo(tokenHash, replicaSetInDC.size))
+          hostMap(endpoint)(absModulo(tokenHash, partitionsPerReplicaSet))
         } else {
-          hostMap(randomHost(tokenHash))(tokenHash % partitionsPerReplicaSet)
+          hostMap(randomHost(tokenHash))(absModulo(tokenHash, partitionsPerReplicaSet))
         }
       case _ => throw new IllegalArgumentException(
         "ReplicaPartitioner can only determine the partition of a tuple whose key is a non-empty Set[InetAddress]. " +


### PR DESCRIPTION
Tokens might give Integer.MIN_VALUE as hashcode. This will lead to a negative
index into the set of replicas for the corresponding key and fail the task.

The reason is that Math.abs() returns a negative value for Integer.MIN_VALUE
and % gives a negative result in case the dividend is negative.

To fix this the partitioner now applies Math.abs() to the result of the modulo
calculation instead of to the token hash (the dividend). This guarantees that
the index is never negative.