### PR TITLE
SPARKC-441 Fix CassandraConnector sessionCache remote and race condit…

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -44,7 +44,7 @@ case class CassandraConnectorConf(
 
   override def equals(obj: Any): Boolean = {
     obj match {
-      case that: CassandraConnectorConf => that.hashCode == serializedConfString.hashCode
+      case that: CassandraConnectorConf => that.serializedConfString == serializedConfString
       case _ => false
     }
   }


### PR DESCRIPTION
…ion issue

If set up a remote C* cluster and submit a job from spark cluster to
connect to remote C* cluster. The CassandraConnectorConf is serialized
and deserialized into different CassandraConnectorConf object for
the same original CassandraConnectorConf. Then each time sessionCache
creates new session for each deserialized CassandraConnectorConf.

Too many new sessions results too many cluster objects, and the
following errors are found.

ResourceLeakDetector: LEAK: You are creating too many HashedWheelTimer instances

To fix the issue, we change sessionCache key from CassandraConnectorConf
to String which is the serialized CassandraConnectorConf in String format.

The second issue is acquire method of RefCountedCache is not synchronized.
Even the cache itself is TriMap, the acquire method still creates two
sessions at certain moment when there are two concurrent requests to
acquire a new session.

To fix the issue, the code of creating new session in acquire method
when the session is not found in the cache should be synchronized.

It does have some performance overhead when new session is created
and serialize/deserialize CassandraConnectorConf