### PR TITLE
SPARKC 492: Protect against Size Estimate Overflows

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/Murmur3PartitionerTokenRangeSplitter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/Murmur3PartitionerTokenRangeSplitter.scala
@@ -17,12 +17,12 @@ class Murmur3PartitionerTokenRangeSplitter(dataSize: Long)
   def split(range: TR, splitSize: Long): Seq[TR] = {
     val rangeSize = range.dataSize
     val rangeTokenCount = tokenFactory.distance(range.start, range.end)
-    val n = math.max(1, math.round(rangeSize.toDouble / splitSize).toInt)
+    val n = math.max(1, math.round(rangeSize.toDouble / splitSize))
 
     val left = range.start.value
     val right = range.end.value
     val splitPoints =
-      (for (i <- 0 until n) yield left + (rangeTokenCount * i / n).toLong) :+ right
+      (for (i <- 0L until n) yield left + (rangeTokenCount * i / n).toLong) :+ right
 
     for (Seq(l, r) <- splitPoints.sliding(2).toSeq) yield
       new TokenRange[Long, LongToken](

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/RandomPartitionerTokenRangeSplitter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/RandomPartitionerTokenRangeSplitter.scala
@@ -23,12 +23,12 @@ class RandomPartitionerTokenRangeSplitter(dataSize: Long)
   def split(range: TR, splitSize: Long): Seq[TR] = {
     val rangeSize = range.dataSize
     val rangeTokenCount = tokenFactory.distance(range.start, range.end)
-    val n = math.max(1, math.round(rangeSize.toDouble / splitSize)).toInt
+    val n = math.max(1, math.round(rangeSize.toDouble / splitSize))
 
     val left = range.start.value
     val right = range.end.value
     val splitPoints =
-      (for (i <- 0 until n) yield wrap(left + (rangeTokenCount * i / n))) :+ right
+      (for (i <- 0L until n) yield wrap(left + (rangeTokenCount * i / n))) :+ right
 
     for (Seq(l, r) <- splitPoints.sliding(2).toSeq) yield
       new TokenRange[BigInt, BigIntToken](

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/partitioner/RandomPartitionerTokenRangeSplitterTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/partitioner/RandomPartitionerTokenRangeSplitterTest.scala
@@ -4,9 +4,9 @@ import java.net.InetAddress
 
 import org.junit.Assert._
 import org.junit.Test
-
 import com.datastax.spark.connector.rdd.partitioner.dht.TokenFactory.RandomPartitionerTokenFactory
-import com.datastax.spark.connector.rdd.partitioner.dht.{BigIntToken, TokenFactory}
+import com.datastax.spark.connector.rdd.partitioner.dht.BigIntToken
+
 
 class RandomPartitionerTokenRangeSplitterTest {
 
@@ -87,5 +87,4 @@ class RandomPartitionerTokenRangeSplitterTest {
     assertNoHoles(out)
     assertSimilarSize(out)
   }
-
 }


### PR DESCRIPTION
```scala
val tokenRangeSizeInBytes = (totalDataSizeInBytes /
ringFraction).toLong
```

In datasize estimates has the possibility of overflowing when
getting the size_estimates from a datacenter whose primary range
contains a very tiny range BUT still also contains data. In these
cases a tiny size in bytes will be divided by a miniscule range
fraction leading to a huge value. This when converted toLong becomes
Long.MaxValue.

When these situations arise our size_estimates are no longer
reliable so we need to fall back to a safer estimate. In 2.0 we can
use the min Spark Nodes * 2 + 1 but in 1.6 we don't have that
information. To keep our changes small, here we will just use the
endpoints present in the target datacenter * 2 + 1.