### PR TITLE
B1.6 Backports

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,18 @@
  * Fix conversion of LocalDate to Joda LocalDate (SPARKC-391)
  * Shade Guava to avoid conflict with outdated Guava in Spark (SPARKC-355)
 
+2.0.0 M1
+ * Added support for left outer joins with C* table (SPARKC-181)
+ * Removed CassandraSqlContext and underscore based options (SPARKC-399)
+ * Upgrade to Spark 2.0.0-preview (SPARKC-396)
+    - Removed Twitter demo because there is no spark-streaming-twitter package available anymore
+    - Removed Akka Actor demo becaues there is no support for such streams anymore
+    - Bring back Kafka project and make it compile
+    - Update several classes to use our Logging instead of Spark Logging because Spark Logging became private
+    - Update few components and tests to make them work with Spark 2.0.0
+    - Fix Spark SQL - temporarily
+    - Update plugins and Scala version
+
 1.6.0
  * SparkSql write supports TTL per row (SPARKC-345)
  * Make Repartition by Cassandra Replica Deterministic (SPARKC-278)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+ * Add RDD.deleteFromCassandra() method (SPARKC-349)
  * Fixed use of connection.local_dc parameter (SPARKC-448)
 
 1.6.3

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ execute arbitrary CQL queries in your Spark applications.
  - Maps table rows to CassandraRow objects or tuples
  - Offers customizable object mapper for mapping rows to objects of user-defined classes
  - Saves RDDs back to Cassandra by implicit `saveToCassandra` call
+ - Delete rows and columns from cassandra by implicit `deleteFromCassandra` call
  - Join with a subset of Cassandra data using `joinWithCassandraTable` call
  - Partition RDDs according to Cassandra replication using `repartitionByCassandraReplica` call
  - Converts data types between Cassandra and Scala
@@ -97,7 +98,7 @@ See [Building And Artifacts](doc/12_building_and_artifacts.md)
   - [Loading datasets from Cassandra](doc/2_loading.md)
   - [Server-side data selection and filtering](doc/3_selection.md)   
   - [Working with user-defined case classes and tuples](doc/4_mapper.md)
-  - [Saving datasets to Cassandra](doc/5_saving.md)
+  - [Saving and deleting datasets to/from Cassandra](doc/5_saving.md)
   - [Customizing the object mapping](doc/6_advanced_mapper.md)
   - [Using Connector in Java](doc/7_java_api.md)
   - [Spark Streaming with Cassandra](doc/8_streaming.md)

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
@@ -33,9 +33,12 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
   override val conn = CassandraConnector(defaultConf)
   val tableName = "key_value"
   val otherTable = "other_table"
+  val smallerTable = "smaller_table"
+  val emptyTable = "empty_table"
   val wideTable = "wide_table"
   val manyColsTable = "many_cols_table"
   val keys = 0 to 200
+  val smallerTotal = 0 to 10000 by 100
   val total = 0 to 10000
 
   conn.withSessionDo { session =>
@@ -58,6 +61,35 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
             (value * 100).toLong: JLong,
             value.toString)
           ).par.foreach(_.getUninterruptibly)
+      },
+
+      Future {
+        session.execute(
+          s"""
+             |CREATE TABLE $ks.$smallerTable (
+             |  key INT,
+             |  group BIGINT,
+             |  value TEXT,
+             |  PRIMARY KEY (key, group)
+             |)""".stripMargin)
+        (for (value <- smallerTotal) yield
+          session.executeAsync(
+            s"""INSERT INTO $ks.$smallerTable (key, group, value) VALUES (?, ?, ?)""",
+            value: Integer,
+            (value * 100).toLong: JLong,
+            value.toString)
+          ).par.foreach(_.getUninterruptibly)
+      },
+
+      Future {
+        session.execute(
+          s"""
+             |CREATE TABLE $ks.$emptyTable (
+             |  key INT,
+             |  group BIGINT,
+             |  value TEXT,
+             |  PRIMARY KEY (key, group)
+             |)""".stripMargin)
       },
 
       Future {
@@ -128,6 +160,42 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
     }
   }
 
+  def checkArrayOptionCassandraRow[T](result: Array[(T, Option[CassandraRow])]) = {
+    markup("Checking RightSide LeftJoin Results")
+    result.length should be(keys.length)
+    val sorted_result = result
+      .map(_._2)
+      .filter(_.isDefined)
+      .sortBy(_.get.getInt(0))
+    for (key <- keys) {
+      sorted_result(key).get.getInt("key") should be(key)
+      sorted_result(key).get.getLong("group") should be(key * 100)
+      sorted_result(key).get.getString("value") should be(key.toString)
+    }
+  }
+
+  def checkArrayOptionSmallerCassandraRow[T](result: Array[(T, Option[CassandraRow])]) = {
+    markup("Checking RightSide LeftJoin Results")
+    result.length should be(keys.length)
+    val sorted_result = result
+      .map(_._2)
+      .filter(_.isDefined)
+      .sortBy(_.get.getInt(0))
+    for ((key, idx) <- keys.intersect(smallerTotal).zipWithIndex) {
+      sorted_result(idx).get.getInt("key") should be(key)
+      sorted_result(idx).get.getLong("group") should be(key * 100)
+      sorted_result(idx).get.getString("value") should be(key.toString)
+    }
+  }
+
+  def checkArrayOptionEmptyCassandraRow[T](result: Array[(T, Option[CassandraRow])]) = {
+    markup("Checking Empty RightSide LeftJoin Results")
+    result.length should be(keys.length)
+    for (key <- keys) {
+      result(key)._2 should be(None)
+    }
+  }
+
   def checkArrayTuple[T](result: Array[(T, (Int, Long, String))]) = {
     markup("Checking RightSide Join Results")
     result.length should be(keys.length)
@@ -159,7 +227,7 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
     checkLeftSide(leftSide, result)
   }
 
-  it should "be retreivable as a tuple from Cassandra" in {
+  it should "be retrievable as a tuple from Cassandra" in {
     val source = sc.parallelize(keys).map(Tuple1(_))
     val someCass = source.joinWithCassandraTable[(Int, Long, String)](ks, tableName)
     val result = someCass.collect
@@ -168,7 +236,7 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
     checkLeftSide(leftSide, result)
   }
 
-  it should "be retreivable as a case class from cassandra" in {
+  it should "be retrievable as a case class from cassandra" in {
     val source = sc.parallelize(keys).map(Tuple1(_))
     val someCass = source.joinWithCassandraTable[FullRow](ks, tableName)
     val result = someCass.collect
@@ -211,7 +279,7 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
     checkLeftSide(leftSide, result)
   }
 
-  it should "be retreivable as a tuple from Cassandra" in {
+  it should "be retrievable as a tuple from Cassandra" in {
     val source = sc.parallelize(keys).map(x => new KVRow(x))
     val someCass = source.joinWithCassandraTable[(Int, Long, String)](ks, tableName)
     val result = someCass.collect
@@ -220,7 +288,7 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
     checkLeftSide(leftSide, result)
   }
 
-  it should "be retreivable as a case class from cassandra" in {
+  it should "be retrievable as a case class from cassandra" in {
     val source = sc.parallelize(keys).map(x => new KVRow(x))
     val someCass = source.joinWithCassandraTable[FullRow](ks, tableName)
     val result = someCass.collect
@@ -279,7 +347,7 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
     checkLeftSide(leftSide, result)
   }
 
-  it should "be retreivable as a tuple from Cassandra" in {
+  it should "be retrievable as a tuple from Cassandra" in {
     val source = sc.parallelize(keys).map(x => (x, x * 100: Long))
     val someCass = source.joinWithCassandraTable[(Int, Long, String)](ks, tableName)
     val result = someCass.collect
@@ -288,7 +356,7 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
     checkLeftSide(leftSide, result)
   }
 
-  it should "be retreivable as a case class from cassandra" in {
+  it should "be retrievable as a case class from cassandra" in {
     val source = sc.parallelize(keys).map(x => (x, x * 100: Long))
     val someCass = source.joinWithCassandraTable[FullRow](ks, tableName)
     val result = someCass.collect
@@ -359,7 +427,34 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
     checkLeftSide(leftSide, result)
   }
 
-  it should "be retreivable as a tuple from Cassandra" in {
+  it should "be left joinable with Cassandra" in {
+    val source = sc.cassandraTable(ks, otherTable)
+    val someCass = source.leftJoinWithCassandraTable(ks, tableName)
+    val result = someCass.collect
+    val leftSide = source.collect
+    checkArrayOptionCassandraRow(result)
+    checkLeftSide(leftSide, result)
+  }
+
+  it should "be left joinable with a table of a smaller size" in {
+    val source = sc.cassandraTable(ks, otherTable)
+    val someCass = source.leftJoinWithCassandraTable(ks, smallerTable)
+    val result = someCass.collect
+    val leftSide = source.collect
+    checkArrayOptionSmallerCassandraRow(result)
+    checkLeftSide(leftSide, result)
+  }
+
+  it should "be left joinable with an empty table" in {
+    val source = sc.cassandraTable(ks, otherTable)
+    val someCass = source.leftJoinWithCassandraTable(ks, emptyTable)
+    val result = someCass.collect
+    val leftSide = source.collect
+    checkArrayOptionEmptyCassandraRow(result)
+    checkLeftSide(leftSide, result)
+  }
+
+  it should "be retrievable as a tuple from Cassandra" in {
     val source = sc.cassandraTable(ks, otherTable)
     val someCass = source.joinWithCassandraTable[(Int, Long, String)](ks, tableName)
     val result = someCass.collect
@@ -368,7 +463,7 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
     checkLeftSide(leftSide, result)
   }
 
-  it should "be retreivable as a case class from cassandra" in {
+  it should "be retrievable as a case class from cassandra" in {
     val source = sc.cassandraTable(ks, otherTable)
     val someCass = source.joinWithCassandraTable[FullRow](ks, tableName)
     val result = someCass.collect
@@ -377,7 +472,7 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
     checkLeftSide(leftSide, result)
   }
 
-  it should " be retreivable without repartitioning" in {
+  it should " be retrievable without repartitioning" in {
     val someCass = sc.cassandraTable(ks, otherTable).joinWithCassandraTable(ks, tableName)
     someCass.toDebugString should not contain "ShuffledRDD"
     val result = someCass.collect

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/streaming/RDDStreamingSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/streaming/RDDStreamingSpec.scala
@@ -1,19 +1,18 @@
 package com.datastax.spark.connector.streaming
 
-import scala.collection.mutable
-import scala.concurrent.Future
-import scala.language.postfixOps
-import scala.util.Random
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.cql.CassandraConnector
 
+import com.datastax.spark.connector.testkit._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.{Milliseconds, StreamingContext}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
-import com.datastax.spark.connector._
-import com.datastax.spark.connector.cql.CassandraConnector
-import com.datastax.spark.connector.rdd.partitioner.EndpointPartition
-import com.datastax.spark.connector.testkit._
+import scala.collection.mutable
+import scala.concurrent.Future
+import scala.language.postfixOps
+import scala.util.Random
 
 class RDDStreamingSpec
   extends SparkCassandraITFlatSpecBase
@@ -49,6 +48,12 @@ class RDDStreamingSpec
       },
       Future {
         session.execute(s"CREATE TABLE $ks.dstream_join_output (word TEXT PRIMARY KEY, count COUNTER)")
+      },
+      Future {
+        session.execute(s"CREATE TABLE $ks.streaming_deletes (word TEXT PRIMARY KEY, count INT)")
+        session.execute( s"INSERT INTO $ks.streaming_deletes (word, count) VALUES ('1words', 1)")
+        session.execute( s"INSERT INTO $ks.streaming_deletes (word, count) VALUES ('1round', 2)")
+        session.execute( s"INSERT INTO $ks.streaming_deletes (word, count) VALUES ('survival', 3)")
       }
     )
   }
@@ -169,4 +174,27 @@ class RDDStreamingSpec
       ssc.sparkContext.cassandraTable(ks, "dstream_join_output").collect.size should be(data.size)
     }
   }
+
+  it should "delete rows from cassandra table base on streaming keys" in withStreamingContext { ssc =>
+    val stream = ssc.queueStream[String](dataRDDs)
+
+    val wc = stream
+      .map(Key(_))
+      .deleteFromCassandra(ks, "streaming_deletes")
+
+    // start the streaming context so the data can be processed and actor started
+    ssc.start()
+    eventually {
+      dataRDDs shouldBe empty
+    }
+
+    eventually {
+      val rdd = ssc.cassandraTable[WordCount](ks, "streaming_deletes")
+      val result = rdd.collect
+      result.length should be(1)
+      result(0) should be(WordCount("survival", 3))
+    }
+  }
 }
+
+

--- a/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/RDDJavaFunctions.java
+++ b/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/RDDJavaFunctions.java
@@ -61,6 +61,17 @@ public class RDDJavaFunctions<T> extends RDDAndDStreamCommonJavaFunctions<T> {
         rddFunctions.saveToCassandra(keyspace, table, columnNames, conf, connector, rowWriterFactory);
     }
 
+    public void deleteFromCassandra(
+            String keyspace,
+            String table,
+            RowWriterFactory<T> rowWriterFactory,
+            ColumnSelector deleteColumns,
+            ColumnSelector keyColumns,
+            WriteConf conf,
+            CassandraConnector connector
+    ) {
+        rddFunctions.deleteFromCassandra(keyspace, table, deleteColumns, keyColumns, conf, connector, rowWriterFactory);
+    }
     /**
      * Applies a function to each item, and groups consecutive items having the same value together.
      * Contrary to {@code groupBy}, items from the same group must be already next to each other in the

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ColumnSelector.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/ColumnSelector.scala
@@ -21,6 +21,12 @@ case object PartitionKeyColumns extends ColumnSelector {
     table.partitionKey.map(_.ref).toIndexedSeq
 }
 
+case object PrimaryKeyColumns extends ColumnSelector {
+  override def aliases: Map[String, String] = Map.empty.withDefault(x => x)
+  override def selectFrom(table: TableDef) =
+    table.primaryKey.map(_.ref)
+}
+
 case class SomeColumns(columns: ColumnRef*) extends ColumnSelector {
 
   override def aliases: Map[String, String] = columns.map {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
@@ -10,7 +10,6 @@ import com.datastax.spark.connector.rdd.reader._
 import com.datastax.spark.connector.rdd.{ReadConf, CassandraJoinRDD, SpannedRDD, ValidRDDType}
 import com.datastax.spark.connector.writer.{ReplicaLocator, _}
 import org.apache.spark.SparkContext
-import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
 
 import scala.reflect.ClassTag
@@ -36,7 +35,6 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
     val writer = TableWriter(connector, keyspaceName, tableName, columns, writeConf)
     rdd.sparkContext.runJob(rdd, writer.write _)
   }
-
   /**
    * Saves the data from [[org.apache.spark.rdd.RDD RDD]] to a new table defined by the given `TableDef`.
    *
@@ -96,6 +94,29 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
 
     val table = TableDef.fromType[T](keyspaceName, tableName, protocolVersion)
     saveAsCassandraTableEx(table, columns, writeConf)
+  }
+
+  /**
+   * Delete data from Cassandra table, using data from the [[org.apache.spark.rdd.RDD RDD]] as primary keys.
+   * Uses the specified column names.
+   * @see [[com.datastax.spark.connector.writer.WritableToCassandra]]
+   */
+  def deleteFromCassandra(
+    keyspaceName: String,
+    tableName: String,
+    deleteColumns: ColumnSelector = SomeColumns(),
+    keyColumns: ColumnSelector = PrimaryKeyColumns,
+    writeConf: WriteConf = WriteConf.fromSparkConf(sparkContext.getConf))(
+  implicit
+    connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+    rwf: RowWriterFactory[T]): Unit = {
+    // column delete require full primary key, partition key is enough otherwise
+    val columnDelete = deleteColumns match {
+      case c :SomeColumns => c.columns.nonEmpty
+      case _  => false
+    }
+    val writer = TableWriter(connector, keyspaceName, tableName, keyColumns, writeConf, !columnDelete)
+    rdd.sparkContext.runJob(rdd, writer.delete(deleteColumns) _)
   }
 
   /** Applies a function to each item, and groups consecutive items having the same value together.

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
@@ -7,7 +7,7 @@ import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.mapper.ColumnMapper
 import com.datastax.spark.connector.rdd.partitioner.{CassandraPartitionedRDD, ReplicaPartitioner}
 import com.datastax.spark.connector.rdd.reader._
-import com.datastax.spark.connector.rdd.{ReadConf, CassandraJoinRDD, SpannedRDD, ValidRDDType}
+import com.datastax.spark.connector.rdd.{ReadConf, CassandraJoinRDD, CassandraLeftJoinRDD, SpannedRDD, ValidRDDType}
 import com.datastax.spark.connector.writer.{ReplicaLocator, _}
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
@@ -161,6 +161,52 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
     rwf: RowWriterFactory[T]): CassandraJoinRDD[T, R] = {
 
     new CassandraJoinRDD[T, R](
+      rdd,
+      keyspaceName,
+      tableName,
+      connector,
+      columnNames = selectedColumns,
+      joinColumns = joinColumns,
+      readConf = ReadConf.fromSparkConf(rdd.sparkContext.getConf)
+    )
+  }
+
+
+  /**
+    * Uses the data from [[org.apache.spark.rdd.RDD RDD]] to left join with a Cassandra table without
+    * retrieving the entire table.
+    * Any RDD which can be used to saveToCassandra can be used to joinWithCassandra as well as any
+    * RDD which only specifies the partition Key of a Cassandra Table. This method executes single
+    * partition requests against the Cassandra Table and accepts the functional modifiers that a
+    * normal [[com.datastax.spark.connector.rdd.CassandraTableScanRDD]] takes.
+    *
+    * By default this method only uses the Partition Key for joining but any combination of columns
+    * which are acceptable to C* can be used in the join. Specify columns using joinColumns as a parameter
+    * or the on() method.
+    *
+    * Example With Prior Repartitioning: {{{
+    * val source = sc.parallelize(keys).map(x => new KVRow(x))
+    * val repart = source.repartitionByCassandraReplica(keyspace, tableName, 10)
+    * val someCass = repart.leftJoinWithCassandraTable(keyspace, tableName)
+    * }}}
+    *
+    * Example Joining on Clustering Columns: {{{
+    * val source = sc.parallelize(keys).map(x => (x, x * 100))
+    * val someCass = source.leftJoinWithCassandraTable(keyspace, wideTable).on(SomeColumns("key", "group"))
+    * }}}
+    **/
+  def leftJoinWithCassandraTable[R](
+    keyspaceName: String, tableName: String,
+    selectedColumns: ColumnSelector = AllColumns,
+    joinColumns: ColumnSelector = PartitionKeyColumns)(
+  implicit
+    connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+    newType: ClassTag[R], rrf: RowReaderFactory[R],
+    ev: ValidRDDType[R],
+    currentType: ClassTag[T],
+    rwf: RowWriterFactory[T]): CassandraLeftJoinRDD[T, R] = {
+
+    new CassandraLeftJoinRDD[T, R](
       rdd,
       keyspaceName,
       tableName,

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
@@ -175,7 +175,7 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
   /**
     * Uses the data from [[org.apache.spark.rdd.RDD RDD]] to left join with a Cassandra table without
     * retrieving the entire table.
-    * Any RDD which can be used to saveToCassandra can be used to joinWithCassandra as well as any
+    * Any RDD which can be used to saveToCassandra can be used to leftJoinWithCassandra as well as any
     * RDD which only specifies the partition Key of a Cassandra Table. This method executes single
     * partition requests against the Cassandra Table and accepts the functional modifiers that a
     * normal [[com.datastax.spark.connector.rdd.CassandraTableScanRDD]] takes.

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/AbstractCassandraJoin.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/AbstractCassandraJoin.scala
@@ -1,0 +1,186 @@
+package com.datastax.spark.connector.rdd
+
+import com.datastax.driver.core.Session
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.util.CqlWhereParser.{EqPredicate, InListPredicate, InPredicate, RangePredicate}
+import com.datastax.spark.connector.util.Quote._
+import com.datastax.spark.connector.util.{CountingIterator, CqlWhereParser}
+import com.datastax.spark.connector.writer._
+import org.apache.spark.metrics.InputMetricsUpdater
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{Partition, TaskContext}
+
+/**
+ * This trait contains shared methods from [[com.datastax.spark.connector.rdd.CassandraJoinRDD]] and
+ * [[com.datastax.spark.connector.rdd.CassandraLeftJoinRDD]] to avoid code duplication.
+ *
+ * @tparam L item type on the left side of the join (any RDD)
+ * @tparam R item type on the right side of the join (fetched from Cassandra)
+ */
+private[rdd] trait AbstractCassandraJoin[L, R] {
+
+  self: CassandraRDD[(L, R)] with CassandraTableRowReaderProvider[_] =>
+
+  val left: RDD[L]
+  val joinColumns: ColumnSelector
+  val manualRowWriter: Option[RowWriter[L]]
+  implicit val rowWriterFactory: RowWriterFactory[L]
+
+  private[rdd] def fetchIterator(
+    session: Session,
+    bsb: BoundStatementBuilder[L],
+    lastIt: Iterator[L]
+  ): Iterator[(L, R)]
+
+  lazy val rowWriter = manualRowWriter match {
+    case Some(_rowWriter) => _rowWriter
+    case None => implicitly[RowWriterFactory[L]].rowWriter(tableDef, joinColumnNames.toIndexedSeq)
+  }
+
+  lazy val joinColumnNames: Seq[ColumnRef] = joinColumns match {
+    case AllColumns => throw new IllegalArgumentException(
+      "Unable to join against all columns in a Cassandra Table. Only primary key columns allowed."
+    )
+    case PartitionKeyColumns =>
+      tableDef.partitionKey.map(col => col.columnName: ColumnRef)
+    case SomeColumns(cs @ _*) =>
+      checkColumnsExistence(cs)
+      cs.map {
+        case c: ColumnRef => c
+        case _ => throw new IllegalArgumentException(
+          "Unable to join against unnamed columns. No CQL Functions allowed."
+        )
+      }
+  }
+
+  /**
+   * This method will create the RowWriter required before the RDD is serialized.
+   * This is called during getPartitions
+   */
+  protected def checkValidJoin(): Seq[ColumnRef] = {
+    val partitionKeyColumnNames = tableDef.partitionKey.map(_.columnName).toSet
+    val primaryKeyColumnNames = tableDef.primaryKey.map(_.columnName).toSet
+    val colNames = joinColumnNames.map(_.columnName).toSet
+
+    // Initialize RowWriter and Query to be used for accessing Cassandra
+    rowWriter.columnNames
+    singleKeyCqlQuery.length
+
+    def checkSingleColumn(column: ColumnRef): Unit = {
+      require(
+        primaryKeyColumnNames.contains(column.columnName),
+        s"Can't pushdown join on column $column because it is not part of the PRIMARY KEY"
+      )
+    }
+
+    // Make sure we have all of the clustering indexes between the 0th position and the max requested
+    // in the join:
+    val chosenClusteringColumns = tableDef.clusteringColumns
+      .filter(cc => colNames.contains(cc.columnName))
+    if (!tableDef.clusteringColumns.startsWith(chosenClusteringColumns)) {
+      val maxCol = chosenClusteringColumns.last
+      val maxIndex = maxCol.componentIndex.get
+      val requiredColumns = tableDef.clusteringColumns.takeWhile(_.componentIndex.get <= maxIndex)
+      val missingColumns = requiredColumns.toSet -- chosenClusteringColumns.toSet
+      throw new IllegalArgumentException(
+        s"Can't pushdown join on column $maxCol without also specifying [ $missingColumns ]"
+      )
+    }
+    val missingPartitionKeys = partitionKeyColumnNames -- colNames
+    require(
+      missingPartitionKeys.isEmpty,
+      s"Can't join without the full partition key. Missing: [ $missingPartitionKeys ]"
+    )
+
+    joinColumnNames.foreach(checkSingleColumn)
+    joinColumnNames
+  }
+
+  //We need to make sure we get selectedColumnRefs before serialization so that our RowReader is
+  //built
+  lazy val singleKeyCqlQuery: (String) = {
+    val whereClauses = where.predicates.flatMap(CqlWhereParser.parse)
+    val joinColumns = joinColumnNames.map(_.columnName)
+    val joinColumnPredicates = whereClauses.collect {
+      case EqPredicate(c, _) if joinColumns.contains(c) => c
+      case InPredicate(c) if joinColumns.contains(c) => c
+      case InListPredicate(c, _) if joinColumns.contains(c) => c
+      case RangePredicate(c, _, _) if joinColumns.contains(c) => c
+    }.toSet
+
+    require(
+      joinColumnPredicates.isEmpty,
+      s"""Columns specified in both the join on clause and the where clause.
+          |Partition key columns are always part of the join clause.
+          |Columns in both: ${joinColumnPredicates.mkString(", ")}""".stripMargin
+    )
+
+    logDebug("Generating Single Key Query Prepared Statement String")
+    logDebug(s"SelectedColumns : $selectedColumnRefs -- JoinColumnNames : $joinColumnNames")
+    val columns = selectedColumnRefs.map(_.cql).mkString(", ")
+    val joinWhere = joinColumnNames.map(_.columnName).map(name => s"${quote(name)} = :$name")
+    val limitClause = limit.map(limit => s"LIMIT $limit").getOrElse("")
+    val orderBy = clusteringOrder.map(_.toCql(tableDef)).getOrElse("")
+    val filter = (where.predicates ++ joinWhere).mkString(" AND ")
+    val quotedKeyspaceName = quote(keyspaceName)
+    val quotedTableName = quote(tableName)
+    val query =
+      s"SELECT $columns " +
+        s"FROM $quotedKeyspaceName.$quotedTableName " +
+        s"WHERE $filter $limitClause $orderBy"
+    logDebug(s"Query : $query")
+    query
+  }
+
+  private[rdd] def boundStatementBuilder(session: Session): BoundStatementBuilder[L] = {
+    val protocolVersion = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersion
+    val stmt = session.prepare(singleKeyCqlQuery).setConsistencyLevel(consistencyLevel)
+    new BoundStatementBuilder[L](rowWriter, stmt, where.values, protocolVersion = protocolVersion)
+  }
+
+  /**
+   * When computing a CassandraPartitionKeyRDD the data is selected via single CQL statements
+   * from the specified C* Keyspace and Table. This will be preformed on whatever data is
+   * available in the previous RDD in the chain.
+   */
+  override def compute(split: Partition, context: TaskContext): Iterator[(L, R)] = {
+    val session = connector.openSession()
+    val bsb = boundStatementBuilder(session)
+    val metricsUpdater = InputMetricsUpdater(context, readConf)
+    val rowIterator = fetchIterator(session, bsb, left.iterator(split, context))
+    val countingIterator = new CountingIterator(rowIterator, limit)
+
+    context.addTaskCompletionListener { (context) =>
+      val duration = metricsUpdater.finish() / 1000000000d
+      logDebug(
+        f"Fetched ${countingIterator.count} rows " +
+          f"from $keyspaceName.$tableName " +
+          f"for partition ${split.index} in $duration%.3f s."
+      )
+      session.close()
+    }
+    countingIterator
+  }
+
+  override protected def getPartitions: Array[Partition] = {
+    verify()
+    checkValidJoin()
+    left.partitions
+  }
+
+  override def getPreferredLocations(split: Partition): Seq[String] = left.preferredLocations(split)
+
+  override def toEmptyCassandraRDD: EmptyCassandraRDD[(L, R)] =
+    new EmptyCassandraRDD[(L, R)](
+      sc = left.sparkContext,
+      keyspaceName = keyspaceName,
+      tableName = tableName,
+      columnNames = columnNames,
+      where = where,
+      limit = limit,
+      clusteringOrder = clusteringOrder,
+      readConf = readConf
+    )
+
+}
+

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/AbstractCassandraJoin.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/AbstractCassandraJoin.scala
@@ -111,8 +111,8 @@ private[rdd] trait AbstractCassandraJoin[L, R] {
     require(
       joinColumnPredicates.isEmpty,
       s"""Columns specified in both the join on clause and the where clause.
-          |Partition key columns are always part of the join clause.
-          |Columns in both: ${joinColumnPredicates.mkString(", ")}""".stripMargin
+         |Partition key columns are always part of the join clause.
+         |Columns in both: ${joinColumnPredicates.mkString(", ")}""".stripMargin
     )
 
     logDebug("Generating Single Key Query Prepared Statement String")
@@ -127,7 +127,7 @@ private[rdd] trait AbstractCassandraJoin[L, R] {
     val query =
       s"SELECT $columns " +
         s"FROM $quotedKeyspaceName.$quotedTableName " +
-        s"WHERE $filter $limitClause $orderBy"
+        s"WHERE $filter $orderBy $limitClause"
     logDebug(s"Query : $query")
     query
   }
@@ -148,7 +148,7 @@ private[rdd] trait AbstractCassandraJoin[L, R] {
     val bsb = boundStatementBuilder(session)
     val metricsUpdater = InputMetricsUpdater(context, readConf)
     val rowIterator = fetchIterator(session, bsb, left.iterator(split, context))
-    val countingIterator = new CountingIterator(rowIterator, limit)
+    val countingIterator = new CountingIterator(rowIterator, None)
 
     context.addTaskCompletionListener { (context) =>
       val duration = metricsUpdater.finish() / 1000000000d

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
@@ -1,20 +1,14 @@
 package com.datastax.spark.connector.rdd
 
-import org.apache.spark.metrics.InputMetricsUpdater
-
 import com.datastax.driver.core.{ResultSet, Session}
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.rdd.reader._
-import com.datastax.spark.connector.util.CqlWhereParser.{EqPredicate, InListPredicate, InPredicate, RangePredicate}
-import com.datastax.spark.connector.util.{CountingIterator, CqlWhereParser}
 import com.datastax.spark.connector.writer._
-import com.datastax.spark.connector.util.Quote._
-import org.apache.spark.rdd.RDD
-import org.apache.spark.{Partition, TaskContext}
-import scala.reflect.ClassTag
-
 import com.google.common.util.concurrent.{FutureCallback, Futures, SettableFuture}
+import org.apache.spark.rdd.RDD
+
+import scala.reflect.ClassTag
 
 /**
  * An [[org.apache.spark.rdd.RDD RDD]] that will do a selecting join between `left` RDD and the specified
@@ -26,7 +20,7 @@ import com.google.common.util.concurrent.{FutureCallback, Futures, SettableFutur
  * @tparam R item type on the right side of the join (fetched from Cassandra)
  */
 class CassandraJoinRDD[L, R] private[connector](
-    left: RDD[L],
+    override val left: RDD[L],
     val keyspaceName: String,
     val tableName: String,
     val connector: CassandraConnector,
@@ -37,14 +31,15 @@ class CassandraJoinRDD[L, R] private[connector](
     val clusteringOrder: Option[ClusteringOrder] = None,
     val readConf: ReadConf = ReadConf(),
     manualRowReader: Option[RowReader[R]] = None,
-    manualRowWriter: Option[RowWriter[L]] = None)(
+    override val manualRowWriter: Option[RowWriter[L]] = None)(
   implicit
     val leftClassTag: ClassTag[L],
     val rightClassTag: ClassTag[R],
     @transient val rowWriterFactory: RowWriterFactory[L],
     @transient val rowReaderFactory: RowReaderFactory[R])
   extends CassandraRDD[(L, R)](left.sparkContext, left.dependencies)
-  with CassandraTableRowReaderProvider[R] {
+  with CassandraTableRowReaderProvider[R]
+  with AbstractCassandraJoin[L, R] {
 
   override type Self = CassandraJoinRDD[L, R]
 
@@ -52,7 +47,7 @@ class CassandraJoinRDD[L, R] private[connector](
 
   override lazy val rowReader: RowReader[R] = manualRowReader match {
     case Some(rr) => rr
-    case None => rowReaderFactory.rowReader (tableDef, columnNames.selectFrom (tableDef) )
+    case None => rowReaderFactory.rowReader(tableDef, columnNames.selectFrom(tableDef))
   }
 
   override protected def copy(
@@ -61,7 +56,8 @@ class CassandraJoinRDD[L, R] private[connector](
     limit: Option[Long] = limit,
     clusteringOrder: Option[ClusteringOrder] = None,
     readConf: ReadConf = readConf,
-    connector: CassandraConnector = connector): Self = {
+    connector: CassandraConnector = connector
+  ): Self = {
 
     new CassandraJoinRDD[L, R](
       left = left,
@@ -73,21 +69,8 @@ class CassandraJoinRDD[L, R] private[connector](
       where = where,
       limit = limit,
       clusteringOrder = clusteringOrder,
-      readConf = readConf)
-  }
-
-  lazy val joinColumnNames: Seq[ColumnRef] = joinColumns match {
-    case AllColumns => throw new IllegalArgumentException(
-      "Unable to join against all columns in a Cassandra Table. Only primary key columns allowed.")
-    case PartitionKeyColumns =>
-      tableDef.partitionKey.map(col => col.columnName: ColumnRef)
-    case SomeColumns(cs @ _*) =>
-      checkColumnsExistence(cs)
-      cs.map {
-        case c: ColumnRef => c
-        case _ => throw new IllegalArgumentException(
-          "Unable to join against unnamed columns. No CQL Functions allowed.")
-      }
+      readConf = readConf
+    )
   }
 
   override def cassandraCount(): Long = {
@@ -108,52 +91,10 @@ class CassandraJoinRDD[L, R] private[connector](
         where = where,
         limit = limit,
         clusteringOrder = clusteringOrder,
-        readConf= readConf)
+        readConf = readConf
+      )
 
     counts.map(_._2).reduce(_ + _)
-  }
-
-  /** This method will create the RowWriter required before the RDD is serialized.
-    * This is called during getPartitions */
-  protected def checkValidJoin(): Seq[ColumnRef] = {
-    val partitionKeyColumnNames = tableDef.partitionKey.map(_.columnName).toSet
-    val primaryKeyColumnNames = tableDef.primaryKey.map(_.columnName).toSet
-    val colNames = joinColumnNames.map(_.columnName).toSet
-
-    // Initialize RowWriter and Query to be used for accessing Cassandra
-    rowWriter.columnNames
-    singleKeyCqlQuery.length
-
-    def checkSingleColumn(column: ColumnRef): Unit = {
-      require(
-        primaryKeyColumnNames.contains(column.columnName),
-        s"Can't pushdown join on column $column because it is not part of the PRIMARY KEY")
-    }
-
-    // Make sure we have all of the clustering indexes between the 0th position and the max requested
-    // in the join:
-    val chosenClusteringColumns = tableDef.clusteringColumns
-      .filter(cc => colNames.contains(cc.columnName))
-    if (!tableDef.clusteringColumns.startsWith(chosenClusteringColumns)) {
-      val maxCol = chosenClusteringColumns.last
-      val maxIndex = maxCol.componentIndex.get
-      val requiredColumns = tableDef.clusteringColumns.takeWhile(_.componentIndex.get <= maxIndex)
-      val missingColumns = requiredColumns.toSet -- chosenClusteringColumns.toSet
-      throw new IllegalArgumentException(
-        s"Can't pushdown join on column $maxCol without also specifying [ $missingColumns ]")
-    }
-    val missingPartitionKeys = partitionKeyColumnNames -- colNames
-    require(
-      missingPartitionKeys.isEmpty,
-      s"Can't join without the full partition key. Missing: [ $missingPartitionKeys ]")
-
-    joinColumnNames.foreach(checkSingleColumn)
-    joinColumnNames
-  }
-
-  lazy val rowWriter = manualRowWriter match {
-    case Some(rowWriter) => rowWriter
-    case None => implicitly[RowWriterFactory[L]].rowWriter (tableDef, joinColumnNames.toIndexedSeq)
   }
 
   def on(joinColumns: ColumnSelector): CassandraJoinRDD[L, R] = {
@@ -167,82 +108,19 @@ class CassandraJoinRDD[L, R] private[connector](
       where = where,
       limit = limit,
       clusteringOrder = clusteringOrder,
-      readConf = readConf)
-  }
-
-  //We need to make sure we get selectedColumnRefs before serialization so that our RowReader is
-  //built
-  lazy val singleKeyCqlQuery: (String) = {
-    val whereClauses = where.predicates.flatMap(CqlWhereParser.parse)
-    val joinColumns = joinColumnNames.map(_.columnName)
-    val joinColumnPredicates = whereClauses.collect {
-      case EqPredicate(c, _) if joinColumns.contains(c) => c
-      case InPredicate(c) if joinColumns.contains(c) => c
-      case InListPredicate(c, _) if joinColumns.contains(c) => c
-      case RangePredicate(c, _, _) if joinColumns.contains(c) => c
-    }.toSet
-
-    require(
-      joinColumnPredicates.isEmpty,
-      s"""Columns specified in both the join on clause and the where clause.
-         |Partition key columns are always part of the join clause.
-         |Columns in both: ${joinColumnPredicates.mkString(", ")}""".stripMargin
+      readConf = readConf
     )
-
-    logDebug("Generating Single Key Query Prepared Statement String")
-    logDebug(s"SelectedColumns : $selectedColumnRefs -- JoinColumnNames : $joinColumnNames")
-    val columns = selectedColumnRefs.map(_.cql).mkString(", ")
-    val joinWhere = joinColumnNames.map(_.columnName).map(name => s"${quote(name)} = :$name")
-    val limitClause = limit.map(limit => s"LIMIT $limit").getOrElse("")
-    val orderBy = clusteringOrder.map(_.toCql(tableDef)).getOrElse("")
-    val filter = (where.predicates ++ joinWhere).mkString(" AND ")
-    val quotedKeyspaceName = quote(keyspaceName)
-    val quotedTableName = quote(tableName)
-    val query =
-      s"SELECT $columns " +
-        s"FROM $quotedKeyspaceName.$quotedTableName " +
-        s"WHERE $filter $orderBy $limitClause"
-    logDebug(s"Query : $query")
-    query
-  }
-
-  private[rdd] def boundStatementBuilder(session: Session): BoundStatementBuilder[L] = {
-    val protocolVersion = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersion
-    val stmt = session.prepare(singleKeyCqlQuery).setConsistencyLevel(consistencyLevel)
-    new BoundStatementBuilder[L](rowWriter, stmt, where.values, protocolVersion = protocolVersion)
-  }
-
-  /**
-   * When computing a CassandraPartitionKeyRDD the data is selected via single CQL statements
-   * from the specified C* Keyspace and Table. This will be preformed on whatever data is
-   * available in the previous RDD in the chain.
-   */
-  override def compute(split: Partition, context: TaskContext): Iterator[(L, R)] = {
-    val session = connector.openSession()
-    val bsb = boundStatementBuilder(session)
-    val metricsUpdater = InputMetricsUpdater(context, readConf)
-    val rowIterator = fetchIterator(session, bsb, left.iterator(split, context))
-    //Do not limit single partition query iterators
-    val countingIterator = new CountingIterator(rowIterator, None)
-
-    context.addTaskCompletionListener { (context) =>
-      val duration = metricsUpdater.finish() / 1000000000d
-      logDebug(
-        f"Fetched ${countingIterator.count} rows " +
-          f"from $keyspaceName.$tableName " +
-          f"for partition ${split.index} in $duration%.3f s.")
-      session.close()
-    }
-    countingIterator
   }
 
   private[rdd] def fetchIterator(
     session: Session,
     bsb: BoundStatementBuilder[L],
-    leftIterator: Iterator[L]): Iterator[(L, R)] = {
+    leftIterator: Iterator[L]
+  ): Iterator[(L, R)] = {
     val columnNames = selectedColumnRefs.map(_.selectedAs).toIndexedSeq
     val rateLimiter = new RateLimiter(
-      readConf.throughputJoinQueryPerSec, readConf.throughputJoinQueryPerSec)
+      readConf.throughputJoinQueryPerSec, readConf.throughputJoinQueryPerSec
+    )
 
     def pairWithRight(left: L): SettableFuture[Iterator[(L, R)]] = {
       val resultFuture = SettableFuture.create[Iterator[(L, R)]]
@@ -252,7 +130,7 @@ class CassandraJoinRDD[L, R] private[connector](
       Futures.addCallback(queryFuture, new FutureCallback[ResultSet] {
         def onSuccess(rs: ResultSet) {
           val resultSet = new PrefetchingResultSetIterator(rs, fetchSize)
-          val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames,rs);
+          val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames, rs);
           val rightSide = resultSet.map(rowReader.read(_, columnMetaData))
           resultFuture.set(leftSide.zip(rightSide))
         }
@@ -269,33 +147,14 @@ class CassandraJoinRDD[L, R] private[connector](
     queryFutures.iterator.flatMap(_.get)
   }
 
-  override protected def getPartitions: Array[Partition] = {
-    verify()
-    checkValidJoin()
-    left.partitions
-  }
-
-  override def getPreferredLocations(split: Partition): Seq[String] = left.preferredLocations(split)
-
-  override def toEmptyCassandraRDD: EmptyCassandraRDD[(L, R)] =
-    new EmptyCassandraRDD[(L, R)](
-      sc = left.sparkContext,
-      keyspaceName = keyspaceName,
-      tableName = tableName,
-      columnNames = columnNames,
-      where = where,
-      limit = limit,
-      clusteringOrder = clusteringOrder,
-      readConf = readConf)
-
   /**
    * Turns this CassandraJoinRDD into a factory for converting other RDD's after being serialized
    * This method is for streaming operations as it allows us to Serialize a template JoinRDD
    * and the use that serializable template in the DStream closure. This gives us a fully serializable
    * joinWithCassandra operation
    */
-  private[connector] def applyToRDD( left:RDD[L]): CassandraJoinRDD[L,R] =  {
-    new CassandraJoinRDD[L,R](
+  private[connector] def applyToRDD(left: RDD[L]): CassandraJoinRDD[L, R] = {
+    new CassandraJoinRDD[L, R](
       left,
       keyspaceName,
       tableName,

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
@@ -56,12 +56,12 @@ class CassandraLeftJoinRDD[L, R] private[connector](
   }
 
   override protected def copy(
-                               columnNames: ColumnSelector = columnNames,
-                               where: CqlWhereClause = where,
-                               limit: Option[Long] = limit,
-                               clusteringOrder: Option[ClusteringOrder] = None,
-                               readConf: ReadConf = readConf,
-                               connector: CassandraConnector = connector): Self = {
+    columnNames: ColumnSelector = columnNames,
+    where: CqlWhereClause = where,
+    limit: Option[Long] = limit,
+    clusteringOrder: Option[ClusteringOrder] = None,
+    readConf: ReadConf = readConf,
+    connector: CassandraConnector = connector): Self = {
 
     new CassandraLeftJoinRDD[L, R](
       left = left,
@@ -108,7 +108,7 @@ class CassandraLeftJoinRDD[L, R] private[connector](
         where = where,
         limit = limit,
         clusteringOrder = clusteringOrder,
-        readConf= readConf)
+        readConf = readConf)
 
     counts.map(_._2.getOrElse(0L)).reduce( _ + _ )
   }
@@ -291,10 +291,10 @@ class CassandraLeftJoinRDD[L, R] private[connector](
       readConf = readConf)
 
   /**
-    * Turns this CassandraJoinRDD into a factory for converting other RDD's after being serialized
+    * Turns this CassandraLeftJoinRDD into a factory for converting other RDD's after being serialized
     * This method is for streaming operations as it allows us to Serialize a template JoinRDD
     * and the use that serializable template in the DStream closure. This gives us a fully serializable
-    * joinWithCassandra operation
+    * leftJoinWithCassandra operation
     */
   private[connector] def applyToRDD( left:RDD[L]): CassandraLeftJoinRDD[L,R] =  {
     new CassandraLeftJoinRDD[L,R](

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
@@ -1,32 +1,26 @@
 package com.datastax.spark.connector.rdd
 
-import org.apache.spark.metrics.InputMetricsUpdater
-
 import com.datastax.driver.core.{ResultSet, Session}
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.rdd.reader._
-import com.datastax.spark.connector.util.CqlWhereParser.{EqPredicate, InListPredicate, InPredicate, RangePredicate}
-import com.datastax.spark.connector.util.{CountingIterator, CqlWhereParser}
 import com.datastax.spark.connector.writer._
-import com.datastax.spark.connector.util.Quote._
+import com.google.common.util.concurrent.{FutureCallback, Futures, SettableFuture}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.{Partition, TaskContext}
+
 import scala.reflect.ClassTag
 
-import com.google.common.util.concurrent.{FutureCallback, Futures, SettableFuture}
-
 /**
-  * An [[org.apache.spark.rdd.RDD RDD]] that will do a selecting join between `left` RDD and the specified
-  * Cassandra Table This will perform individual selects to retrieve the rows from Cassandra and will take
-  * advantage of RDDs that have been partitioned with the
-  * [[com.datastax.spark.connector.rdd.partitioner.ReplicaPartitioner]]
-  *
-  * @tparam L item type on the left side of the join (any RDD)
-  * @tparam R item type on the right side of the join (fetched from Cassandra)
-  */
+ * An [[org.apache.spark.rdd.RDD RDD]] that will do a selecting join between `left` RDD and the specified
+ * Cassandra Table This will perform individual selects to retrieve the rows from Cassandra and will take
+ * advantage of RDDs that have been partitioned with the
+ * [[com.datastax.spark.connector.rdd.partitioner.ReplicaPartitioner]]
+ *
+ * @tparam L item type on the left side of the join (any RDD)
+ * @tparam R item type on the right side of the join (fetched from Cassandra)
+ */
 class CassandraLeftJoinRDD[L, R] private[connector](
-    left: RDD[L],
+    override val left: RDD[L],
     val keyspaceName: String,
     val tableName: String,
     val connector: CassandraConnector,
@@ -37,14 +31,15 @@ class CassandraLeftJoinRDD[L, R] private[connector](
     val clusteringOrder: Option[ClusteringOrder] = None,
     val readConf: ReadConf = ReadConf(),
     manualRowReader: Option[RowReader[R]] = None,
-    manualRowWriter: Option[RowWriter[L]] = None)(
+    override val manualRowWriter: Option[RowWriter[L]] = None)(
   implicit
     val leftClassTag: ClassTag[L],
     val rightClassTag: ClassTag[R],
     @transient val rowWriterFactory: RowWriterFactory[L],
     @transient val rowReaderFactory: RowReaderFactory[R])
   extends CassandraRDD[(L, Option[R])](left.sparkContext, left.dependencies)
-    with CassandraTableRowReaderProvider[R] {
+  with CassandraTableRowReaderProvider[R]
+  with AbstractCassandraJoin[L, Option[R]] {
 
   override type Self = CassandraLeftJoinRDD[L, R]
 
@@ -52,7 +47,7 @@ class CassandraLeftJoinRDD[L, R] private[connector](
 
   override lazy val rowReader: RowReader[R] = manualRowReader match {
     case Some(rr) => rr
-    case None => rowReaderFactory.rowReader (tableDef, columnNames.selectFrom (tableDef) )
+    case None => rowReaderFactory.rowReader(tableDef, columnNames.selectFrom(tableDef))
   }
 
   override protected def copy(
@@ -61,7 +56,8 @@ class CassandraLeftJoinRDD[L, R] private[connector](
     limit: Option[Long] = limit,
     clusteringOrder: Option[ClusteringOrder] = None,
     readConf: ReadConf = readConf,
-    connector: CassandraConnector = connector): Self = {
+    connector: CassandraConnector = connector
+  ): Self = {
 
     new CassandraLeftJoinRDD[L, R](
       left = left,
@@ -73,21 +69,8 @@ class CassandraLeftJoinRDD[L, R] private[connector](
       where = where,
       limit = limit,
       clusteringOrder = clusteringOrder,
-      readConf = readConf)
-  }
-
-  lazy val joinColumnNames: Seq[ColumnRef] = joinColumns match {
-    case AllColumns => throw new IllegalArgumentException(
-      "Unable to join against all columns in a Cassandra Table. Only primary key columns allowed.")
-    case PartitionKeyColumns =>
-      tableDef.partitionKey.map(col => col.columnName: ColumnRef)
-    case SomeColumns(cs @ _*) =>
-      checkColumnsExistence(cs)
-      cs.map {
-        case c: ColumnRef => c
-        case _ => throw new IllegalArgumentException(
-          "Unable to join against unnamed columns. No CQL Functions allowed.")
-      }
+      readConf = readConf
+    )
   }
 
   override def cassandraCount(): Long = {
@@ -108,52 +91,10 @@ class CassandraLeftJoinRDD[L, R] private[connector](
         where = where,
         limit = limit,
         clusteringOrder = clusteringOrder,
-        readConf = readConf)
+        readConf = readConf
+      )
 
-    counts.map(_._2.getOrElse(0L)).reduce( _ + _ )
-  }
-
-  /** This method will create the RowWriter required before the RDD is serialized.
-    * This is called during getPartitions */
-  protected def checkValidJoin(): Seq[ColumnRef] = {
-    val partitionKeyColumnNames = tableDef.partitionKey.map(_.columnName).toSet
-    val primaryKeyColumnNames = tableDef.primaryKey.map(_.columnName).toSet
-    val colNames = joinColumnNames.map(_.columnName).toSet
-
-    // Initialize RowWriter and Query to be used for accessing Cassandra
-    rowWriter.columnNames
-    singleKeyCqlQuery.length
-
-    def checkSingleColumn(column: ColumnRef): Unit = {
-      require(
-        primaryKeyColumnNames.contains(column.columnName),
-        s"Can't pushdown join on column $column because it is not part of the PRIMARY KEY")
-    }
-
-    // Make sure we have all of the clustering indexes between the 0th position and the max requested
-    // in the join:
-    val chosenClusteringColumns = tableDef.clusteringColumns
-      .filter(cc => colNames.contains(cc.columnName))
-    if (!tableDef.clusteringColumns.startsWith(chosenClusteringColumns)) {
-      val maxCol = chosenClusteringColumns.last
-      val maxIndex = maxCol.componentIndex.get
-      val requiredColumns = tableDef.clusteringColumns.takeWhile(_.componentIndex.get <= maxIndex)
-      val missingColumns = requiredColumns.toSet -- chosenClusteringColumns.toSet
-      throw new IllegalArgumentException(
-        s"Can't pushdown join on column $maxCol without also specifying [ $missingColumns ]")
-    }
-    val missingPartitionKeys = partitionKeyColumnNames -- colNames
-    require(
-      missingPartitionKeys.isEmpty,
-      s"Can't join without the full partition key. Missing: [ $missingPartitionKeys ]")
-
-    joinColumnNames.foreach(checkSingleColumn)
-    joinColumnNames
-  }
-
-  lazy val rowWriter = manualRowWriter match {
-    case Some(_rowWriter) => _rowWriter
-    case None => implicitly[RowWriterFactory[L]].rowWriter (tableDef, joinColumnNames.toIndexedSeq)
+    counts.map(_._2.getOrElse(0L)).reduce(_ + _)
   }
 
   def on(joinColumns: ColumnSelector): CassandraLeftJoinRDD[L, R] = {
@@ -167,81 +108,42 @@ class CassandraLeftJoinRDD[L, R] private[connector](
       where = where,
       limit = limit,
       clusteringOrder = clusteringOrder,
-      readConf = readConf)
-  }
-
-  //We need to make sure we get selectedColumnRefs before serialization so that our RowReader is
-  //built
-  lazy val singleKeyCqlQuery: (String) = {
-    val whereClauses = where.predicates.flatMap(CqlWhereParser.parse)
-    val joinColumns = joinColumnNames.map(_.columnName)
-    val joinColumnPredicates = whereClauses.collect {
-      case EqPredicate(c, _) if joinColumns.contains(c) => c
-      case InPredicate(c) if joinColumns.contains(c) => c
-      case InListPredicate(c, _) if joinColumns.contains(c) => c
-      case RangePredicate(c, _, _) if joinColumns.contains(c) => c
-    }.toSet
-
-    require(
-      joinColumnPredicates.isEmpty,
-      s"""Columns specified in both the join on clause and the where clause.
-          |Partition key columns are always part of the join clause.
-          |Columns in both: ${joinColumnPredicates.mkString(", ")}""".stripMargin
+      readConf = readConf
     )
-
-    logDebug("Generating Single Key Query Prepared Statement String")
-    logDebug(s"SelectedColumns : $selectedColumnRefs -- JoinColumnNames : $joinColumnNames")
-    val columns = selectedColumnRefs.map(_.cql).mkString(", ")
-    val joinWhere = joinColumnNames.map(_.columnName).map(name => s"${quote(name)} = :$name")
-    val limitClause = limit.map(limit => s"LIMIT $limit").getOrElse("")
-    val orderBy = clusteringOrder.map(_.toCql(tableDef)).getOrElse("")
-    val filter = (where.predicates ++ joinWhere).mkString(" AND ")
-    val quotedKeyspaceName = quote(keyspaceName)
-    val quotedTableName = quote(tableName)
-    val query =
-      s"SELECT $columns " +
-        s"FROM $quotedKeyspaceName.$quotedTableName " +
-        s"WHERE $filter $limitClause $orderBy"
-    logDebug(s"Query : $query")
-    query
-  }
-
-  private[rdd] def boundStatementBuilder(session: Session): BoundStatementBuilder[L] = {
-    val protocolVersion = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersion
-    val stmt = session.prepare(singleKeyCqlQuery).setConsistencyLevel(consistencyLevel)
-    new BoundStatementBuilder[L](rowWriter, stmt, where.values, protocolVersion = protocolVersion)
   }
 
   /**
-    * When computing a CassandraPartitionKeyRDD the data is selected via single CQL statements
-    * from the specified C* Keyspace and Table. This will be preformed on whatever data is
-    * available in the previous RDD in the chain.
-    */
-  override def compute(split: Partition, context: TaskContext): Iterator[(L, Option[R])] = {
-    val session = connector.openSession()
-    val bsb = boundStatementBuilder(session)
-    val metricsUpdater = InputMetricsUpdater(context, readConf)
-    val rowIterator = fetchIterator(session, bsb, left.iterator(split, context))
-    val countingIterator = new CountingIterator(rowIterator, limit)
-
-    context.addTaskCompletionListener { (context) =>
-      val duration = metricsUpdater.finish() / 1000000000d
-      logDebug(
-        f"Fetched ${countingIterator.count} rows " +
-          f"from $keyspaceName.$tableName " +
-          f"for partition ${split.index} in $duration%.3f s.")
-      session.close()
-    }
-    countingIterator
+   * Turns this CassandraLeftJoinRDD into a factory for converting other RDD's after being serialized
+   * This method is for streaming operations as it allows us to Serialize a template JoinRDD
+   * and the use that serializable template in the DStream closure. This gives us a fully serializable
+   * leftJoinWithCassandra operation
+   */
+  private[connector] def applyToRDD(left: RDD[L]): CassandraLeftJoinRDD[L, R] = {
+    new CassandraLeftJoinRDD[L, R](
+      left,
+      keyspaceName,
+      tableName,
+      connector,
+      columnNames,
+      joinColumns,
+      where,
+      limit,
+      clusteringOrder,
+      readConf,
+      Some(rowReader),
+      Some(rowWriter)
+    )
   }
 
   private[rdd] def fetchIterator(
-                                  session: Session,
-                                  bsb: BoundStatementBuilder[L],
-                                  leftIterator: Iterator[L]): Iterator[(L, Option[R])] = {
+    session: Session,
+    bsb: BoundStatementBuilder[L],
+    leftIterator: Iterator[L]
+  ): Iterator[(L, Option[R])] = {
     val columnNames = selectedColumnRefs.map(_.selectedAs).toIndexedSeq
     val rateLimiter = new RateLimiter(
-      readConf.throughputJoinQueryPerSec, readConf.throughputJoinQueryPerSec)
+      readConf.throughputJoinQueryPerSec, readConf.throughputJoinQueryPerSec
+    )
 
     def pairWithRight(left: L): SettableFuture[Iterator[(L, Option[R])]] = {
       val resultFuture = SettableFuture.create[Iterator[(L, Option[R])]]
@@ -251,7 +153,7 @@ class CassandraLeftJoinRDD[L, R] private[connector](
       Futures.addCallback(queryFuture, new FutureCallback[ResultSet] {
         def onSuccess(rs: ResultSet) {
           val resultSet = new PrefetchingResultSetIterator(rs, fetchSize)
-          val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames,rs)
+          val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames, rs)
           val rightSide = resultSet.isEmpty match {
             case true => Iterator.single(None)
             case false => resultSet.map(r => Some(rowReader.read(r, columnMetaData)))
@@ -269,47 +171,5 @@ class CassandraLeftJoinRDD[L, R] private[connector](
       pairWithRight(left)
     }).toList
     queryFutures.iterator.flatMap(_.get)
-  }
-
-  override protected def getPartitions: Array[Partition] = {
-    verify()
-    checkValidJoin()
-    left.partitions
-  }
-
-  override def getPreferredLocations(split: Partition): Seq[String] = left.preferredLocations(split)
-
-  override def toEmptyCassandraRDD: EmptyCassandraRDD[(L, Option[R])] =
-    new EmptyCassandraRDD[(L, Option[R])](
-      sc = left.sparkContext,
-      keyspaceName = keyspaceName,
-      tableName = tableName,
-      columnNames = columnNames,
-      where = where,
-      limit = limit,
-      clusteringOrder = clusteringOrder,
-      readConf = readConf)
-
-  /**
-    * Turns this CassandraLeftJoinRDD into a factory for converting other RDD's after being serialized
-    * This method is for streaming operations as it allows us to Serialize a template JoinRDD
-    * and the use that serializable template in the DStream closure. This gives us a fully serializable
-    * leftJoinWithCassandra operation
-    */
-  private[connector] def applyToRDD( left:RDD[L]): CassandraLeftJoinRDD[L,R] =  {
-    new CassandraLeftJoinRDD[L,R](
-      left,
-      keyspaceName,
-      tableName,
-      connector,
-      columnNames,
-      joinColumns,
-      where,
-      limit,
-      clusteringOrder,
-      readConf,
-      Some(rowReader),
-      Some(rowWriter)
-    )
   }
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
@@ -1,0 +1,315 @@
+package com.datastax.spark.connector.rdd
+
+import org.apache.spark.metrics.InputMetricsUpdater
+
+import com.datastax.driver.core.{ResultSet, Session}
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.cql._
+import com.datastax.spark.connector.rdd.reader._
+import com.datastax.spark.connector.util.CqlWhereParser.{EqPredicate, InListPredicate, InPredicate, RangePredicate}
+import com.datastax.spark.connector.util.{CountingIterator, CqlWhereParser}
+import com.datastax.spark.connector.writer._
+import com.datastax.spark.connector.util.Quote._
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{Partition, TaskContext}
+import scala.reflect.ClassTag
+
+import com.google.common.util.concurrent.{FutureCallback, Futures, SettableFuture}
+
+/**
+  * An [[org.apache.spark.rdd.RDD RDD]] that will do a selecting join between `left` RDD and the specified
+  * Cassandra Table This will perform individual selects to retrieve the rows from Cassandra and will take
+  * advantage of RDDs that have been partitioned with the
+  * [[com.datastax.spark.connector.rdd.partitioner.ReplicaPartitioner]]
+  *
+  * @tparam L item type on the left side of the join (any RDD)
+  * @tparam R item type on the right side of the join (fetched from Cassandra)
+  */
+class CassandraLeftJoinRDD[L, R] private[connector](
+    left: RDD[L],
+    val keyspaceName: String,
+    val tableName: String,
+    val connector: CassandraConnector,
+    val columnNames: ColumnSelector = AllColumns,
+    val joinColumns: ColumnSelector = PartitionKeyColumns,
+    val where: CqlWhereClause = CqlWhereClause.empty,
+    val limit: Option[Long] = None,
+    val clusteringOrder: Option[ClusteringOrder] = None,
+    val readConf: ReadConf = ReadConf(),
+    manualRowReader: Option[RowReader[R]] = None,
+    manualRowWriter: Option[RowWriter[L]] = None)(
+  implicit
+    val leftClassTag: ClassTag[L],
+    val rightClassTag: ClassTag[R],
+    @transient val rowWriterFactory: RowWriterFactory[L],
+    @transient val rowReaderFactory: RowReaderFactory[R])
+  extends CassandraRDD[(L, Option[R])](left.sparkContext, left.dependencies)
+    with CassandraTableRowReaderProvider[R] {
+
+  override type Self = CassandraLeftJoinRDD[L, R]
+
+  override protected val classTag = rightClassTag
+
+  override lazy val rowReader: RowReader[R] = manualRowReader match {
+    case Some(rr) => rr
+    case None => rowReaderFactory.rowReader (tableDef, columnNames.selectFrom (tableDef) )
+  }
+
+  override protected def copy(
+                               columnNames: ColumnSelector = columnNames,
+                               where: CqlWhereClause = where,
+                               limit: Option[Long] = limit,
+                               clusteringOrder: Option[ClusteringOrder] = None,
+                               readConf: ReadConf = readConf,
+                               connector: CassandraConnector = connector): Self = {
+
+    new CassandraLeftJoinRDD[L, R](
+      left = left,
+      keyspaceName = keyspaceName,
+      tableName = tableName,
+      connector = connector,
+      columnNames = columnNames,
+      joinColumns = joinColumns,
+      where = where,
+      limit = limit,
+      clusteringOrder = clusteringOrder,
+      readConf = readConf)
+  }
+
+  lazy val joinColumnNames: Seq[ColumnRef] = joinColumns match {
+    case AllColumns => throw new IllegalArgumentException(
+      "Unable to join against all columns in a Cassandra Table. Only primary key columns allowed.")
+    case PartitionKeyColumns =>
+      tableDef.partitionKey.map(col => col.columnName: ColumnRef)
+    case SomeColumns(cs @ _*) =>
+      checkColumnsExistence(cs)
+      cs.map {
+        case c: ColumnRef => c
+        case _ => throw new IllegalArgumentException(
+          "Unable to join against unnamed columns. No CQL Functions allowed.")
+      }
+  }
+
+  override def cassandraCount(): Long = {
+    columnNames match {
+      case SomeColumns(_) =>
+        logWarning("You are about to count rows but an explicit projection has been specified.")
+      case _ =>
+    }
+
+    val counts =
+      new CassandraLeftJoinRDD[L, Long](
+        left = left,
+        connector = connector,
+        keyspaceName = keyspaceName,
+        tableName = tableName,
+        columnNames = SomeColumns(RowCountRef),
+        joinColumns = joinColumns,
+        where = where,
+        limit = limit,
+        clusteringOrder = clusteringOrder,
+        readConf= readConf)
+
+    counts.map(_._2.getOrElse(0L)).reduce( _ + _ )
+  }
+
+  /** This method will create the RowWriter required before the RDD is serialized.
+    * This is called during getPartitions */
+  protected def checkValidJoin(): Seq[ColumnRef] = {
+    val partitionKeyColumnNames = tableDef.partitionKey.map(_.columnName).toSet
+    val primaryKeyColumnNames = tableDef.primaryKey.map(_.columnName).toSet
+    val colNames = joinColumnNames.map(_.columnName).toSet
+
+    // Initialize RowWriter and Query to be used for accessing Cassandra
+    rowWriter.columnNames
+    singleKeyCqlQuery.length
+
+    def checkSingleColumn(column: ColumnRef): Unit = {
+      require(
+        primaryKeyColumnNames.contains(column.columnName),
+        s"Can't pushdown join on column $column because it is not part of the PRIMARY KEY")
+    }
+
+    // Make sure we have all of the clustering indexes between the 0th position and the max requested
+    // in the join:
+    val chosenClusteringColumns = tableDef.clusteringColumns
+      .filter(cc => colNames.contains(cc.columnName))
+    if (!tableDef.clusteringColumns.startsWith(chosenClusteringColumns)) {
+      val maxCol = chosenClusteringColumns.last
+      val maxIndex = maxCol.componentIndex.get
+      val requiredColumns = tableDef.clusteringColumns.takeWhile(_.componentIndex.get <= maxIndex)
+      val missingColumns = requiredColumns.toSet -- chosenClusteringColumns.toSet
+      throw new IllegalArgumentException(
+        s"Can't pushdown join on column $maxCol without also specifying [ $missingColumns ]")
+    }
+    val missingPartitionKeys = partitionKeyColumnNames -- colNames
+    require(
+      missingPartitionKeys.isEmpty,
+      s"Can't join without the full partition key. Missing: [ $missingPartitionKeys ]")
+
+    joinColumnNames.foreach(checkSingleColumn)
+    joinColumnNames
+  }
+
+  lazy val rowWriter = manualRowWriter match {
+    case Some(_rowWriter) => _rowWriter
+    case None => implicitly[RowWriterFactory[L]].rowWriter (tableDef, joinColumnNames.toIndexedSeq)
+  }
+
+  def on(joinColumns: ColumnSelector): CassandraLeftJoinRDD[L, R] = {
+    new CassandraLeftJoinRDD[L, R](
+      left = left,
+      connector = connector,
+      keyspaceName = keyspaceName,
+      tableName = tableName,
+      columnNames = columnNames,
+      joinColumns = joinColumns,
+      where = where,
+      limit = limit,
+      clusteringOrder = clusteringOrder,
+      readConf = readConf)
+  }
+
+  //We need to make sure we get selectedColumnRefs before serialization so that our RowReader is
+  //built
+  lazy val singleKeyCqlQuery: (String) = {
+    val whereClauses = where.predicates.flatMap(CqlWhereParser.parse)
+    val joinColumns = joinColumnNames.map(_.columnName)
+    val joinColumnPredicates = whereClauses.collect {
+      case EqPredicate(c, _) if joinColumns.contains(c) => c
+      case InPredicate(c) if joinColumns.contains(c) => c
+      case InListPredicate(c, _) if joinColumns.contains(c) => c
+      case RangePredicate(c, _, _) if joinColumns.contains(c) => c
+    }.toSet
+
+    require(
+      joinColumnPredicates.isEmpty,
+      s"""Columns specified in both the join on clause and the where clause.
+          |Partition key columns are always part of the join clause.
+          |Columns in both: ${joinColumnPredicates.mkString(", ")}""".stripMargin
+    )
+
+    logDebug("Generating Single Key Query Prepared Statement String")
+    logDebug(s"SelectedColumns : $selectedColumnRefs -- JoinColumnNames : $joinColumnNames")
+    val columns = selectedColumnRefs.map(_.cql).mkString(", ")
+    val joinWhere = joinColumnNames.map(_.columnName).map(name => s"${quote(name)} = :$name")
+    val limitClause = limit.map(limit => s"LIMIT $limit").getOrElse("")
+    val orderBy = clusteringOrder.map(_.toCql(tableDef)).getOrElse("")
+    val filter = (where.predicates ++ joinWhere).mkString(" AND ")
+    val quotedKeyspaceName = quote(keyspaceName)
+    val quotedTableName = quote(tableName)
+    val query =
+      s"SELECT $columns " +
+        s"FROM $quotedKeyspaceName.$quotedTableName " +
+        s"WHERE $filter $limitClause $orderBy"
+    logDebug(s"Query : $query")
+    query
+  }
+
+  private[rdd] def boundStatementBuilder(session: Session): BoundStatementBuilder[L] = {
+    val protocolVersion = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersion
+    val stmt = session.prepare(singleKeyCqlQuery).setConsistencyLevel(consistencyLevel)
+    new BoundStatementBuilder[L](rowWriter, stmt, where.values, protocolVersion = protocolVersion)
+  }
+
+  /**
+    * When computing a CassandraPartitionKeyRDD the data is selected via single CQL statements
+    * from the specified C* Keyspace and Table. This will be preformed on whatever data is
+    * available in the previous RDD in the chain.
+    */
+  override def compute(split: Partition, context: TaskContext): Iterator[(L, Option[R])] = {
+    val session = connector.openSession()
+    val bsb = boundStatementBuilder(session)
+    val metricsUpdater = InputMetricsUpdater(context, readConf)
+    val rowIterator = fetchIterator(session, bsb, left.iterator(split, context))
+    val countingIterator = new CountingIterator(rowIterator, limit)
+
+    context.addTaskCompletionListener { (context) =>
+      val duration = metricsUpdater.finish() / 1000000000d
+      logDebug(
+        f"Fetched ${countingIterator.count} rows " +
+          f"from $keyspaceName.$tableName " +
+          f"for partition ${split.index} in $duration%.3f s.")
+      session.close()
+    }
+    countingIterator
+  }
+
+  private[rdd] def fetchIterator(
+                                  session: Session,
+                                  bsb: BoundStatementBuilder[L],
+                                  leftIterator: Iterator[L]): Iterator[(L, Option[R])] = {
+    val columnNames = selectedColumnRefs.map(_.selectedAs).toIndexedSeq
+    val rateLimiter = new RateLimiter(
+      readConf.throughputJoinQueryPerSec, readConf.throughputJoinQueryPerSec)
+
+    def pairWithRight(left: L): SettableFuture[Iterator[(L, Option[R])]] = {
+      val resultFuture = SettableFuture.create[Iterator[(L, Option[R])]]
+      val leftSide = Iterator.continually(left)
+
+      val queryFuture = session.executeAsync(bsb.bind(left))
+      Futures.addCallback(queryFuture, new FutureCallback[ResultSet] {
+        def onSuccess(rs: ResultSet) {
+          val resultSet = new PrefetchingResultSetIterator(rs, fetchSize)
+          val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames,rs)
+          val rightSide = resultSet.isEmpty match {
+            case true => Iterator.single(None)
+            case false => resultSet.map(r => Some(rowReader.read(r, columnMetaData)))
+          }
+          resultFuture.set(leftSide.zip(rightSide))
+        }
+        def onFailure(throwable: Throwable) {
+          resultFuture.setException(throwable)
+        }
+      })
+      resultFuture
+    }
+    val queryFutures = leftIterator.map(left => {
+      rateLimiter.maybeSleep(1)
+      pairWithRight(left)
+    }).toList
+    queryFutures.iterator.flatMap(_.get)
+  }
+
+  override protected def getPartitions: Array[Partition] = {
+    verify()
+    checkValidJoin()
+    left.partitions
+  }
+
+  override def getPreferredLocations(split: Partition): Seq[String] = left.preferredLocations(split)
+
+  override def toEmptyCassandraRDD: EmptyCassandraRDD[(L, Option[R])] =
+    new EmptyCassandraRDD[(L, Option[R])](
+      sc = left.sparkContext,
+      keyspaceName = keyspaceName,
+      tableName = tableName,
+      columnNames = columnNames,
+      where = where,
+      limit = limit,
+      clusteringOrder = clusteringOrder,
+      readConf = readConf)
+
+  /**
+    * Turns this CassandraJoinRDD into a factory for converting other RDD's after being serialized
+    * This method is for streaming operations as it allows us to Serialize a template JoinRDD
+    * and the use that serializable template in the DStream closure. This gives us a fully serializable
+    * joinWithCassandra operation
+    */
+  private[connector] def applyToRDD( left:RDD[L]): CassandraLeftJoinRDD[L,R] =  {
+    new CassandraLeftJoinRDD[L,R](
+      left,
+      keyspaceName,
+      tableName,
+      connector,
+      columnNames,
+      joinColumns,
+      where,
+      limit,
+      clusteringOrder,
+      readConf,
+      Some(rowReader),
+      Some(rowWriter)
+    )
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/GettableDataToMappedTypeConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/GettableDataToMappedTypeConverter.scala
@@ -81,7 +81,7 @@ private[connector] class GettableDataToMappedTypeConverter[T : TypeTag : ColumnM
     E.g. for a list type, we recursively call this method to get the converter for the
     list items and then we call `TypeConverter.forType` to get a proper converter for lists.
     */
-    val tpe = typeTag[U].tpe
+    val tpe = SparkReflectionLock.synchronized(typeTag[U].tpe)
     (columnType, tpe) match {
       case (argColumnType, TypeRef(_, Symbols.OptionSymbol, List(argScalaType))) =>
         val argConverter = converter(argColumnType, argScalaType)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/ColumnType.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/ColumnType.scala
@@ -82,10 +82,14 @@ object ColumnType {
     DataType.time() -> TimeType
   )
 
-  private lazy val customFromDriverRow: PartialFunction[DataType, ColumnType[_]] = {
+  lazy val customDriverConverter: Option[CustomDriverConverter] = {
     Option(SparkEnv.get)
       .flatMap(env => env.conf.getOption(ColumnTypeConf.CustomDriverTypeParam.name))
       .flatMap(className => Some(ReflectionUtil.findGlobalObject[CustomDriverConverter](className)))
+  }
+
+  private lazy val customFromDriverRow: PartialFunction[DataType, ColumnType[_]] = {
+    customDriverConverter
       .flatMap(clazz => Some(clazz.fromDriverRowExtension))
       .getOrElse(PartialFunction.empty)
   }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/CustomDriverConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/CustomDriverConverter.scala
@@ -1,9 +1,26 @@
 package com.datastax.spark.connector.types
 
 import com.datastax.driver.core.DataType
+import org.apache.spark.sql.{types => catalystTypes}
 
 trait CustomDriverConverter {
 
+  /**
+    * Function to get connector type for RDD conversions
+    */
   val fromDriverRowExtension: PartialFunction[DataType, ColumnType[_]]
 
+  /**
+    * Function to get SparkSQL type for the connector type
+    *  Should be overridden If sparkSQL support is needed for the types.
+    */
+  val catalystDataType: PartialFunction[ColumnType[_], catalystTypes.DataType] =  PartialFunction.empty
+
+  /**
+    *  Should convert custom C* types to the catalyst compatible one.
+    *  Should be overridden If sparkSQL support is needed for the types.
+    *  Good approach is to use kryo serializer here or correct toString implementation.
+    */
+
+  val catalystDataTypeConverter: PartialFunction[Any, AnyRef] = PartialFunction.empty
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WritableToCassandra.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WritableToCassandra.scala
@@ -47,4 +47,42 @@ abstract class WritableToCassandra[T] {
                       writeConf: WriteConf)
                      (implicit connector: CassandraConnector, rwf: RowWriterFactory[T])
 
+  /**
+    * Delete data from Cassandra table, using data from the [[org.apache.spark.rdd.RDD RDD]] as a list of primary keys.
+    * Uses the specified column names.
+    * By default, it deletes all columns from corresponding Cassandra rows.
+    *
+    * Example:
+    * {{{
+    *   CREATE KEYSPACE test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };
+    *   CREATE TABLE test.words(word VARCHAR PRIMARY KEY, count INT, other VARCHAR);
+    *   INSERT INTO test.words((word,count,other) values ('foo', 5, 'foo');
+    * }}}
+    *
+    * {{{
+    *   case class WordCount(word: String, count: Int, other: String)
+    *   val rdd = sc.cassandraTable("test", "words")
+    * }}}
+    *
+    * The underlying RDD class must provide data for all primary key columns.
+    * Delete "other" column values
+    * {{{
+    *   rdd.deleteFromCassandra("test", "words", Seq("other"))
+    * }}}
+    *
+    * This delete consistency level and other properties are the same as for writes
+    *
+    * @param keyspaceName the name of the Keyspace to use
+    * @param tableName the name of the Table to use
+    * @param deleteColumns The list of column names to delete, empty ColumnSelector means full row.
+    * @param keyColumns Primary key columns selector, Optional. All RDD primary columns columns will be checked by default
+    * @param writeConf additional configuration object allowing to set consistency level, batch size, etc.
+    */
+  def deleteFromCassandra(keyspaceName: String,
+                          tableName: String,
+                          deleteColumns: ColumnSelector,
+                          keyColumns: ColumnSelector,
+                          writeConf: WriteConf)
+                         (implicit connector: CassandraConnector, rwf: RowWriterFactory[T])
+
 }

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/testkit/SparkCassandraFixture.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/testkit/SparkCassandraFixture.scala
@@ -22,4 +22,6 @@ private[connector] object TestEvent {
 
   case class WordCount(word: String, count: Int)
 
+  case class Key(word: String)
+
 }


### PR DESCRIPTION
Backports of the following tickets to B1.6:

SparkC-181 (left join)
SparkC-349 (deleteFromCassandraTable)
SparkC-440 (CustomDriverConverter)

EDIT - 

Added SparkC-443 backport