### PR TITLE
SPARKC-470: Allow Writes to Static Columnns and Partition Keys

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/DefaultColumnMapper.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/DefaultColumnMapper.scala
@@ -90,7 +90,7 @@ class DefaultColumnMapper[T : TypeTag](columnNameOverride: Map[String, String] =
   }
 
   override def columnMapForWriting(
-      struct: StructDef, 
+      struct: StructDef,
       selectedColumns: IndexedSeq[ColumnRef]): ColumnMapForWriting = {
 
     val columns = columnByName(selectedColumns)


### PR DESCRIPTION
Previously we were overly strict on checking whether a write was
valid. A Cassandra Table can be written too with only Partition Keys and
Static columns if no clustering columns are included. We ease the check
in TableWriter by only requiring the partition key if all other columns
are Static Columns.