### PR TITLE
SPARKC-472-b1.6 Always use the codec cache when reading from Driver Rows

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+1.6.5
+* Optimize Spark Sql Count(*) with CassandraCount (SPARKC-412)
+* Fix Incomplete Shading of Guava (SPARKC-461)
+* Replace all Logging Dependencies from Spark-Core with Internal Class (SPARKC-460)
+* Remove Java8 Dependency in CassandraConnectorConf (SPARKC-462)
+
 1.6.4
 * Find converters for classes on different classloaders (SPARKC-363)
 * Fix CassandraConnector and Session Race Condition (SPARKC-441)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/CassandraRow.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/CassandraRow.scala
@@ -118,6 +118,9 @@ case class CassandraRowMetadata(columnNames: IndexedSeq[String],
         s"Available columns are: ${columnNames.mkString("[", ", ", "]")}")
   }
 
+  def codecs(name: String): TypeCodec[AnyRef] =
+    codecs(namesToIndex(name))
+
   def unaliasedColumnNames = resultSetColumnNames.getOrElse(columnNames)
 }
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/FunctionBasedRowReader.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/FunctionBasedRowReader.scala
@@ -20,7 +20,7 @@ class FunctionBasedRowReader1[R, A0](f: A0 => R)(
   implicit a0c: TypeConverter[A0], @transient override val ct: ClassTag[R]) extends FunctionBasedRowReader[R] {
 
   override def read(row: Row, rowMetaData: CassandraRowMetadata) =
-    f(a0c.convert(GettableData.get(row, 0)))
+    f(a0c.convert(GettableData.get(row, 0, rowMetaData.codecs(0))))
 
 }
 
@@ -33,8 +33,8 @@ class FunctionBasedRowReader2[R, A0, A1](f: (A0, A1) => R)(
 
   override def read(row: Row, rowMetaData: CassandraRowMetadata) =
     f(
-      a0c.convert(GettableData.get(row, 0)),
-      a1c.convert(GettableData.get(row, 1))
+      a0c.convert(GettableData.get(row, 0, rowMetaData.codecs(0))),
+      a1c.convert(GettableData.get(row, 1, rowMetaData.codecs(1)))
     )
 }
 
@@ -48,9 +48,9 @@ class FunctionBasedRowReader3[R, A0, A1, A2](f: (A0, A1, A2) => R)(
 
   override def read(row: Row, rowMetaData: CassandraRowMetadata) =
     f(
-      a0c.convert(GettableData.get(row, 0)),
-      a1c.convert(GettableData.get(row, 1)),
-      a2c.convert(GettableData.get(row, 2)))
+      a0c.convert(GettableData.get(row, 0, rowMetaData.codecs(0))),
+      a1c.convert(GettableData.get(row, 1, rowMetaData.codecs(1))),
+      a2c.convert(GettableData.get(row, 2, rowMetaData.codecs(2))))
 
 }
 
@@ -65,10 +65,10 @@ class FunctionBasedRowReader4[R, A0, A1, A2, A3](f: (A0, A1, A2, A3) => R)(
 
   override def read(row: Row, rowMetaData: CassandraRowMetadata) =
     f(
-      a0c.convert(GettableData.get(row, 0)),
-      a1c.convert(GettableData.get(row, 1)),
-      a2c.convert(GettableData.get(row, 2)),
-      a3c.convert(GettableData.get(row, 3))
+      a0c.convert(GettableData.get(row, 0, rowMetaData.codecs(0))),
+      a1c.convert(GettableData.get(row, 1, rowMetaData.codecs(1))),
+      a2c.convert(GettableData.get(row, 2, rowMetaData.codecs(2))),
+      a3c.convert(GettableData.get(row, 3, rowMetaData.codecs(3)))
     )
 }
 
@@ -84,11 +84,11 @@ class FunctionBasedRowReader5[R, A0, A1, A2, A3, A4](f: (A0, A1, A2, A3, A4) => 
 
   override def read(row: Row, rowMetaData: CassandraRowMetadata) =
     f(
-      a0c.convert(GettableData.get(row, 0)),
-      a1c.convert(GettableData.get(row, 1)),
-      a2c.convert(GettableData.get(row, 2)),
-      a3c.convert(GettableData.get(row, 3)),
-      a4c.convert(GettableData.get(row, 4))
+      a0c.convert(GettableData.get(row, 0, rowMetaData.codecs(0))),
+      a1c.convert(GettableData.get(row, 1, rowMetaData.codecs(1))),
+      a2c.convert(GettableData.get(row, 2, rowMetaData.codecs(2))),
+      a3c.convert(GettableData.get(row, 3, rowMetaData.codecs(3))),
+      a4c.convert(GettableData.get(row, 4, rowMetaData.codecs(4)))
     )
 }
 
@@ -105,12 +105,12 @@ class FunctionBasedRowReader6[R, A0, A1, A2, A3, A4, A5](f: (A0, A1, A2, A3, A4,
 
   override def read(row: Row, rowMetaData: CassandraRowMetadata) =
     f(
-      a0c.convert(GettableData.get(row, 0)),
-      a1c.convert(GettableData.get(row, 1)),
-      a2c.convert(GettableData.get(row, 2)),
-      a3c.convert(GettableData.get(row, 3)),
-      a4c.convert(GettableData.get(row, 4)),
-      a5c.convert(GettableData.get(row, 5))
+      a0c.convert(GettableData.get(row, 0, rowMetaData.codecs(0))),
+      a1c.convert(GettableData.get(row, 1, rowMetaData.codecs(1))),
+      a2c.convert(GettableData.get(row, 2, rowMetaData.codecs(2))),
+      a3c.convert(GettableData.get(row, 3, rowMetaData.codecs(3))),
+      a4c.convert(GettableData.get(row, 4, rowMetaData.codecs(4))),
+      a5c.convert(GettableData.get(row, 5, rowMetaData.codecs(5)))
     )
 }
 
@@ -128,13 +128,13 @@ class FunctionBasedRowReader7[R, A0, A1, A2, A3, A4, A5, A6](f: (A0, A1, A2, A3,
 
   override def read(row: Row, rowMetaData: CassandraRowMetadata) =
     f(
-      a0c.convert(GettableData.get(row, 0)),
-      a1c.convert(GettableData.get(row, 1)),
-      a2c.convert(GettableData.get(row, 2)),
-      a3c.convert(GettableData.get(row, 3)),
-      a4c.convert(GettableData.get(row, 4)),
-      a5c.convert(GettableData.get(row, 5)),
-      a6c.convert(GettableData.get(row, 6))
+      a0c.convert(GettableData.get(row, 0, rowMetaData.codecs(0))),
+      a1c.convert(GettableData.get(row, 1, rowMetaData.codecs(1))),
+      a2c.convert(GettableData.get(row, 2, rowMetaData.codecs(2))),
+      a3c.convert(GettableData.get(row, 3, rowMetaData.codecs(3))),
+      a4c.convert(GettableData.get(row, 4, rowMetaData.codecs(4))),
+      a5c.convert(GettableData.get(row, 5, rowMetaData.codecs(5))),
+      a6c.convert(GettableData.get(row, 6, rowMetaData.codecs(6)))
     )
 }
 
@@ -154,14 +154,14 @@ class FunctionBasedRowReader8[R, A0, A1, A2, A3, A4, A5, A6, A7]
 
   override def read(row: Row, rowMetaData: CassandraRowMetadata) =
     f(
-      a0c.convert(GettableData.get(row, 0)),
-      a1c.convert(GettableData.get(row, 1)),
-      a2c.convert(GettableData.get(row, 2)),
-      a3c.convert(GettableData.get(row, 3)),
-      a4c.convert(GettableData.get(row, 4)),
-      a5c.convert(GettableData.get(row, 5)),
-      a6c.convert(GettableData.get(row, 6)),
-      a7c.convert(GettableData.get(row, 7))
+      a0c.convert(GettableData.get(row, 0, rowMetaData.codecs(0))),
+      a1c.convert(GettableData.get(row, 1, rowMetaData.codecs(1))),
+      a2c.convert(GettableData.get(row, 2, rowMetaData.codecs(2))),
+      a3c.convert(GettableData.get(row, 3, rowMetaData.codecs(3))),
+      a4c.convert(GettableData.get(row, 4, rowMetaData.codecs(4))),
+      a5c.convert(GettableData.get(row, 5, rowMetaData.codecs(5))),
+      a6c.convert(GettableData.get(row, 6, rowMetaData.codecs(6))),
+      a7c.convert(GettableData.get(row, 7, rowMetaData.codecs(7)))
     )
 }
 
@@ -182,15 +182,15 @@ class FunctionBasedRowReader9[R, A0, A1, A2, A3, A4, A5, A6, A7, A8]
 
   override def read(row: Row, rowMetaData: CassandraRowMetadata) =
     f(
-      a0c.convert(GettableData.get(row, 0)),
-      a1c.convert(GettableData.get(row, 1)),
-      a2c.convert(GettableData.get(row, 2)),
-      a3c.convert(GettableData.get(row, 3)),
-      a4c.convert(GettableData.get(row, 4)),
-      a5c.convert(GettableData.get(row, 5)),
-      a6c.convert(GettableData.get(row, 6)),
-      a7c.convert(GettableData.get(row, 7)),
-      a8c.convert(GettableData.get(row, 8))
+      a0c.convert(GettableData.get(row, 0, rowMetaData.codecs(0))),
+      a1c.convert(GettableData.get(row, 1, rowMetaData.codecs(1))),
+      a2c.convert(GettableData.get(row, 2, rowMetaData.codecs(2))),
+      a3c.convert(GettableData.get(row, 3, rowMetaData.codecs(3))),
+      a4c.convert(GettableData.get(row, 4, rowMetaData.codecs(4))),
+      a5c.convert(GettableData.get(row, 5, rowMetaData.codecs(5))),
+      a6c.convert(GettableData.get(row, 6, rowMetaData.codecs(6))),
+      a7c.convert(GettableData.get(row, 7, rowMetaData.codecs(7))),
+      a8c.convert(GettableData.get(row, 8, rowMetaData.codecs(8)))
     )
 }
 
@@ -212,16 +212,16 @@ class FunctionBasedRowReader10[R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9]
 
   override def read(row: Row, rowMetaData: CassandraRowMetadata) =
     f(
-      a0c.convert(GettableData.get(row, 0)),
-      a1c.convert(GettableData.get(row, 1)),
-      a2c.convert(GettableData.get(row, 2)),
-      a3c.convert(GettableData.get(row, 3)),
-      a4c.convert(GettableData.get(row, 4)),
-      a5c.convert(GettableData.get(row, 5)),
-      a6c.convert(GettableData.get(row, 6)),
-      a7c.convert(GettableData.get(row, 7)),
-      a8c.convert(GettableData.get(row, 8)),
-      a9c.convert(GettableData.get(row, 9))
+      a0c.convert(GettableData.get(row, 0, rowMetaData.codecs(0))),
+      a1c.convert(GettableData.get(row, 1, rowMetaData.codecs(1))),
+      a2c.convert(GettableData.get(row, 2, rowMetaData.codecs(2))),
+      a3c.convert(GettableData.get(row, 3, rowMetaData.codecs(3))),
+      a4c.convert(GettableData.get(row, 4, rowMetaData.codecs(4))),
+      a5c.convert(GettableData.get(row, 5, rowMetaData.codecs(5))),
+      a6c.convert(GettableData.get(row, 6, rowMetaData.codecs(6))),
+      a7c.convert(GettableData.get(row, 7, rowMetaData.codecs(7))),
+      a8c.convert(GettableData.get(row, 8, rowMetaData.codecs(8))),
+      a9c.convert(GettableData.get(row, 9, rowMetaData.codecs(9)))
     )
 }
 
@@ -244,17 +244,17 @@ class FunctionBasedRowReader11[R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10]
 
   override def read(row: Row, rowMetaData: CassandraRowMetadata) =
     f(
-      a0c.convert(GettableData.get(row, 0)),
-      a1c.convert(GettableData.get(row, 1)),
-      a2c.convert(GettableData.get(row, 2)),
-      a3c.convert(GettableData.get(row, 3)),
-      a4c.convert(GettableData.get(row, 4)),
-      a5c.convert(GettableData.get(row, 5)),
-      a6c.convert(GettableData.get(row, 6)),
-      a7c.convert(GettableData.get(row, 7)),
-      a8c.convert(GettableData.get(row, 8)),
-      a9c.convert(GettableData.get(row, 9)),
-      a10c.convert(GettableData.get(row, 10))
+      a0c.convert(GettableData.get(row, 0, rowMetaData.codecs(0))),
+      a1c.convert(GettableData.get(row, 1, rowMetaData.codecs(1))),
+      a2c.convert(GettableData.get(row, 2, rowMetaData.codecs(2))),
+      a3c.convert(GettableData.get(row, 3, rowMetaData.codecs(3))),
+      a4c.convert(GettableData.get(row, 4, rowMetaData.codecs(4))),
+      a5c.convert(GettableData.get(row, 5, rowMetaData.codecs(5))),
+      a6c.convert(GettableData.get(row, 6, rowMetaData.codecs(6))),
+      a7c.convert(GettableData.get(row, 7, rowMetaData.codecs(7))),
+      a8c.convert(GettableData.get(row, 8, rowMetaData.codecs(8))),
+      a9c.convert(GettableData.get(row, 9, rowMetaData.codecs(9))),
+      a10c.convert(GettableData.get(row, 10, rowMetaData.codecs(10)))
     )
 }
 
@@ -278,18 +278,18 @@ class FunctionBasedRowReader12[R, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A
 
   override def read(row: Row, rowMetaData: CassandraRowMetadata) =
     f(
-      a0c.convert(GettableData.get(row, 0)),
-      a1c.convert(GettableData.get(row, 1)),
-      a2c.convert(GettableData.get(row, 2)),
-      a3c.convert(GettableData.get(row, 3)),
-      a4c.convert(GettableData.get(row, 4)),
-      a5c.convert(GettableData.get(row, 5)),
-      a6c.convert(GettableData.get(row, 6)),
-      a7c.convert(GettableData.get(row, 7)),
-      a8c.convert(GettableData.get(row, 8)),
-      a9c.convert(GettableData.get(row, 9)),
-      a10c.convert(GettableData.get(row, 10)),
-      a11c.convert(GettableData.get(row, 11))
+      a0c.convert(GettableData.get(row, 0, rowMetaData.codecs(0))),
+      a1c.convert(GettableData.get(row, 1, rowMetaData.codecs(1))),
+      a2c.convert(GettableData.get(row, 2, rowMetaData.codecs(2))),
+      a3c.convert(GettableData.get(row, 3, rowMetaData.codecs(3))),
+      a4c.convert(GettableData.get(row, 4, rowMetaData.codecs(4))),
+      a5c.convert(GettableData.get(row, 5, rowMetaData.codecs(5))),
+      a6c.convert(GettableData.get(row, 6, rowMetaData.codecs(6))),
+      a7c.convert(GettableData.get(row, 7, rowMetaData.codecs(7))),
+      a8c.convert(GettableData.get(row, 8, rowMetaData.codecs(8))),
+      a9c.convert(GettableData.get(row, 9, rowMetaData.codecs(9))),
+      a10c.convert(GettableData.get(row, 10, rowMetaData.codecs(10))),
+      a11c.convert(GettableData.get(row, 11, rowMetaData.codecs(11)))
     )
 }
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/ValueRowReader.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/ValueRowReader.scala
@@ -14,7 +14,10 @@ class ValueRowReader[T: TypeConverter](columnRef: ColumnRef) extends RowReader[T
     * @param row row fetched from Cassandra
     * @param rowMetaData: column names available in the `row` */
   override def read(row: Row, rowMetaData: CassandraRowMetadata): T =
-    converter.convert(GettableData.get(row, columnRef.cqlValueName))
+    converter.convert(GettableData.get(
+      row,
+      columnRef.cqlValueName,
+      rowMetaData.codecs(columnRef.cqlValueName)))
 
   /** List of columns this `RowReader` is going to read.
     * Useful to avoid fetching the columns that are not needed. */


### PR DESCRIPTION
SPARKC-383 added a cache of codecs so reads would not look up codecs for
every row. This patch extends that so that all RowReaders will use the
cache instead of just some.