### PR TITLE
Requesting a pull to datastax:b1.6 from datastax:SPARKC-462

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,16 @@ The connector project has several branches, each of which map into different sup
 Spark and Cassandra. Refer to the compatibility table below which shows the major.minor 
 version range supported between the connector, Spark, Cassandra, and the Cassandra Java driver:
 
-| Connector | Spark         | Cassandra | Cassandra Java Driver |
-| --------- | ------------- | --------- | --------------------- |
-| 1.6       | 1.6           | 2.1.5*, 2.2, 3.0  | 3.0           |
-| 1.5       | 1.5, 1.6      | 2.1.5*, 2.2, 3.0  | 3.0           |
-| 1.4       | 1.4           | 2.1.5*    | 2.1                   |
-| 1.3       | 1.3           | 2.1.5*    | 2.1                   |
-| 1.2       | 1.2           | 2.1, 2.0  | 2.1                   |
-| 1.1       | 1.1, 1.0      | 2.1, 2.0  | 2.1                   |
-| 1.0       | 1.0, 0.9      | 2.0       | 2.0                   |
+| Connector | Spark         | Cassandra | Cassandra Java Driver | Minimum Java Version | Supported Scala Versions |
+| --------- | ------------- | --------- | --------------------- | -------------------- | -----------------------  |
+| 2.0       | 2.0, 2.1      | 2.1.5*, 2.2, 3.0 | 3.0            | 8                    | 2.10, 2.11               |
+| 1.6       | 1.6           | 2.1.5*, 2.2, 3.0  | 3.0           | 7                    | 2.10, 2.11               |
+| 1.5       | 1.5, 1.6      | 2.1.5*, 2.2, 3.0  | 3.0           | 7                    | 2.10, 2.11               |
+| 1.4       | 1.4           | 2.1.5*    | 2.1                   | 7                    | 2.10, 2.11               |
+| 1.3       | 1.3           | 2.1.5*    | 2.1                   | 7                    | 2.10, 2.11               |
+| 1.2       | 1.2           | 2.1, 2.0  | 2.1                   | 7                    | 2.10, 2.11               |
+| 1.1       | 1.1, 1.0      | 2.1, 2.0  | 2.1                   | 7                    | 2.10, 2.11               |
+| 1.0       | 1.0, 0.9      | 2.0       | 2.0                   | 7                    | 2.10, 2.11               |
 
 **Compatible with 2.1.X where X >= 5*
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -2,7 +2,8 @@ package com.datastax.spark.connector.cql
 
 import java.net.InetAddress
 import java.io.{ObjectOutputStream, ObjectInputStream, ByteArrayOutputStream, ByteArrayInputStream}
-import java.util.Base64
+
+import org.apache.commons.codec.binary.Base64
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
@@ -38,7 +39,7 @@ case class CassandraConnectorConf(
     val oos = new ObjectOutputStream(baos)
     oos.writeObject(this);
     oos.close;
-    Base64.getEncoder.encodeToString(baos.toByteArray)
+    Base64.encodeBase64String(baos.toByteArray)
   }
 
   override def hashCode: Int = serializedConfString.hashCode


### PR DESCRIPTION
Changes:

89bdff2 (Russell Spitzer, 81 seconds ago)
    SPARKC-462: Publicly display minimum Java Target Versions

    Readme version table now has Java and Scala Version Info.

489cf89 (Russell Spitzer, 11 minutes ago)
    SPARKC-462: Remove Java8 Dependency in CassandraConnectorConf

    While we internally had decided to target Java8 in 1.6 we did not publiclly
    announce this. To keep Java7 Compatibility we will roll back the use of
    Java8 Classes.