### PR TITLE
SPARKC-441 Fix CassandraConnector sessionCache remote and race condition

### DIFF
--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
@@ -20,7 +20,6 @@ case class KeyValueWithTTL(key: Int, group: Long, value: String, ttl: Int)
 case class KeyValueWithTimestamp(key: Int, group: Long, value: String, timestamp: Long)
 case class KeyValueWithConversion(key: String, group: Int, value: String)
 case class ClassWithWeirdProps(devil: String, cat: Int, value: String)
-case class Address(street: String, city: String, zip: Int)
 
 class SuperKeyValue(val key: Int, val value: String) extends Serializable
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -1,6 +1,8 @@
 package com.datastax.spark.connector.cql
 
 import java.net.InetAddress
+import java.io.{ObjectOutputStream, ObjectInputStream, ByteArrayOutputStream, ByteArrayInputStream}
+import java.util.Base64
 
 import com.datastax.spark.connector.cql.CassandraConnectorConf.RetryDelayConf
 
@@ -32,7 +34,26 @@ case class CassandraConnectorConf(
   cassandraSSLConf: CassandraConnectorConf.CassandraSSLConf = CassandraConnectorConf.DefaultCassandraSSLConf,
   @deprecated("delayed retrying has been disabled; see SPARKC-360", "1.2.6, 1.3.2, 1.4.3, 1.5.1")
   queryRetryDelay: CassandraConnectorConf.RetryDelayConf = CassandraConnectorConf.QueryRetryDelayParam.default
-)
+) {
+
+  @transient
+  lazy val serializedConfString: String = {
+    val baos = new ByteArrayOutputStream
+    val oos = new ObjectOutputStream(baos)
+    oos.writeObject(this);
+    oos.close;
+    Base64.getEncoder.encodeToString(baos.toByteArray)
+  }
+
+  override def hashCode: Int = serializedConfString.hashCode
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case that: CassandraConnectorConf => that.serializedConfString == serializedConfString
+      case _ => false
+    }
+  }
+}
 
 /** A factory for [[CassandraConnectorConf]] objects.
   * Allows for manually setting connection properties or reading them from [[org.apache.spark.SparkConf SparkConf]]

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -2,8 +2,7 @@ package com.datastax.spark.connector.cql
 
 import java.net.InetAddress
 import java.io.{ObjectOutputStream, ObjectInputStream, ByteArrayOutputStream, ByteArrayInputStream}
-
-import org.apache.commons.codec.binary.Base64
+import java.util.Base64
 
 import com.datastax.spark.connector.cql.CassandraConnectorConf.RetryDelayConf
 
@@ -43,7 +42,7 @@ case class CassandraConnectorConf(
     val oos = new ObjectOutputStream(baos)
     oos.writeObject(this);
     oos.close;
-    Base64.encodeBase64String(baos.toByteArray)
+    Base64.getEncoder.encodeToString(baos.toByteArray)
   }
 
   override def hashCode: Int = serializedConfString.hashCode

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -2,7 +2,8 @@ package com.datastax.spark.connector.cql
 
 import java.net.InetAddress
 import java.io.{ObjectOutputStream, ObjectInputStream, ByteArrayOutputStream, ByteArrayInputStream}
-import java.util.Base64
+
+import org.apache.commons.codec.binary.Base64
 
 import com.datastax.spark.connector.cql.CassandraConnectorConf.RetryDelayConf
 
@@ -42,7 +43,7 @@ case class CassandraConnectorConf(
     val oos = new ObjectOutputStream(baos)
     oos.writeObject(this);
     oos.close;
-    Base64.getEncoder.encodeToString(baos.toByteArray)
+    Base64.encodeBase64String(baos.toByteArray)
   }
 
   override def hashCode: Int = serializedConfString.hashCode


### PR DESCRIPTION
If set up a remote C* cluster and submit a job from spark cluster to
connect to remote C* cluster. The CassandraConnectorConf is serialized
and deserialized into different CassandraConnectorConf object for
the same original CassandraConnectorConf. Then each time sessionCache
creates new session for each deserialized CassandraConnectorConf.

Too many new sessions results too many cluster objects, and the
following errors are found.

ResourceLeakDetector: LEAK: You are creating too many HashedWheelTimer instances

To fix the issue, we change sessionCache key from CassandraConnectorConf
to String which is the serialized CassandraConnectorConf in String format.

The second issue is acquire method of RefCountedCache is not synchronized.
Even the cache itself is TriMap, the acquire method still creates two
sessions at certain moment when there are two concurrent requests to
acquire a new session.

To fix the issue, the code of creating new session in acquire method
when the session is not found in the cache should be synchronized.

It does have some performance overhead when new session is created
and serialize/deserialize CassandraConnectorConf