### PR TITLE
Implemented where that have individual clause for each row.

### DIFF
--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
@@ -505,6 +505,12 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
     results should have length keys.count(_ >= 5)
   }
 
+  it should " support functional where clauses" in {
+    val someCass = sc.parallelize(keys).map(x => new KVRow(x)).joinWithCassandraTable(ks, tableName).where("group = ?", (k : KVRow) => Seq(k.key * 100))
+    val results = someCass.collect.map(_._2)
+    results should have length keys.size
+  }
+
   it should " throw an exception if using a where on a column that is specified by the join" in {
     val exc = intercept[IllegalArgumentException] {
       val someCass = sc.parallelize(keys).map(x => (x, x * 100L))

--- a/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/RDDJavaFunctions.java
+++ b/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/RDDJavaFunctions.java
@@ -103,6 +103,7 @@ public class RDDJavaFunctions<T> extends RDDAndDStreamCommonJavaFunctions<T> {
         Option<ClusteringOrder> clusteringOrder = Option.empty();
         Option<Object> limit = Option.empty();
         CqlWhereClause whereClause = CqlWhereClause.empty();
+        FCqlWhereClause<T> fwhereClause = FCqlWhereClause.empty();
         ReadConf readConf = ReadConf.fromSparkConf(rdd.conf());
 
         CassandraJoinRDD<T, R> joinRDD = new CassandraJoinRDD<>(
@@ -113,6 +114,7 @@ public class RDDJavaFunctions<T> extends RDDAndDStreamCommonJavaFunctions<T> {
                 selectedColumns,
                 joinColumns,
                 whereClause,
+                fwhereClause,
                 limit,
                 clusteringOrder,
                 readConf,


### PR DESCRIPTION
Added individual  clause to the joins where.
This allow this kind of syntax : `rdd.joinWithCassandraTable(ks, tableName).where("timestampMilis = ?", (k : KVRow) => Seq(k.timestampSecond * 1000))`

Of course the syntax un the where can be enhance, it's why it's open to review.