### PR TITLE
SPARKC-466: Add a CassandraRDDMock for end users to use in Unit Testing

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -205,6 +205,11 @@ would like to add. We would be happy to discuss it with you and see your work. F
 that you are satisfied with and passes all the tests (`/dev/run_tests.sh`) make a GitHub PR against
 your target Connector Version and set your Jira to Reviewing.
 
+### Is there a CassandraRDDMock I can use in my tests?
+
+Yes. Please see CassandraRDDMock.scala for the class and CassandraRDDMockSpec.scala for example
+usage.
+
 ### What should I do if I find a bug? 
 
 Feel free to post a repo on the Mailing List or if you are feeling ambitious file a Jira with

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDMockSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDMockSpec.scala
@@ -1,0 +1,24 @@
+package com.datastax.spark.connector.rdd
+
+import com.datastax.spark.connector.{CassandraRow, SparkCassandraITFlatSpecBase}
+import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.embedded.YamlTransformations
+
+class CassandraRDDMockSpec extends SparkCassandraITFlatSpecBase {
+  useCassandraConfig(Seq(YamlTransformations.Default))
+  useSparkConf(defaultConf)
+
+  override val conn = CassandraConnector(defaultConf)
+
+  "A CassandraRDDMock" should "behave like a CassandraRDD without needing Cassandra" in {
+    val columns = Seq("key", "value")
+    //Create a fake CassandraRDD[CassandraRow]
+    val rdd = sc
+      .parallelize(1 to 10)
+      .map(num => CassandraRow.fromMap(columns.zip(Seq(num, num)).toMap))
+
+    val fakeCassandraRDD: CassandraRDD[CassandraRow] = new CassandraRDDMock(rdd)
+
+    fakeCassandraRDD.cassandraCount() should be (10)
+  }
+}

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/CassandraRDDMock.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/CassandraRDDMock.scala
@@ -1,0 +1,55 @@
+package com.datastax.spark.connector.rdd
+
+import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.{ColumnRef, ColumnSelector, SomeColumns}
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{Partition, TaskContext}
+
+import scala.reflect.ClassTag
+
+/**
+  * A Fake CassandraRDD for mocking CassandraRDDs. Instead of reading data from cassandra this
+  * call uses an RDD prev as a source for data. In essenece this is a passthrough RDD which
+  * takes the contents of the previous RDD and pretends it is a CassandraRDD.
+  */
+class CassandraRDDMock[R : ClassTag](prev: RDD[R], keyspace: String = "fake", table: String = "fake") extends
+  CassandraRDD[R](prev.sparkContext, prev.dependencies){
+
+  /** This is slightly different than Scala this.type.
+    * this.type is the unique singleton type of an object which is not compatible with other
+    * instances of the same type, so returning anything other than `this` is not really possible
+    * without lying to the compiler by explicit casts.
+    * Here SelfType is used to return a copy of the object - a different instance of the same type */
+  override type Self = this.type
+
+  override protected[connector] def keyspaceName: String = keyspace
+  override protected[connector] def tableName: String = table
+  override protected def columnNames: ColumnSelector = SomeColumns()
+  override protected def where: CqlWhereClause = CqlWhereClause(Seq.empty, Seq.empty)
+  override protected def readConf: ReadConf = ReadConf()
+  override protected def limit: Option[CassandraLimit] = None
+  override protected def clusteringOrder: Option[ClusteringOrder] = None
+  override protected def connector: CassandraConnector = ???
+  override val selectedColumnRefs: Seq[ColumnRef] = Seq.empty
+  override protected def narrowColumnSelection(columns: Seq[ColumnRef]): Seq[ColumnRef] = Seq.empty
+
+  override def toEmptyCassandraRDD: EmptyCassandraRDD[R] = new EmptyCassandraRDD[R](prev.sparkContext, keyspace, table)
+
+  /** Counts the number of items in this RDD by selecting count(*) on Cassandra table */
+  override def cassandraCount(): Long = prev.count
+
+  /** Doesn't actually copy since we don't really use any of these parameters **/
+  override protected def copy(
+     columnNames: ColumnSelector,
+     where: CqlWhereClause,
+     limit: Option[CassandraLimit],
+     clusteringOrder: Option[ClusteringOrder],
+     readConf: ReadConf,
+     connector: CassandraConnector) : CassandraRDDMock.this.type = this
+
+  /*** Pass through the parent RDD's Compute and partitions ***/
+  @DeveloperApi
+  override def compute(split: Partition, context: TaskContext): Iterator[R] = prev.compute(split, context)
+  override protected def getPartitions: Array[Partition] = prev.partitions
+}


### PR DESCRIPTION
The CassandraRDDMock just passes through another RDD and pretends it is
a CassandraRDD.