### PR TITLE
SPARKC-363: Find Converters for Classes on Different Classloaders

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/MappedToGettableDataConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/MappedToGettableDataConverter.scala
@@ -3,19 +3,27 @@ package com.datastax.spark.connector.writer
 import scala.language.existentials
 import scala.reflect.runtime.universe._
 import scala.util.control.NonFatal
-
 import org.apache.spark.sql.catalyst.ReflectionLock.SparkReflectionLock
-
-import com.datastax.spark.connector.util.{Symbols, ReflectionUtil}
-import com.datastax.spark.connector.{GettableByIndexData, TupleValue, UDTValue, ColumnRef}
+import org.apache.spark.Logging
+import com.datastax.spark.connector.util.{ReflectionUtil, Symbols}
+import com.datastax.spark.connector.{ColumnRef, GettableByIndexData, TupleValue, UDTValue}
 import com.datastax.spark.connector.cql.StructDef
 import com.datastax.spark.connector.mapper.{DefaultColumnMapper, TupleColumnMapper, JavaBeanColumnMapper, ColumnMapper}
 import com.datastax.spark.connector.types.{TupleType, MapType, SetType, ListType, ColumnType, TypeConverter}
 
-private[connector] object MappedToGettableDataConverter {
+private[connector] object MappedToGettableDataConverter extends Logging {
 
-  def apply[T : TypeTag : ColumnMapper]
-      (struct: StructDef, columnSelection: IndexedSeq[ColumnRef]): TypeConverter[struct.ValueRepr] =
+  /**
+    * When the Spark Cassandra Connector is running on a separate
+    * classloader it is possible that application classes will
+    * not be accessible. To avoid this scenario we can forcibly
+    * pass through the classloader from the application provided
+    * class to all converters created for children of this converter.
+    */
+  def apply[T : TypeTag : ColumnMapper](
+    struct: StructDef,
+    columnSelection: IndexedSeq[ColumnRef],
+    forceClassLoader: Option[ClassLoader] = None): TypeConverter[struct.ValueRepr] =
 
     new TypeConverter[struct.ValueRepr] {
 
@@ -36,6 +44,7 @@ private[connector] object MappedToGettableDataConverter {
         * and for everything else uses
         * [[com.datastax.spark.connector.mapper.DefaultColumnMapper DefaultColumnMapper]] */
       private def columnMapper[U: TypeTag]: ColumnMapper[U] = {
+        logDebug(s"Finding a UDT ColumnMapper for typeTag ${typeTag[U]}")
         val tpe = SparkReflectionLock.synchronized(typeTag[U].tpe)
         if (ReflectionUtil.isScalaTuple(tpe))
           new TupleColumnMapper[U]
@@ -55,6 +64,8 @@ private[connector] object MappedToGettableDataConverter {
       private def converter[U : TypeTag](columnType: ColumnType[_]): TypeConverter[_ <: AnyRef] = {
         SparkReflectionLock.synchronized {
           val scalaType = typeTag[U].tpe
+
+          logDebug(s"Getting converter for $columnType to $scalaType")
 
           (columnType, scalaType) match {
             // Collections need recursive call to get the converter for the collection elements
@@ -101,7 +112,7 @@ private[connector] object MappedToGettableDataConverter {
             // ColumnMappers support mapping Scala tuples, so we don't need a special case for them.
             case (t: StructDef, _) =>
               implicit val cm: ColumnMapper[U] = columnMapper[U]
-              apply[U](t, t.columnRefs)
+              apply[U](t, t.columnRefs, Some(childClassloader))
 
             // Primitive types
             case _ =>
@@ -123,7 +134,21 @@ private[connector] object MappedToGettableDataConverter {
         typeTag[T].tpe
       }
 
-      private val cls = typeTag[T].mirror.runtimeClass(typeTag[T].tpe).asInstanceOf[Class[T]]
+      @transient
+      private val mirror = forceClassLoader match {
+        case Some(cl) => runtimeMirror(cl)
+        case None => typeTag[T].mirror
+      }
+
+      /**
+        * All converters descended from this converter should use the same classloader even if
+        * this class (MappedToGettableDataConverter) happens to be on a different classloader.
+        */
+      @transient
+      private val childClassloader = mirror.classLoader
+
+      logDebug(s"Finding a class for $tpe in ${mirror.classLoader}")
+      private val cls = mirror.runtimeClass(typeTag[T].tpe).asInstanceOf[Class[T]]
       private val typeName = tpe.toString
 
       val columnNames =
@@ -164,6 +189,7 @@ private[connector] object MappedToGettableDataConverter {
       }
 
       override def targetTypeTag = typeTag[struct.ValueRepr]
+
 
       override def convertPF = {
         case obj if cls.isInstance(obj) =>


### PR DESCRIPTION
The current code assumes that if you are converting a UDT in a
collection or some other nested structure that all subclasses can be
loaded on the same classloader than the SCC has been loaded on. For some
runtime enivronments (like DSE) this is not true and the SCC is on a
different classloader than the application code. This can lead to the
lookup on the contained class failing with a ClassNotFound Exception.

To avoid this situation we allow for the first class (which will be
tuned to the correct classloader in it's runtime mirror) to force
all sub-converters created to enable it's construction to be built
with the same Classloader.

This fixes situations like

case class Row(k: Int, v: Seq[UdtCaseClass])

so that

The Classloader which loads "Row" will be used to load "UdtCaseClass".

A Test has been added but it cannot trigger the bug since our testing
all happens on the same classloader.