### PR TITLE
Requesting a pull to datastax:master from datastax:SPARKC-459

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,18 @@
 language: scala
 jdk:
   - oraclejdk8
+
 sudo: required
+
 dist: trusty
 scala:
   - 2.10.6
   - 2.11.8
 
-cache:
-  directories:
-    - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot
-    - $HOME/.coursier-cache
-
-before_cache:
-  # Tricks to avoid unnecessary cache updates
-  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
-  - find $HOME/.sbt -name "*.lock" -delete
+env:
+ - CASSANDRA_VERSION=2.1.15
+ - CASSANDRA_VERSION=3.6
 
 script:
-  - "sbt ++$TRAVIS_SCALA_VERSION -Dtravis=true test"
-  - "sbt ++$TRAVIS_SCALA_VERSION -Dtravis=true it:test"
-  - "sbt ++$TRAVIS_SCALA_VERSION -Dtest.cassandra.version=2.1.15 -Dtravis=true test"
-  - "sbt ++$TRAVIS_SCALA_VERSION -Dtest.cassandra.version=2.1.15 -Dtravis=true it:test"
-  - "sbt ++$TRAVIS_SCALA_VERSION -Dtravis=true assembly"
+  - "sbt ++$TRAVIS_SCALA_VERSION -Dtest.cassandra.version=$CASSANDRA_VERSION -Dtravis=true -Dtravis=true it:test"  #Integration Suite
+  - "sbt ++$TRAVIS_SCALA_VERSION -Dtest.cassandra.version=$CASSANDRA_VERSION -Dtravis=true -Dtravis=true assembly" #Test Suite and Assembly Test

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -206,13 +206,18 @@ OSS Cassandra this should never be used.</td>
 </tr>
 <tr>
   <td><code>input.join.throughput_query_per_sec</code></td>
-  <td>9223372036854775807</td>
-  <td>Maximum read throughput allowed per single core in query/s while joining RDD with Cassandra table</td>
+  <td>2147483647</td>
+  <td>**Deprecated** Please use input.reads_per_sec. Maximum read throughput allowed per single core in query/s while joining RDD with Cassandra table</td>
 </tr>
 <tr>
   <td><code>input.metrics</code></td>
   <td>true</td>
   <td>Sets whether to record connector specific metrics on write</td>
+</tr>
+<tr>
+  <td><code>input.reads_per_sec</code></td>
+  <td>2147483647</td>
+  <td>Sets max requests per core per second for joinWithCassandraTable and some Enterprise integrations</td>
 </tr>
 <tr>
   <td><code>input.split.size_in_mb</code></td>

--- a/project/Testing.scala
+++ b/project/Testing.scala
@@ -77,6 +77,7 @@ object Testing extends Build {
       else if (test.name.contains("CustomFromDriverSpec")) "customdriverspec"
       else if (test.name.contains("CETSpec") || test.name.contains("CETTest")) "cetspec"
       else if (test.name.contains("PSTSpec") || test.name.contains("PSTTest")) "pstspec"
+      else if (test.name.contains("Connector")) "connector"
       else test.name.reverse.dropWhile(_ != '.').reverse
     }
 
@@ -94,6 +95,7 @@ object Testing extends Build {
       else if (test.name.contains("CustomFromDriverSpec")) "customdriverspec"
       else if (test.name.contains("CETSpec") || test.name.contains("CETTest")) "cetspec"
       else if (test.name.contains("PSTSpec") || test.name.contains("PSTTest")) "pstspec"
+      else if (test.name.contains("Connector")) "connector"
       else "other"
     }
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CustomTableScanMethodSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CustomTableScanMethodSpec.scala
@@ -1,0 +1,64 @@
+package com.datastax.spark.connector.rdd
+
+import com.datastax.driver.core.{Cluster, Row, Session, Statement}
+import com.datastax.spark.connector.{SparkCassandraITFlatSpecBase, _}
+import com.datastax.spark.connector.cql.{CassandraConnectionFactory, CassandraConnector, CassandraConnectorConf, DefaultConnectionFactory}
+import com.datastax.spark.connector.embedded.SparkTemplate._
+import com.datastax.spark.connector.embedded.YamlTransformations
+import com.datastax.spark.connector.rdd.partitioner.dht.TokenFactory
+import org.apache.spark.SparkException
+import org.scalatest.Inspectors
+
+class CustomTableScanMethodSpec extends SparkCassandraITFlatSpecBase with Inspectors {
+  useCassandraConfig(Seq(YamlTransformations.Default))
+  useSparkConf(
+    defaultConf
+      .set(CassandraConnectionFactory.FactoryParam.name,
+       "com.datastax.spark.connector.rdd.DummyFactory"
+      ))
+
+  override val conn = CassandraConnector(defaultConf)
+  val tokenFactory = TokenFactory.forSystemLocalPartitioner(conn)
+  val tableName = "data"
+  val noMinimalThreshold = Int.MinValue
+
+  override def beforeAll(): Unit = {
+    conn.withSessionDo { session =>
+
+      session.execute(s"CREATE KEYSPACE IF NOT EXISTS $ks " +
+        s"WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }")
+
+      session.execute(s"CREATE TABLE $ks.$tableName(key int primary key, value text)")
+      val st = session.prepare(s"INSERT INTO $ks.$tableName(key, value) VALUES(?, ?)")
+      // 1M rows x 64 bytes of payload = 64 MB of data + overhead
+      for (i <- (1 to 100).par) {
+        val key = i.asInstanceOf[AnyRef]
+        val value = "123456789.123456789.123456789.123456789.123456789.123456789."
+        session.execute(st.bind(key, value))
+      }
+    }
+  }
+
+  "CassandraTableScanRDD" should "be able to use a custom scan method" in withoutLogging{
+    //The dummy method set in the SparkConf only throws a NIE
+    val se = intercept[SparkException] {
+      sc.cassandraTable[CassandraRow](ks, tableName).collect
+    }
+    se.getCause.getMessage should be (DummyFactory.nie.getMessage)
+  }
+}
+
+object DummyFactory extends CassandraConnectionFactory {
+  
+  val nie = new NotImplementedError("TestingOnly")
+  override def getScanMethod(
+    readConf: ReadConf,
+    session: Session,
+    columnNames: IndexedSeq[String]): (Statement) => (Iterator[Row], CassandraRowMetadata) = {
+    throw nie
+  }
+
+  /** Creates and configures native Cassandra connection */
+  override def createCluster(conf: CassandraConnectorConf): Cluster =
+    DefaultConnectionFactory.createCluster(conf)
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/SessionProxy.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/SessionProxy.scala
@@ -2,7 +2,11 @@ package com.datastax.spark.connector.cql
 
 import java.lang.reflect.{InvocationHandler, InvocationTargetException, Method, Proxy}
 
+import com.datastax.spark.connector.util.Logging
 import com.datastax.driver.core.{RegularStatement, Session, SimpleStatement}
+import org.apache.commons.lang3.ClassUtils
+
+import collection.JavaConverters._
 
 /** Wraps a `Session` and intercepts:
   *  - `close` method to invoke `afterClose` handler
@@ -47,7 +51,7 @@ class SessionProxy(session: Session, afterClose: Session => Any) extends Invocat
   }
 }
 
-object SessionProxy {
+object SessionProxy extends Logging {
 
   /** Creates a new `SessionProxy` delegating to the given `Session`.
     * The proxy adds prepared statement caching functionality. */
@@ -57,9 +61,12 @@ object SessionProxy {
   /** Creates a new `SessionProxy` delegating to the given `Session`.
     * Additionally registers a callback on `Session#close` method.
     * @param afterClose code to be invoked after the session has been closed */
-  def wrapWithCloseAction(session: Session)(afterClose: Session => Any): Session =
+  def wrapWithCloseAction(session: Session)(afterClose: Session => Any): Session = {
+    val listInterfaces = ClassUtils.getAllInterfaces(session.getClass)
+    val availableInterfaces = listInterfaces.toArray[Class[_]](new Array[Class[_]](listInterfaces.size))
     Proxy.newProxyInstance(
       session.getClass.getClassLoader,
-      Array(classOf[Session]),
+      availableInterfaces,
       new SessionProxy(session, afterClose)).asInstanceOf[Session]
+  }
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
@@ -119,7 +119,7 @@ class CassandraJoinRDD[L, R] private[connector](
   ): Iterator[(L, R)] = {
     val columnNames = selectedColumnRefs.map(_.selectedAs).toIndexedSeq
     val rateLimiter = new RateLimiter(
-      readConf.throughputJoinQueryPerSec, readConf.throughputJoinQueryPerSec
+      readConf.readsPerSec, readConf.readsPerSec
     )
 
     def pairWithRight(left: L): SettableFuture[Iterator[(L, R)]] = {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
@@ -142,7 +142,7 @@ class CassandraLeftJoinRDD[L, R] private[connector](
   ): Iterator[(L, Option[R])] = {
     val columnNames = selectedColumnRefs.map(_.selectedAs).toIndexedSeq
     val rateLimiter = new RateLimiter(
-      readConf.throughputJoinQueryPerSec, readConf.throughputJoinQueryPerSec
+      readConf.readsPerSec, readConf.readsPerSec
     )
 
     def pairWithRight(left: L): SettableFuture[Iterator[(L, Option[R])]] = {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
@@ -12,7 +12,7 @@ import com.datastax.spark.connector.rdd.reader._
 import com.datastax.spark.connector.types.ColumnType
 import com.datastax.spark.connector.util.CqlWhereParser.{EqPredicate, InListPredicate, InPredicate, Predicate, RangePredicate}
 import com.datastax.spark.connector.util.Quote._
-import com.datastax.spark.connector.util.{CountingIterator, CqlWhereParser}
+import com.datastax.spark.connector.util.{CountingIterator, CqlWhereParser, ReflectionUtil}
 import com.datastax.spark.connector.writer.RowWriterFactory
 import org.apache.spark.metrics.InputMetricsUpdater
 import org.apache.spark.rdd.{PartitionCoalescer, RDD}
@@ -327,7 +327,8 @@ class CassandraTableScanRDD[R] private[connector](
   private def fetchTokenRange(
     session: Session,
     range: CqlTokenRange[_, _],
-    inputMetricsUpdater: InputMetricsUpdater): Iterator[R] = {
+    inputMetricsUpdater: InputMetricsUpdater,
+    scanExecuteMethod: Statement => (Iterator[Row], CassandraRowMetadata)): Iterator[R] = {
 
     val (cql, values) = tokenRangeToCqlQuery(range)
     logDebug(
@@ -337,11 +338,8 @@ class CassandraTableScanRDD[R] private[connector](
     val stmt = createStatement(session, cql, values: _*)
 
     try {
-      val rs = session.execute(stmt)
-      val columnNames = selectedColumnRefs.map(_.selectedAs).toIndexedSeq
-      val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames,rs)
+      val (iterator, columnMetaData) = scanExecuteMethod(stmt)
 
-      val iterator = new PrefetchingResultSetIterator(rs, fetchSize)
       val iteratorWithMetrics = iterator.map(inputMetricsUpdater.updateMetrics)
       val result = iteratorWithMetrics.map(rowReader.read(_, columnMetaData))
       logDebug(s"Row iterator for range ${range.cql(partitionKeyStr)} obtained successfully.")
@@ -358,11 +356,14 @@ class CassandraTableScanRDD[R] private[connector](
     val tokenRanges = partition.tokenRanges
     val metricsUpdater = InputMetricsUpdater(context, readConf)
 
+    val columnNames = selectedColumnRefs.map(_.selectedAs).toIndexedSeq
+    val scanExecuteMethod = connector.connectionFactory.getScanMethod(readConf, session, columnNames)
+
     // Iterator flatMap trick flattens the iterator-of-iterator structure into a single iterator.
     // flatMap on iterator is lazy, therefore a query for the next token range is executed not earlier
     // than all of the rows returned by the previous query have been consumed
     val rowIterator = tokenRanges.iterator.flatMap(
-      fetchTokenRange(session, _: CqlTokenRange[_, _], metricsUpdater))
+      fetchTokenRange(session, _: CqlTokenRange[_, _], metricsUpdater, scanExecuteMethod))
     val countingIterator = new CountingIterator(rowIterator, limitForIterator(limit))
 
     context.addTaskCompletionListener { (context) =>

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/ConfigCheck.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/ConfigCheck.scala
@@ -4,8 +4,7 @@ import org.apache.commons.configuration.ConfigurationException
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.cassandra.{CassandraSQLContextParams, CassandraSourceRelation}
-
-import com.datastax.spark.connector.cql.{AuthConfFactory, CassandraConnectionFactory, CassandraConnectorConf}
+import com.datastax.spark.connector.cql.{AuthConfFactory, CassandraConnectionFactory, CassandraConnectorConf, SessionProxy}
 import com.datastax.spark.connector.rdd.ReadConf
 import com.datastax.spark.connector.types.ColumnTypeConf
 import com.datastax.spark.connector.writer.WriteConf

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/ReadConfTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/ReadConfTest.scala
@@ -1,0 +1,30 @@
+package com.datastax.spark.connector.rdd
+
+import org.apache.spark.SparkConf
+import org.scalatest.{FlatSpec, ShouldMatchers}
+
+class ReadConfTest extends FlatSpec with ShouldMatchers {
+
+  "A ReadConf" should "ignore JoinWithCassandraTable Parameters if readsPerSec is set" in {
+    val expected = 50
+    val notExpected = 122
+
+    val conf = new SparkConf(true)
+      .set(ReadConf.ReadsPerSecParam.name, expected.toString)
+      .set(ReadConf.ThroughputJoinQueryPerSecParam.name, notExpected.toString)
+
+    val readConf = ReadConf.fromSparkConf(conf)
+    readConf.readsPerSec should be (expected)
+  }
+
+  it should "use JoinWithCassandraTable Parameters if readPerSec is not set" in {
+    val expected = 493
+
+    val conf = new SparkConf(true)
+      .set(ReadConf.ThroughputJoinQueryPerSecParam.name, expected.toString)
+
+    val readConf = ReadConf.fromSparkConf(conf)
+    readConf.readsPerSec should be (expected)
+  }
+
+}


### PR DESCRIPTION
Write a message for this pull request. The first block
of text is the title and the rest is the description.

Changes:

550eed4 (Russell Spitzer, 2 minutes ago)
   SPARKC-459: Creation of CustomTableScan Extension Point

   Users can now extend the CustomTableMethod trait to provide a new method of
   executing statements. The given method is passed in via classname in the
   SparkConf.

08d95e9 (Russell Spitzer, 2 hours ago)
   SPARKC-459: Allow for a different Session Interface in SessionProxy

   Previously the interface of Session proxy was always the default OSS
   Datastax Driver session. A new connection parameter is added
   spark.cassandra.connection.session_interface which lets an end user specify
   a different session interface to be used.

e905ccb (Russell Spitzer, 3 hours ago)
   SPARKC-459: Seperate Execute Method out of FetchTokenRange Code

   The initial refactor moves the logic for actually executing statements out
   of the fetchTokenRange method. This is now done via a method which is
   determined at runtime. At the moment this just falls back to the original
   method.

acca81f (Russell Spitzer, 4 hours ago)
   SPARKC-459: Deprecate and Rename ThroughputJoinCassandra

   To give the parameter a more generic name and purpose the parameter has
   been changed to reads_per_sec and placed under input. The old parameter can
   still be used but the user will be warned and any values larger than
   Int.MaxValue will be rounded to Int.MaxValue.