### PR TITLE
SPARKC-433: Correct order of "Limit" and "orderBy" clauses in JWCT

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -24,7 +24,6 @@ import com.typesafe.sbt.SbtScalariform
 import com.typesafe.sbt.SbtScalariform._
 import com.typesafe.tools.mima.plugin.MimaKeys._
 import com.typesafe.tools.mima.plugin.MimaPlugin._
-import net.virtualvoid.sbt.graph.Plugin.graphSettings
 import sbt.Keys._
 import sbt._
 import sbtassembly.Plugin.AssemblyKeys._
@@ -82,7 +81,7 @@ object Settings extends Build {
 
   val encoding = Seq("-encoding", "UTF-8")
 
-  lazy val projectSettings = graphSettings ++ Seq(
+  lazy val projectSettings = Seq(
 
     aggregate in update := false,
 
@@ -191,7 +190,7 @@ object Settings extends Build {
     publish in (IntegrationTest,packageBin) := ()
   )
 
-  lazy val testSettings = testConfigs ++ testArtifacts ++ graphSettings ++ Seq(
+  lazy val testSettings = testConfigs ++ testArtifacts ++ Seq(
     parallelExecution in Test := false,
     parallelExecution in IntegrationTest := false,
     javaOptions in IntegrationTest ++= Seq(

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
@@ -184,6 +184,13 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
     checkArrayCassandraRow(result)
   }
 
+  it should "work with both limit and order clauses SPARKC-433" in {
+    val source = sc.parallelize(keys).map(x => new KVRow(x))
+    val someCass = source.joinWithCassandraTable(ks, tableName).limit(1).withAscOrder
+    val result = someCass.collect
+    checkArrayCassandraRow(result)
+  }
+
   it should "throw a meaningful exception if partition column is null when joining with Cassandra table" in {
     val source = sc.parallelize(keys).map(x ⇒ new KVWithOptionRow(None))
 
@@ -269,11 +276,11 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
     checkLeftSide(leftSide, result)
   }
 
-  it should "be be able to be limited" in {
-    val source = sc.parallelize(keys).map(x => (x, x * 100))
-    val someCass = source.joinWithCassandraTable(ks, wideTable).on(SomeColumns("key", "group")).limit(3)
+  it should "be able to be limited" in {
+    val source = sc.parallelize(keys).map(x => KVRow(x))
+    val someCass = source.joinWithCassandraTable(ks, wideTable).on(SomeColumns("key")).limit(3)
     val result = someCass.collect
-    result should have size (3 * someCass.partitions.size)
+    result should have size (3 * keys.length)
   }
 
   it should "have be able to be counted" in {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
@@ -194,7 +194,7 @@ class CassandraJoinRDD[L, R] private[connector](
     val query =
       s"SELECT $columns " +
         s"FROM $quotedKeyspaceName.$quotedTableName " +
-        s"WHERE $filter $limitClause $orderBy"
+        s"WHERE $filter $orderBy $limitClause"
     logDebug(s"Query : $query")
     query
   }
@@ -211,7 +211,8 @@ class CassandraJoinRDD[L, R] private[connector](
     val bsb = new BoundStatementBuilder[L](rowWriter, stmt, pv, where.values)
     val metricsUpdater = InputMetricsUpdater(context, readConf)
     val rowIterator = fetchIterator(session, bsb, left.iterator(split, context))
-    val countingIterator = new CountingIterator(rowIterator, limit)
+    //Do not limit single partition query iterators
+    val countingIterator = new CountingIterator(rowIterator, None)
 
     context.addTaskCompletionListener { (context) =>
       val duration = metricsUpdater.finish() / 1000000000d


### PR DESCRIPTION
JoinWithCassandraTable places limit and order queries in the wrong
order. Thanks to bryanventeicher@gmail.com for pointing this out.