### PR TITLE
SPARKC-428: Better error messages on CreateCassandraTable from DataFrame

### DIFF
--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSpec.scala
@@ -156,6 +156,30 @@ class CassandraDataFrameSpec extends SparkCassandraITFlatSpecBase with Eventuall
 
   }
 
+  it should " provide useful messages when creating a table with columnName mismatches" in {
+    val df = sqlContext
+      .read
+      .format("org.apache.spark.sql.cassandra")
+      .options(
+        Map(
+          "table" -> "kv",
+          "keyspace" -> ks
+        )
+      )
+      .load()
+
+    val pkError = intercept[IllegalArgumentException] {
+      df.createCassandraTable(ks, "kv_auto", Some(Seq("cara")))
+    }
+    pkError.getMessage should include ("\"cara\" not Found.")
+
+    val ccError = intercept[IllegalArgumentException] {
+      df.createCassandraTable(ks, "kv_auto", Some(Seq("k")), Some(Seq("sundance")))
+    }
+    ccError.getMessage should include ("\"sundance\" not Found.")
+
+  }
+
   it should " provide error out with a sensible message when a table can't be found" in {
     val exception = intercept[IOException] {
       val df = sqlContext


### PR DESCRIPTION
Give a useful error message when creating a table and a column specified
to be a partition key or clustering key cannot be found. Previously the
user would get a criptic error on a None type.