### PR TITLE
SPARKC-461: Fix Incomplete Shading of Guava

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -349,7 +349,8 @@ object Settings extends Build {
     assemblyShadeRules in assembly := {
       val shadePackage = "shade.com.datastax.spark.connector"
       Seq(
-        ShadeRule.rename("com.google.common.**" -> s"$shadePackage.google.common.@1").inAll
+        ShadeRule.rename("com.google.common.**" -> s"$shadePackage.google.common.@1").inAll,
+        ShadeRule.rename("com.google.thirdparty.publicsuffix.**" -> s"$shadePackage.google.thirdparty.publicsuffix.@1").inAll
       )
     }
   )


### PR DESCRIPTION
Previously the Guava 16.0.1 shading was missing the thirdparty package
within the library. This caused conflicts with user applications that
were importing their own copy of Guava 16.0.1. Correctly shading the
library should fix this issue.