### PR TITLE
Use ConnectionHostParam.default as the default hosts string.

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -217,7 +217,7 @@ object CassandraConnectorConf extends Logging {
 
   def apply(conf: SparkConf): CassandraConnectorConf = {
     ConfigCheck.checkConfig(conf)
-    val hostsStr = conf.get(ConnectionHostParam.name, InetAddress.getLocalHost.getHostAddress)
+    val hostsStr = conf.get(ConnectionHostParam.name, ConnectionHostParam.default)
     val hosts = for {
       hostName <- hostsStr.split(",").toSet[String]
       hostAddress <- resolveHost(hostName.trim)


### PR DESCRIPTION
`InetAddress.getLocalHost.getHostAddress` fails in certain environments, so it cannot reliably be used as a default value for the hostsStr.

See the following StackOverflow post for an example of this occurring in the wild: http://stackoverflow.com/questions/1881546/inetaddress-getlocalhost-throws-unknownhostexception

Our temporary solution is to add the address that this generates to `/etc/hosts`.