### PR TITLE
SPARKC-481: Refactor Custom Scan Method

### DIFF
--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CustomTableScanMethodSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CustomTableScanMethodSpec.scala
@@ -2,7 +2,7 @@ package com.datastax.spark.connector.rdd
 
 import com.datastax.driver.core.{Cluster, Row, Session, Statement}
 import com.datastax.spark.connector.{SparkCassandraITFlatSpecBase, _}
-import com.datastax.spark.connector.cql.{CassandraConnectionFactory, CassandraConnector, CassandraConnectorConf, DefaultConnectionFactory}
+import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.embedded.SparkTemplate._
 import com.datastax.spark.connector.embedded.YamlTransformations
 import com.datastax.spark.connector.rdd.partitioner.dht.TokenFactory
@@ -51,12 +51,10 @@ class CustomTableScanMethodSpec extends SparkCassandraITFlatSpecBase with Inspec
 object DummyFactory extends CassandraConnectionFactory {
   
   val nie = new NotImplementedError("TestingOnly")
-  override def getScanMethod(
+  override def getScanner(
     readConf: ReadConf,
-    session: Session,
-    columnNames: IndexedSeq[String]): (Statement) => (Iterator[Row], CassandraRowMetadata) = {
-    throw nie
-  }
+    connConf: CassandraConnectorConf,
+    columnNames: IndexedSeq[String]): Scanner = throw nie
 
   /** Creates and configures native Cassandra connection */
   override def createCluster(conf: CassandraConnectorConf): Cluster =

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
@@ -48,7 +48,7 @@ import com.datastax.spark.connector.util.Logging
   *   - `spark.cassandra.connection.ssl.protocol`:              SSL protocol (default TLS)
   *   - `spark.cassandra.connection.ssl.enabledAlgorithms`:         SSL cipher suites (default TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_256_CBC_SHA)
   */
-class CassandraConnector(conf: CassandraConnectorConf)
+class CassandraConnector(val conf: CassandraConnectorConf)
   extends Serializable with Logging {
 
   import com.datastax.spark.connector.cql.CassandraConnector._

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Scanner.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/Scanner.scala
@@ -1,0 +1,41 @@
+package com.datastax.spark.connector.cql
+
+import com.datastax.driver.core.{Row, Session, Statement}
+import com.datastax.spark.connector.CassandraRowMetadata
+import com.datastax.spark.connector.rdd.ReadConf
+import com.datastax.spark.connector.rdd.reader.PrefetchingResultSetIterator
+
+/**
+  * Object which will be used in Table Scanning Operations.
+  * One Scanner will be created per Spark Partition, it will be
+  * created at the beginning of the compute method and Closed at the
+  * end of the compute method.
+  */
+trait Scanner {
+  def close(): Unit
+  def getSession(): Session
+  def scan(statement: Statement): ScanResult
+}
+
+case class ScanResult (rows: Iterator[Row], metadata: CassandraRowMetadata)
+
+class DefaultScanner (
+    readConf: ReadConf,
+    connConf: CassandraConnectorConf,
+    columnNames: IndexedSeq[String]) extends Scanner {
+
+  private val session = new CassandraConnector(connConf).openSession()
+
+  override def close(): Unit = {
+    session.close()
+  }
+
+  override def scan(statement: Statement): ScanResult = {
+    val rs = session.execute(statement)
+    val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames, rs)
+    val iterator = new PrefetchingResultSetIterator(rs, readConf.fetchSizeInRows)
+    ScanResult(iterator, columnMetaData)
+  }
+
+  override def getSession(): Session = session
+}


### PR DESCRIPTION
The original implmentation of the CustomScanMethod made it difficult to
extend the functionality inside of CassandraTableScan RDD since it
provided no ability to perform a "close" action on termination. This
meant external users were unable to properly cleanup their
implementations.

To fix this we change getScanMethod to getScanner which returns a
Scanner object which provides two methods, Scan and Close. One Scanner
is built per Spark Partition so the the initializer will only be called
once per Spark Partition and the close method only once at task
Completion.