### PR TITLE
SPARKC-435: Allow Custom Conf Options for CustomPushdowns

### DIFF
--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraPredicateRules.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraPredicateRules.scala
@@ -2,6 +2,7 @@ package org.apache.spark.sql.cassandra
 
 import com.datastax.spark.connector.cql.TableDef
 import org.apache.spark.sql.sources.Filter
+import org.apache.spark.SparkConf
 
 case class AnalyzedPredicates(
   handledByCassandra: Set[Filter],
@@ -13,5 +14,5 @@ case class AnalyzedPredicates(
 }
 
 trait CassandraPredicateRules{
-  def apply(predicates: AnalyzedPredicates, tableDef: TableDef): AnalyzedPredicates
+  def apply(predicates: AnalyzedPredicates, tableDef: TableDef, conf: SparkConf): AnalyzedPredicates
 }

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/DefaultSource.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/DefaultSource.scala
@@ -123,7 +123,7 @@ object DefaultSource {
     val keyspaceName = parameters(CassandraDataSourceKeyspaceNameProperty)
     val clusterName = parameters.get(CassandraDataSourceClusterNameProperty)
     val pushdown : Boolean = parameters.getOrElse(CassandraDataSourcePushdownEnableProperty, "true").toBoolean
-    val cassandraConfs = buildConfMap(parameters)
+    val cassandraConfs = parameters
 
     (TableRef(tableName, keyspaceName, clusterName), CassandraSourceOptions(pushdown, cassandraConfs))
   }
@@ -134,10 +134,6 @@ object DefaultSource {
     CassandraSourceRelation.Properties.map(_.name) ++
     AuthConfFactory.Properties.map(_.name) ++
     DefaultAuthConfFactory.properties
-
-  /** Construct a map stores Cassandra Conf settings from options */
-  def buildConfMap(parameters: Map[String, String]): Map[String, String] =
-    parameters.filterKeys(confProperties.contains)
 
   /** Check whether the provider is Cassandra datasource or not */
   def cassandraSource(provider: String) : Boolean = {


### PR DESCRIPTION
Previously we removed all options to be passed through to the
CassandraSource that were not defined in the connector. This made it
impossible for a user supplied pushdown class to use per Table options
or Spark Conf settings.

This commit also breaks the custom pushdown rules api by passing through the
consolidated SparkConf which includes TableOptions and the Spark Conf.
