### PR TITLE
SPARKC-446 Enabling PerPartitionLimits for CassandraTable and JoinWithCassandraTable

### DIFF
--- a/doc/3_selection.md
+++ b/doc/3_selection.md
@@ -84,6 +84,12 @@ predicate for the where clause, you will get unpredictable amount of
 rows because the limit will be applied on each Spark partition which 
 is created for the RDD.
 
+If you are connecting to Cassandra 3.6 or greater you can also use the 
+`perPartitionLimit` method. This will add `PER PARTITION LIMIT` clause
+to all CQL executed by the RDD. The `PARTITION` here is a Cassandra 
+Partition so it will only retrieve `rowsNumber` CQL Rows for each 
+partition key in the result.
+
 ### Grouping rows by partition key
 
 Physically, Cassandra stores data already grouped by partition key and 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -29,7 +29,7 @@ object Versions {
   lazy val scalaBinary = scalaVersion.dropRight(2)
 
   val Akka            = "2.3.4"
-  val Cassandra       = "3.0.2"
+  val Cassandra       = "3.6"
   val CassandraDriver = "3.0.2"
   val CommonsIO       = "2.4"
   val CommonsLang3    = "3.3.2"

--- a/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/EmbeddedCassandra.scala
+++ b/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/EmbeddedCassandra.scala
@@ -80,7 +80,7 @@ object EmbeddedCassandra {
   val cassandraVersion = System.getProperty("test.cassandra.version", DEFAULT_CASSANDRA_VERSION)
   val (cassandraMajorVersion, cassandraMinorVersion) = {
     val parts = cassandraVersion.split("\\.")
-    require(parts.length > 2, s"Can't determine Cassandra Version from $cassandraVersion : ${parts.mkString(",")}")
+    require(parts.length >= 2, s"Can't determine Cassandra Version from $cassandraVersion : ${parts.mkString(",")}")
     (parts(0).toInt, parts(1).toInt)
   }
 

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -132,6 +132,112 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
       },
 
       Future {
+        session.execute(s"""CREATE TABLE $ks.delete_short_rows_partition(key INT, group INT, value VARCHAR, PRIMARY KEY (key,group))""")
+        session.execute(s"""INSERT INTO $ks.delete_short_rows_partition(key, group, value) VALUES (10, 10, '1010')""")
+        session.execute(s"""INSERT INTO $ks.delete_short_rows_partition(key, group, value) VALUES (10, 11, '1011')""")
+        session.execute(s"""INSERT INTO $ks.delete_short_rows_partition(key, group, value) VALUES (10, 12, '1012')""")
+        session.execute(s"""INSERT INTO $ks.delete_short_rows_partition(key, group, value) VALUES (20, 20, '2020')""")
+        session.execute(s"""INSERT INTO $ks.delete_short_rows_partition(key, group, value) VALUES (20, 21, '2021')""")
+        session.execute(s"""INSERT INTO $ks.delete_short_rows_partition(key, group, value) VALUES (20, 22, '2022')""")
+      },
+
+      Future {
+        session.execute(s"""CREATE TABLE $ks.delete_short_rows(key INT, group INT, value VARCHAR, PRIMARY KEY (key,group))""")
+        session.execute(s"""INSERT INTO $ks.delete_short_rows(key, group, value) VALUES (10, 10, '1010')""")
+        session.execute(s"""INSERT INTO $ks.delete_short_rows(key, group, value) VALUES (10, 11, '1011')""")
+        session.execute(s"""INSERT INTO $ks.delete_short_rows(key, group, value) VALUES (10, 12, '1012')""")
+        session.execute(s"""INSERT INTO $ks.delete_short_rows(key, group, value) VALUES (20, 20, '2020')""")
+        session.execute(s"""INSERT INTO $ks.delete_short_rows(key, group, value) VALUES (20, 21, '2021')""")
+        session.execute(s"""INSERT INTO $ks.delete_short_rows(key, group, value) VALUES (20, 22, '2022')""")
+      },
+
+      Future {
+        session.execute(s"""CREATE TABLE $ks.delete_wide_rows4(key INT, group TEXT, group2 INT, value VARCHAR, PRIMARY KEY ((key, group), group2))""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows4(key, group, group2, value) VALUES (10, '1', 1, '1010')""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows4(key, group, group2, value) VALUES (10, '1', 2, '1011')""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows4(key, group, group2, value) VALUES (10, '2', 1, '1012')""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows4(key, group, group2, value) VALUES (1, '2', 2, '2020')""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows4(key, group, group2, value) VALUES (2, '2', 1, '2021')""")
+      },
+
+      Future {
+        session.execute(s"""CREATE TABLE $ks.delete_wide_rows3(key INT, group INT, value VARCHAR, PRIMARY KEY (key, group))""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows3(key, group, value) VALUES (10, 10, '1010')""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows3(key, group, value) VALUES (10, 11, '1011')""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows3(key, group, value) VALUES (10, 12, '1012')""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows3(key, group, value) VALUES (1, 20, '2020')""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows3(key, group, value) VALUES (2, 21, '2021')""")
+      },
+
+      Future {
+        session.execute(s"""CREATE TABLE $ks.delete_wide_rows2(key INT, group INT, value VARCHAR, PRIMARY KEY (key, group))""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows2(key, group, value) VALUES (10, 10, '1010')""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows2(key, group, value) VALUES (10, 11, '1011')""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows2(key, group, value) VALUES (10, 12, '1012')""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows2(key, group, value) VALUES (20, 20, '2020')""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows2(key, group, value) VALUES (20, 21, '2021')""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows2(key, group, value) VALUES (20, 22, '2022')""")
+      },
+
+      Future {
+        session.execute(s"""CREATE TABLE $ks.delete_wide_rows1(key INT, group INT, value VARCHAR, PRIMARY KEY (key, group))""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows1(key, group, value) VALUES (10, 10, '1010')""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows1(key, group, value) VALUES (10, 11, '1011')""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows1(key, group, value) VALUES (10, 12, '1012')""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows1(key, group, value) VALUES (20, 20, '2020')""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows1(key, group, value) VALUES (20, 21, '2021')""")
+        session.execute(s"""INSERT INTO $ks.delete_wide_rows1(key, group, value) VALUES (20, 22, '2022')""")
+       },
+
+      Future {
+        session.execute(
+          s"""CREATE TYPE $ks."Attachment" (
+            |  "Id" text,
+            |  "MimeType" text,
+            |  "FileName" text
+            |)
+          """.stripMargin)
+        session.execute(
+          s"""CREATE TABLE $ks."Interaction" (
+            |  "Id" text PRIMARY KEY,
+            |  "Attachments" map<text,frozen<"Attachment">>,
+            |  "ContactId" text
+            |)
+          """.stripMargin)
+        session.execute(
+          s"""INSERT INTO $ks."Interaction"(
+            |  "Id",
+            |  "Attachments",
+            |  "ContactId"
+            |)
+            |VALUES (
+            |  '000000a5ixIEvmPD',
+            |  null,
+            |  'xcb9HMoQ'
+            |)
+          """.stripMargin)
+        session.execute(
+          s"""UPDATE $ks."Interaction"
+            |SET
+            |  "Attachments" = "Attachments" + {'rVpgK':
+            |  {"Id":'rVpgK',
+            |  "MimeType":'text/plain',
+            |  "FileName":'notes.txt'}}
+            |WHERE "Id" = '000000a5ixIEvmPD'
+          """.stripMargin)
+      },
+
+      Future {
+        val tableName = "caseclasstuplegrouped"
+        session.execute(s"""CREATE TABLE IF NOT EXISTS $ks.$tableName (key INT, group INT, value VARCHAR, PRIMARY KEY (key, group))""")
+        session.execute(s"""INSERT INTO $ks.$tableName (key, group, value) VALUES (10, 10, '1010')""")
+        session.execute(s"""INSERT INTO $ks.$tableName (key, group, value) VALUES (10, 11, '1011')""")
+        session.execute(s"""INSERT INTO $ks.$tableName (key, group, value) VALUES (10, 12, '1012')""")
+        session.execute(s"""INSERT INTO $ks.$tableName (key, group, value) VALUES (20, 20, '2020')""")
+        session.execute(s"""INSERT INTO $ks.$tableName (key, group, value) VALUES (20, 21, '2021')""")
+        session.execute(s"""INSERT INTO $ks.$tableName (key, group, value) VALUES (20, 22, '2022')""")
+      },
+      Future {
         createKeyspace(session, s""""MixedSpace"""")
         session.execute(s"""CREATE TABLE "MixedSpace"."MixedCase"(key INT PRIMARY KEY, value INT)""")
         session.execute(s"""CREATE TABLE "MixedSpace"."MiXEDCase"(key INT PRIMARY KEY, value INT)""")
@@ -682,21 +788,16 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
     results should contain ((KeyGroup(2, 100), (2, 100, "0002")))
     results should contain ((KeyGroup(3, 300), (3, 300, "0003")))
   }
+  it should "allow the use of PER PARTITION LIMITs " in skipIfProtocolVersionLT(V4){
+    val result = sc.cassandraTable(ks, "clustering_time").perPartitionLimit(1).collect
+    result.size should be (1)
+  }
 
   it should "allow to read Cassandra table as Array of KV tuples of a case class and a tuple grouped by partition key" in {
 
-    conn.withSessionDo { session =>
-      session.execute(s"""CREATE TABLE IF NOT EXISTS $ks.wide_rows(key INT, group INT, value VARCHAR, PRIMARY KEY (key, group))""")
-      session.execute(s"""INSERT INTO $ks.wide_rows(key, group, value) VALUES (10, 10, '1010')""")
-      session.execute(s"""INSERT INTO $ks.wide_rows(key, group, value) VALUES (10, 11, '1011')""")
-      session.execute(s"""INSERT INTO $ks.wide_rows(key, group, value) VALUES (10, 12, '1012')""")
-      session.execute(s"""INSERT INTO $ks.wide_rows(key, group, value) VALUES (20, 20, '2020')""")
-      session.execute(s"""INSERT INTO $ks.wide_rows(key, group, value) VALUES (20, 21, '2021')""")
-      session.execute(s"""INSERT INTO $ks.wide_rows(key, group, value) VALUES (20, 22, '2022')""")
-    }
-
+    val tableName = "caseclasstuplegrouped"
     val results = sc
-      .cassandraTable[(Int, Int, String)](ks, "wide_rows")
+      .cassandraTable[(Int, Int, String)](ks, tableName)
       .select("key", "group", "value")
       .keyBy[Key]
       .spanByKey
@@ -980,43 +1081,7 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
   }
 
   it should "handle upper case characters in UDT fields" in {
-    conn.withSessionDo { session =>
-      session.execute(
-        s"""CREATE TYPE $ks."Attachment" (
-          |  "Id" text,
-          |  "MimeType" text,
-          |  "FileName" text
-          |)
-        """.stripMargin)
-      session.execute(
-        s"""CREATE TABLE $ks."Interaction" (
-          |  "Id" text PRIMARY KEY,
-          |  "Attachments" map<text,frozen<"Attachment">>,
-          |  "ContactId" text
-          |)
-        """.stripMargin)
-      session.execute(
-        s"""INSERT INTO $ks."Interaction"(
-          |  "Id",
-          |  "Attachments",
-          |  "ContactId"
-          |)
-          |VALUES (
-          |  '000000a5ixIEvmPD',
-          |  null,
-          |  'xcb9HMoQ'
-          |)
-        """.stripMargin)
-      session.execute(
-        s"""UPDATE $ks."Interaction"
-          |SET
-          |  "Attachments" = "Attachments" + {'rVpgK':
-          |  {"Id":'rVpgK',
-          |  "MimeType":'text/plain',
-          |  "FileName":'notes.txt'}}
-          |WHERE "Id" = '000000a5ixIEvmPD'
-        """.stripMargin)
-    }
+
     val tableRdd = sc.cassandraTable(ks, "Interaction")
     val dataColumns = tableRdd.map(row => row.getString("ContactId"))
     dataColumns.count shouldBe 1
@@ -1158,17 +1223,6 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
 
   "RDD.deleteFromCassandra" should "delete rows just selected from the C*" in {
 
-    conn.withSessionDo { session =>
-      session.execute(s"""DROP TABLE IF EXISTS $ks.delete_wide_rows1""")
-      session.execute(s"""CREATE TABLE $ks.delete_wide_rows1(key INT, group INT, value VARCHAR, PRIMARY KEY (key, group))""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows1(key, group, value) VALUES (10, 10, '1010')""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows1(key, group, value) VALUES (10, 11, '1011')""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows1(key, group, value) VALUES (10, 12, '1012')""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows1(key, group, value) VALUES (20, 20, '2020')""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows1(key, group, value) VALUES (20, 21, '2021')""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows1(key, group, value) VALUES (20, 22, '2022')""")
-    }
-
     sc.cassandraTable(ks, "delete_wide_rows1").where("key = 20")
       .deleteFromCassandra(ks, "delete_wide_rows1")
 
@@ -1187,17 +1241,6 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
   }
 
   it should "delete rows with specified mapping" in {
-
-    conn.withSessionDo { session =>
-      session.execute(s"""DROP TABLE IF EXISTS $ks.delete_wide_rows2""")
-      session.execute(s"""CREATE TABLE $ks.delete_wide_rows2(key INT, group INT, value VARCHAR, PRIMARY KEY (key, group))""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows2(key, group, value) VALUES (10, 10, '1010')""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows2(key, group, value) VALUES (10, 11, '1011')""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows2(key, group, value) VALUES (10, 12, '1012')""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows2(key, group, value) VALUES (20, 20, '2020')""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows2(key, group, value) VALUES (20, 21, '2021')""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows2(key, group, value) VALUES (20, 22, '2022')""")
-    }
 
     sc.cassandraTable[(Int, Int)](ks, "delete_wide_rows2")
       .select("group", "key").where("key = 20")
@@ -1219,16 +1262,6 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
 
   it should "delete rows with joins" in {
 
-    conn.withSessionDo { session =>
-      session.execute(s"""DROP TABLE IF EXISTS $ks.delete_wide_rows3""")
-      session.execute(s"""CREATE TABLE $ks.delete_wide_rows3(key INT, group INT, value VARCHAR, PRIMARY KEY (key, group))""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows3(key, group, value) VALUES (10, 10, '1010')""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows3(key, group, value) VALUES (10, 11, '1011')""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows3(key, group, value) VALUES (10, 12, '1012')""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows3(key, group, value) VALUES (1, 20, '2020')""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows3(key, group, value) VALUES (2, 21, '2021')""")
-    }
-
     sc.cassandraTable(ks, "delete_wide_rows3").joinWithCassandraTable(ks, "key_value").map(_._1)
       .deleteFromCassandra(ks, "delete_wide_rows3")
 
@@ -1248,16 +1281,6 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
 
   it should "delete rows with composite key" in {
 
-    conn.withSessionDo { session =>
-      session.execute(s"""DROP TABLE IF EXISTS $ks.delete_wide_rows4""")
-      session.execute(s"""CREATE TABLE $ks.delete_wide_rows4(key INT, group TEXT, group2 INT, value VARCHAR, PRIMARY KEY ((key, group), group2))""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows4(key, group, group2, value) VALUES (10, '1', 1, '1010')""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows4(key, group, group2, value) VALUES (10, '1', 2, '1011')""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows4(key, group, group2, value) VALUES (10, '2', 1, '1012')""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows4(key, group, group2, value) VALUES (1, '2', 2, '2020')""")
-      session.execute(s"""INSERT INTO $ks.delete_wide_rows4(key, group, group2, value) VALUES (2, '2', 1, '2021')""")
-    }
-
     sc.parallelize(Seq((10, "1", 1), (10, "2", 1)))
       .deleteFromCassandra(ks, "delete_wide_rows4")
 
@@ -1271,18 +1294,7 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
 
   it should "delete just selected column from the C*" in {
 
-    conn.withSessionDo { session =>
-      session.execute(s"""DROP TABLE IF EXISTS $ks.delete_short_rows""")
-      session.execute(s"""CREATE TABLE $ks.delete_short_rows(key INT, group INT, value VARCHAR, PRIMARY KEY (key,group))""")
-      session.execute(s"""INSERT INTO $ks.delete_short_rows(key, group, value) VALUES (10, 10, '1010')""")
-      session.execute(s"""INSERT INTO $ks.delete_short_rows(key, group, value) VALUES (10, 11, '1011')""")
-      session.execute(s"""INSERT INTO $ks.delete_short_rows(key, group, value) VALUES (10, 12, '1012')""")
-      session.execute(s"""INSERT INTO $ks.delete_short_rows(key, group, value) VALUES (20, 20, '2020')""")
-      session.execute(s"""INSERT INTO $ks.delete_short_rows(key, group, value) VALUES (20, 21, '2021')""")
-      session.execute(s"""INSERT INTO $ks.delete_short_rows(key, group, value) VALUES (20, 22, '2022')""")
-    }
-
-    sc.cassandraTable(ks, "delete_short_rows").where("key = 20")
+   sc.cassandraTable(ks, "delete_short_rows").where("key = 20")
       .deleteFromCassandra(ks, "delete_short_rows", SomeColumns("value"))
 
     val results = sc.cassandraTable[(Int, Int, Option[String])](ks, "delete_short_rows")
@@ -1300,17 +1312,6 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
   }
 
   it should "delete base on partition key only" in {
-
-    conn.withSessionDo { session =>
-      session.execute(s"""DROP TABLE IF EXISTS $ks.delete_short_rows_partition""")
-      session.execute(s"""CREATE TABLE $ks.delete_short_rows_partition(key INT, group INT, value VARCHAR, PRIMARY KEY (key,group))""")
-      session.execute(s"""INSERT INTO $ks.delete_short_rows_partition(key, group, value) VALUES (10, 10, '1010')""")
-      session.execute(s"""INSERT INTO $ks.delete_short_rows_partition(key, group, value) VALUES (10, 11, '1011')""")
-      session.execute(s"""INSERT INTO $ks.delete_short_rows_partition(key, group, value) VALUES (10, 12, '1012')""")
-      session.execute(s"""INSERT INTO $ks.delete_short_rows_partition(key, group, value) VALUES (20, 20, '2020')""")
-      session.execute(s"""INSERT INTO $ks.delete_short_rows_partition(key, group, value) VALUES (20, 21, '2021')""")
-      session.execute(s"""INSERT INTO $ks.delete_short_rows_partition(key, group, value) VALUES (20, 22, '2022')""")
-    }
 
     sc.parallelize(Seq(Key(20)))
       .deleteFromCassandra(ks, "delete_short_rows_partition", keyColumns = SomeColumns("key"))

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/RDDSpec.scala
@@ -9,6 +9,8 @@ import com.datastax.spark.connector.embedded.SparkTemplate._
 import com.datastax.spark.connector.embedded.YamlTransformations
 import com.datastax.spark.connector.rdd.partitioner.EndpointPartition
 
+import com.datastax.driver.core.ProtocolVersion._
+
 case class KVRow(key: Int)
 
 case class KVWithOptionRow(key: Option[Int])
@@ -385,6 +387,7 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
     someCass.readConf.consistencyLevel should be (com.datastax.driver.core.ConsistencyLevel.ONE)
   }
 
+
   it should "be joinable on both partitioning key and clustering key" in {
     val source = sc.parallelize(keys).map(x => (x, x * 100))
     val someCass = source.joinWithCassandraTable(ks, wideTable, joinColumns = SomeColumns("key", "group"))
@@ -410,12 +413,23 @@ class RDDSpec extends SparkCassandraITFlatSpecBase {
     result should have size (3 * keys.length)
   }
 
-  it should "have be able to be counted" in {
+  it should "be able to be counted" in {
     val source = sc.parallelize(keys).map(x => (x, x * 100))
     val someCass = source.joinWithCassandraTable(ks, wideTable).on(SomeColumns("key", "group")).cassandraCount()
     someCass should be(201)
 
   }
+
+  it should "should be joinable with a PER PARTITION LIMIT limit" in skipIfProtocolVersionLT(V4){
+    val source = sc.parallelize(keys).map(x => (x, x * 100))
+    val someCass = source
+      .joinWithCassandraTable(ks, wideTable, joinColumns = SomeColumns("key", "group"))
+      .perPartitionLimit(1)
+      .collect
+
+    source.collect should have length (someCass.length)
+  }
+
 
   "A CassandraRDD " should "be joinable with Cassandra" in {
     val source = sc.cassandraTable(ks, otherTable)

--- a/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/RDDJavaFunctions.java
+++ b/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/RDDJavaFunctions.java
@@ -112,7 +112,7 @@ public class RDDJavaFunctions<T> extends RDDAndDStreamCommonJavaFunctions<T> {
 
         CassandraConnector connector = defaultConnector();
         Option<ClusteringOrder> clusteringOrder = Option.empty();
-        Option<Object> limit = Option.empty();
+        Option<CassandraLimit> limit = Option.empty();
         CqlWhereClause whereClause = CqlWhereClause.empty();
         ReadConf readConf = ReadConf.fromSparkConf(rdd.conf());
 

--- a/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraJavaPairRDD.java
+++ b/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraJavaPairRDD.java
@@ -124,6 +124,16 @@ public class CassandraJavaPairRDD<K, V> extends JavaPairRDD<K, V> {
     }
 
     /**
+     * Adds the PER PARTITION LIMIT clause to CQL select statement. The limit will be applied for each
+     * Cassandra Partition
+     */
+    @SuppressWarnings("unchecked")
+    public CassandraJavaPairRDD<K, V> perPartitionLimit(Long rowsNumber) {
+        CassandraRDD<Tuple2<K, V>> newRDD = rdd().perPartitionLimit(rowsNumber);
+        return wrap(newRDD);
+    }
+
+    /**
      * Returns the names of columns to be selected from the table.
      */
     @SuppressWarnings("RedundantCast")

--- a/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraJavaRDD.java
+++ b/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/rdd/CassandraJavaRDD.java
@@ -151,6 +151,15 @@ public class CassandraJavaRDD<R> extends JavaRDD<R> {
     }
 
     /**
+     * Adds the PER PARTITION LIMIT clause to CQL select statement. The limit will be applied for each
+     * Cassandra Partition
+     */
+    public CassandraJavaRDD<R> perPartitionLimit(Long rowsNumber) {
+        CassandraRDD<R> newRDD = rdd().perPartitionLimit(rowsNumber);
+        return wrap(newRDD);
+    }
+
+    /**
      * Applies a function to each item, and groups consecutive items having the same value together.
      * Contrary to `groupBy`, items from the same group must be already next to each other in the
      * original collection. Works locally on each partition, so items from different partitions will

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/package.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/package.scala
@@ -1,6 +1,6 @@
 package com.datastax.spark
 
-import com.datastax.spark.connector.rdd.CassandraTableScanRDD
+import com.datastax.spark.connector.rdd.{CassandraTableScanRDD, SparkPartitionLimit}
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.DataFrame
@@ -72,7 +72,6 @@ package object connector {
   implicit def toCassandraTableScanRDDPairFunctions[K, V](
     rdd: CassandraTableScanRDD[(K, V)]): CassandraTableScanPairRDDFunctions[K, V] =
     new CassandraTableScanPairRDDFunctions(rdd)
-
 
   implicit class ColumnNameFunctions(val columnName: String) extends AnyVal {
     def writeTime: WriteTime = WriteTime(columnName)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/AbstractCassandraJoin.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/AbstractCassandraJoin.scala
@@ -2,6 +2,7 @@ package com.datastax.spark.connector.rdd
 
 import com.datastax.driver.core.Session
 import com.datastax.spark.connector._
+import com.datastax.spark.connector.rdd.CassandraLimit._
 import com.datastax.spark.connector.util.CqlWhereParser.{EqPredicate, InListPredicate, InPredicate, RangePredicate}
 import com.datastax.spark.connector.util.Quote._
 import com.datastax.spark.connector.util.{CountingIterator, CqlWhereParser}
@@ -119,7 +120,7 @@ private[rdd] trait AbstractCassandraJoin[L, R] {
     logDebug(s"SelectedColumns : $selectedColumnRefs -- JoinColumnNames : $joinColumnNames")
     val columns = selectedColumnRefs.map(_.cql).mkString(", ")
     val joinWhere = joinColumnNames.map(_.columnName).map(name => s"${quote(name)} = :$name")
-    val limitClause = limit.map(limit => s"LIMIT $limit").getOrElse("")
+    val limitClause = limitToClause(limit)
     val orderBy = clusteringOrder.map(_.toCql(tableDef)).getOrElse("")
     val filter = (where.predicates ++ joinWhere).mkString(" AND ")
     val quotedKeyspaceName = quote(keyspaceName)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
@@ -27,7 +27,7 @@ class CassandraJoinRDD[L, R] private[connector](
     val columnNames: ColumnSelector = AllColumns,
     val joinColumns: ColumnSelector = PartitionKeyColumns,
     val where: CqlWhereClause = CqlWhereClause.empty,
-    val limit: Option[Long] = None,
+    val limit: Option[CassandraLimit] = None,
     val clusteringOrder: Option[ClusteringOrder] = None,
     val readConf: ReadConf = ReadConf(),
     manualRowReader: Option[RowReader[R]] = None,
@@ -53,7 +53,7 @@ class CassandraJoinRDD[L, R] private[connector](
   override protected def copy(
     columnNames: ColumnSelector = columnNames,
     where: CqlWhereClause = where,
-    limit: Option[Long] = limit,
+    limit: Option[CassandraLimit] = limit,
     clusteringOrder: Option[ClusteringOrder] = None,
     readConf: ReadConf = readConf,
     connector: CassandraConnector = connector

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
@@ -27,7 +27,7 @@ class CassandraLeftJoinRDD[L, R] private[connector](
     val columnNames: ColumnSelector = AllColumns,
     val joinColumns: ColumnSelector = PartitionKeyColumns,
     val where: CqlWhereClause = CqlWhereClause.empty,
-    val limit: Option[Long] = None,
+    val limit: Option[CassandraLimit] = None,
     val clusteringOrder: Option[ClusteringOrder] = None,
     val readConf: ReadConf = ReadConf(),
     manualRowReader: Option[RowReader[R]] = None,
@@ -53,7 +53,7 @@ class CassandraLeftJoinRDD[L, R] private[connector](
   override protected def copy(
     columnNames: ColumnSelector = columnNames,
     where: CqlWhereClause = where,
-    limit: Option[Long] = limit,
+    limit: Option[CassandraLimit] = limit,
     clusteringOrder: Option[ClusteringOrder] = None,
     readConf: ReadConf = readConf,
     connector: CassandraConnector = connector

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLimit.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLimit.scala
@@ -1,0 +1,25 @@
+package com.datastax.spark.connector.rdd
+
+sealed trait CassandraLimit
+
+case class CassandraPartitionLimit(rowsNumber: Long) extends CassandraLimit {
+  require(rowsNumber > 0, s"$rowsNumber <= 0. Per Partition Limits must be greater than 0")
+}
+case class SparkPartitionLimit(rowsNumber: Long) extends CassandraLimit {
+  require(rowsNumber > 0, s"$rowsNumber <= 0. Limits must be greater than 0")
+}
+
+object CassandraLimit {
+
+  def limitToClause
+  (limit: Option[CassandraLimit]): String = limit match {
+    case Some(SparkPartitionLimit(rowsNumber)) => s"LIMIT $rowsNumber"
+    case Some(CassandraPartitionLimit(rowsNumber)) => s"PER PARTITION LIMIT $rowsNumber"
+    case None => ""
+  }
+
+  def limitForIterator(limit: Option[CassandraLimit]): Option[Long] = limit.collect {
+    case SparkPartitionLimit(rowsNumber) => rowsNumber
+  }
+}
+

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/EmptyCassandraRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/EmptyCassandraRDD.scala
@@ -15,7 +15,7 @@ class EmptyCassandraRDD[R : ClassTag](
     val tableName: String,
     val columnNames: ColumnSelector = AllColumns,
     val where: CqlWhereClause = CqlWhereClause.empty,
-    val limit: Option[Long] = None,
+    val limit: Option[CassandraLimit] = None,
     val clusteringOrder: Option[ClusteringOrder] = None,
     val readConf: ReadConf = ReadConf())
   extends CassandraRDD[R](sc, Seq.empty) {
@@ -25,7 +25,7 @@ class EmptyCassandraRDD[R : ClassTag](
   override protected def copy(
       columnNames: ColumnSelector = columnNames,
       where: CqlWhereClause = where,
-      limit: Option[Long] = limit,
+      limit: Option[CassandraLimit] = limit,
       clusteringOrder: Option[ClusteringOrder] = None,
       readConf: ReadConf = readConf,
       connector: CassandraConnector = connector) = {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/CassandraStreamingRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/CassandraStreamingRDD.scala
@@ -2,7 +2,7 @@ package com.datastax.spark.connector.streaming
 
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.rdd.reader._
-import com.datastax.spark.connector.rdd.{CassandraTableScanRDD, ClusteringOrder, CqlWhereClause, ReadConf}
+import com.datastax.spark.connector.rdd._
 import com.datastax.spark.connector.{AllColumns, ColumnSelector}
 import org.apache.spark.streaming.StreamingContext
 
@@ -18,7 +18,7 @@ class CassandraStreamingRDD[R] private[connector] (
     columns: ColumnSelector = AllColumns,
     where: CqlWhereClause = CqlWhereClause.empty,
     empty: Boolean = false,
-    limit: Option[Long] = None,
+    limit: Option[CassandraLimit] = None,
     clusteringOrder: Option[ClusteringOrder] = None,
     readConf: ReadConf = ReadConf())(
   implicit

--- a/spark-cassandra-connector/src/test/java/com/datastax/spark/connector/japi/rdd/CassandraJavaPairRDDTest.java
+++ b/spark-cassandra-connector/src/test/java/com/datastax/spark/connector/japi/rdd/CassandraJavaPairRDDTest.java
@@ -114,4 +114,13 @@ public class CassandraJavaPairRDDTest {
         assertThat(jrdd.limit(1L).rdd(), is(rdd2));
     }
 
+    @Test
+    public void testPerPartitionLimit() {
+        CassandraRDD<Tuple2<String, Integer>> rdd = mock(CassandraRDD.class);
+        CassandraRDD<Tuple2<String, Integer>> rdd2 = mock(CassandraRDD.class);
+        when(rdd.perPartitionLimit(1L)).thenReturn(rdd2);
+        CassandraJavaPairRDD<String, Integer> jrdd = new CassandraJavaPairRDD<>(rdd, String.class, Integer.class);
+        assertThat(jrdd.perPartitionLimit(1L).rdd(), is(rdd2));
+    }
+
 }

--- a/spark-cassandra-connector/src/test/java/com/datastax/spark/connector/japi/rdd/CassandraJavaRDDTest.java
+++ b/spark-cassandra-connector/src/test/java/com/datastax/spark/connector/japi/rdd/CassandraJavaRDDTest.java
@@ -3,6 +3,7 @@ package com.datastax.spark.connector.japi.rdd;
 import static com.datastax.spark.connector.japi.CassandraJavaUtil.column;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+
 import org.junit.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -111,4 +112,12 @@ public class CassandraJavaRDDTest {
         assertThat(jrdd.limit(1L).rdd(), is(rdd2));
     }
 
+    @Test
+    public void testPerPartitionLimit() {
+        CassandraRDD<Integer> rdd = mock(CassandraRDD.class);
+        CassandraRDD<Integer> rdd2 = mock(CassandraRDD.class);
+        when(rdd.perPartitionLimit(1L)).thenReturn(rdd2);
+        CassandraJavaRDD<Integer> jrdd = new CassandraJavaRDD<>(rdd, Integer.class);
+        assertThat(jrdd.perPartitionLimit(1L).rdd(), is(rdd2));
+    }
 }


### PR DESCRIPTION
c2f1cdb (Russell Spitzer, 6 minutes ago)
    SPARKC-446: Enable PerPartitionLimit as a CassandraRDD Function

    Cassandra 3.6 enables PerPartitionLimit. To accesses this the underlying
    CassandraRDD limit field now holds a `CassandraLimit` opition. There are
    two possible values at the moment.

    SparkPartitionLimit - Which limits the number of rows returned per Spark
    Partition CassandraPartitionLimit - Which limits the number of rows
    returned per Cassandra Partition

    They are accessed through the same api as previously existed

    CassandraRDD.limit() - Sets the SparkPartitionLimit like previously
    CassandraRDD.perPartitionLimit - Sets the CassandraPartitionLimit

ce8ea46 (Russell Spitzer, 6 minutes ago)
    SPARKC-446: Change Cassandra Version to 3.6

    Only 3.6 Supports Per Partition Limit