### PR TITLE
SPARKC-475: Add implicit RowWriterFactory for RDD[Row]

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/RowWriterFactory.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/RowWriterFactory.scala
@@ -1,10 +1,10 @@
 package com.datastax.spark.connector.writer
 
 import scala.reflect.runtime.universe._
-
 import com.datastax.spark.connector.ColumnRef
 import com.datastax.spark.connector.cql.TableDef
 import com.datastax.spark.connector.mapper.ColumnMapper
+import org.apache.spark.sql.Row
 
 /** Creates instances of [[RowWriter]] objects for the given row type `T`.
   * `RowWriterFactory` is the trait you need to implement if you want to support row representations
@@ -21,6 +21,9 @@ trait RowWriterFactory[T] {
 /** Provides a low-priority implicit `RowWriterFactory` able to write objects of any class for which
   * a [[com.datastax.spark.connector.mapper.ColumnMapper ColumnMapper]] is defined. */
 trait LowPriorityRowWriterFactoryImplicits {
+  implicit def sqlRowWriterFactory[T <: Row : TypeTag]: RowWriterFactory[Row] =
+    SqlRowWriter.Factory
+
   implicit def defaultRowWriterFactory[T : TypeTag : ColumnMapper]: RowWriterFactory[T] =
     DefaultRowWriter.factory
 }


### PR DESCRIPTION
Previously when a DataFrame was turned into an RDD by it's `rdd` method
saveToCassandra and joinWithCassandraTable would fail because of the
lack of an implicit RowWriterFactory. To fix this we add an implicit
for a RowWriterFactory for RDD[T <: Row] which ends up mapping to the
SqlRowWriterFactory which we already have written.