### PR TITLE
SPARCK-471: Automatic Adjustment of Max Connections

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -26,6 +26,13 @@
   <td>Compression to use (LZ4, SNAPPY or NONE)</td>
 </tr>
 <tr>
+  <td><code>connection.connections_per_executor_max</code></td>
+  <td>None</td>
+  <td>Maximum number of connections per Host set on each Executor JVM. Will be
+updated to DefaultParallelism / Executors for Spark Commands. Defaults to 1
+ if not specifying and not in a Spark Env</td>
+</tr>
+<tr>
   <td><code>connection.factory</code></td>
   <td>DefaultConnectionFactory</td>
   <td>Name of a Scala module or class implementing

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/DataFrameFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/DataFrameFunctions.scala
@@ -21,7 +21,7 @@ class DataFrameFunctions(dataFrame: DataFrame) extends Serializable {
     partitionKeyColumns: Option[Seq[String]] = None,
     clusteringKeyColumns: Option[Seq[String]] = None)(
   implicit
-    connector: CassandraConnector = CassandraConnector(sparkContext.getConf)): Unit = {
+    connector: CassandraConnector = CassandraConnector(sparkContext)): Unit = {
 
     val protocolVersion = connector.
       withClusterDo(_.getConfiguration.getProtocolOptions.getProtocolVersion)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
@@ -29,7 +29,7 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
     columns: ColumnSelector = AllColumns,
     writeConf: WriteConf = WriteConf.fromSparkConf(sparkContext.getConf))(
   implicit
-    connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+    connector: CassandraConnector = CassandraConnector(sparkContext),
     rwf: RowWriterFactory[T]): Unit = {
 
     val writer = TableWriter(connector, keyspaceName, tableName, columns, writeConf)
@@ -57,7 +57,7 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
     columns: ColumnSelector = AllColumns,
     writeConf: WriteConf = WriteConf.fromSparkConf(sparkContext.getConf))(
   implicit
-    connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+    connector: CassandraConnector = CassandraConnector(sparkContext),
     rwf: RowWriterFactory[T]): Unit = {
 
     connector.withSessionDo(session => session.execute(table.cql))
@@ -86,7 +86,7 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
     columns: ColumnSelector = AllColumns,
     writeConf: WriteConf = WriteConf.fromSparkConf(sparkContext.getConf))(
   implicit
-    connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+    connector: CassandraConnector = CassandraConnector(sparkContext),
     rwf: RowWriterFactory[T],
     columnMapper: ColumnMapper[T]): Unit = {
 
@@ -108,7 +108,7 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
     keyColumns: ColumnSelector = PrimaryKeyColumns,
     writeConf: WriteConf = WriteConf.fromSparkConf(sparkContext.getConf))(
   implicit
-    connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+    connector: CassandraConnector = CassandraConnector(sparkContext),
     rwf: RowWriterFactory[T]): Unit = {
     // column delete require full primary key, partition key is enough otherwise
     val columnDelete = deleteColumns match {
@@ -154,7 +154,7 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
     selectedColumns: ColumnSelector = AllColumns,
     joinColumns: ColumnSelector = PartitionKeyColumns)(
   implicit 
-    connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+    connector: CassandraConnector = CassandraConnector(sparkContext),
     newType: ClassTag[R], rrf: RowReaderFactory[R], 
     ev: ValidRDDType[R],
     currentType: ClassTag[T], 
@@ -200,7 +200,7 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
     selectedColumns: ColumnSelector = AllColumns,
     joinColumns: ColumnSelector = PartitionKeyColumns)(
   implicit
-    connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+    connector: CassandraConnector = CassandraConnector(sparkContext),
     newType: ClassTag[R], rrf: RowReaderFactory[R],
     ev: ValidRDDType[R],
     currentType: ClassTag[T],
@@ -231,7 +231,7 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
     partitionsPerHost: Int = 10,
     partitionKeyMapper: ColumnSelector = PartitionKeyColumns)(
   implicit
-    connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+    connector: CassandraConnector = CassandraConnector(sparkContext),
     currentType: ClassTag[T],
     rwf: RowWriterFactory[T]): CassandraPartitionedRDD[T] = {
 
@@ -286,7 +286,7 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
     tableName: String,
     partitionKeyMapper: ColumnSelector = PartitionKeyColumns)(
   implicit
-    connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+    connector: CassandraConnector = CassandraConnector(sparkContext),
     currentType: ClassTag[T],
     rwf: RowWriterFactory[T]): RDD[(Set[InetAddress], T)] = {
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/SparkContextFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/SparkContextFunctions.scala
@@ -49,7 +49,7 @@ class SparkContextFunctions(@transient val sc: SparkContext) extends Serializabl
     keyspace: String,
     table: String)(
   implicit
-    connector: CassandraConnector = CassandraConnector(sc.getConf),
+    connector: CassandraConnector = CassandraConnector(sc),
     readConf: ReadConf = ReadConf.fromSparkConf(sc.getConf),
     ct: ClassTag[T], rrf: RowReaderFactory[T],
     ev: ValidRDDType[T]) = new CassandraTableScanRDD[T](sc, connector, keyspace, table, readConf = readConf)
@@ -57,7 +57,7 @@ class SparkContextFunctions(@transient val sc: SparkContext) extends Serializabl
   /** Produces the empty CassandraRDD which does not perform any validation and it does not even
     * try to return any rows. */
   def emptyCassandraTable[T](keyspace: String, table: String)
-                            (implicit connector: CassandraConnector = CassandraConnector(sc.getConf),
+                            (implicit connector: CassandraConnector = CassandraConnector(sc),
                              readConf: ReadConf = ReadConf.fromSparkConf(sc.getConf),
                              ct: ClassTag[T], rrf: RowReaderFactory[T],
                              ev: ValidRDDType[T]) =

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
@@ -1,5 +1,6 @@
 package com.datastax.spark.connector.rdd
 
+import com.datastax.driver.core.HostDistance
 import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.rdd.ClusteringOrder.{Ascending, Descending}
 import com.datastax.spark.connector.rdd.reader._
@@ -25,6 +26,7 @@ abstract class CassandraRDD[R : ClassTag](
   type Self <: CassandraRDD[R]
   
   ConfigCheck.checkConfig(sc.getConf)
+
 
   protected[connector] def keyspaceName: String
 
@@ -235,11 +237,11 @@ abstract class CassandraRDD[R : ClassTag](
 
 object CassandraRDD {
   def apply[T](sc: SparkContext, keyspaceName: String, tableName: String)
-              (implicit ct: ClassTag[T], rrf: RowReaderFactory[T]): CassandraRDD[T] =
+              (implicit ct: ClassTag[T], rrf: RowReaderFactory[T]): CassandraRDD[T] = {
 
     new CassandraTableScanRDD[T](
       sc,
-      CassandraConnector(sc.getConf),
+      CassandraConnector(sc),
       keyspaceName,
       tableName,
       AllColumns,
@@ -248,13 +250,14 @@ object CassandraRDD {
       None,
       ReadConf.fromSparkConf(sc.getConf)
     )
+  }
 
   def apply[K, V](sc: SparkContext, keyspaceName: String, tableName: String)
                  (implicit keyCT: ClassTag[K], valueCT: ClassTag[V], rrf: RowReaderFactory[(K, V)]): CassandraRDD[(K, V)] =
 
     new CassandraTableScanRDD[(K, V)](
       sc,
-      CassandraConnector(sc.getConf),
+      CassandraConnector(sc),
       keyspaceName,
       tableName,
       AllColumns,

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
@@ -447,7 +447,7 @@ object CassandraTableScanRDD {
 
     new CassandraTableScanRDD[T](
       sc = sc,
-      connector = CassandraConnector(sc.getConf),
+      connector = CassandraConnector(sc),
       keyspaceName = keyspaceName,
       tableName = tableName,
       readConf = ReadConf.fromSparkConf(sc.getConf),
@@ -467,7 +467,7 @@ object CassandraTableScanRDD {
 
     val rdd = new CassandraTableScanRDD[(K, V)](
       sc = sc,
-      connector = CassandraConnector(sc.getConf),
+      connector = CassandraConnector(sc),
       keyspaceName = keyspaceName,
       tableName = tableName,
       readConf = ReadConf.fromSparkConf(sc.getConf),

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/DStreamFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/DStreamFunctions.scala
@@ -66,7 +66,7 @@ class DStreamFunctions[T](dstream: DStream[T])
     keyColumns: ColumnSelector = PrimaryKeyColumns,
     writeConf: WriteConf = WriteConf.fromSparkConf(sparkContext.getConf))(
   implicit
-    connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+    connector: CassandraConnector = CassandraConnector(sparkContext),
     rwf: RowWriterFactory[T]): Unit = {
 
     // column delete require full primary key, partition key is enough otherwise
@@ -118,7 +118,7 @@ class DStreamFunctions[T](dstream: DStream[T])
     selectedColumns: ColumnSelector = AllColumns,
     joinColumns: ColumnSelector = PartitionKeyColumns)(
   implicit
-    connector: CassandraConnector = CassandraConnector(sparkContext.getConf),
+    connector: CassandraConnector = CassandraConnector(sparkContext),
     newType: ClassTag[R],
     @transient rrf: RowReaderFactory[R],
     ev: ValidRDDType[R],

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/StreamingContextFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/streaming/StreamingContextFunctions.scala
@@ -14,7 +14,7 @@ class StreamingContextFunctions (ssc: StreamingContext) extends SparkContextFunc
 
   override def cassandraTable[T](keyspace: String, table: String)(
     implicit
-      connector: CassandraConnector = CassandraConnector(ssc.sparkContext.getConf),
+      connector: CassandraConnector = CassandraConnector(ssc.sparkContext),
       readConf: ReadConf = ReadConf.fromSparkConf(sc.getConf),
       ct: ClassTag[T],
       rrf: RowReaderFactory[T],

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WritableToCassandra.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WritableToCassandra.scala
@@ -8,7 +8,7 @@ abstract class WritableToCassandra[T] {
 
   def sparkContext: SparkContext
 
-  private[connector] lazy val connector = CassandraConnector(sparkContext.getConf)
+  private[connector] lazy val connector = CassandraConnector(sparkContext)
 
   /**
    * Saves the data from [[org.apache.spark.rdd.RDD RDD]] to a Cassandra table.

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/cql/CassandraConnectorConfSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/cql/CassandraConnectorConfSpec.scala
@@ -20,6 +20,15 @@ class CassandraConnectorConfSpec extends FlatSpec with Matchers {
     conf_a should equal (conf_1)
   }
 
+  it should "match a conf with all the same settings but maxConnectionsPerHost" in {
+    val conf_a = CassandraConnectorConf(
+      new SparkConf().set(CassandraConnectorConf.MaxConnectionsPerExecutorParam.name, "20"))
+    val conf_b = CassandraConnectorConf(
+      new SparkConf().set(CassandraConnectorConf.MaxConnectionsPerExecutorParam.name, "13"))
+
+    conf_a should equal (conf_b)
+  }
+
   it should "resolve default SSL settings correctly" in {
     val sparkConf = new SparkConf(loadDefaults = false)
 


### PR DESCRIPTION
We will boost up the number of CassandraDriver Connections based
on the number of cores allocated to the machine. The user will also be
able to force a parameter for this value. This can be changed at runtime
so we will set it at the creation time of the RDD based on the driver's
information at that time.