### PR TITLE
Requesting a pull to datastax:b2.0 from datastax:SPARKC-492-b2.0  Changes:

### DIFF
--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -1350,8 +1350,8 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
   }
 
   "DataSize Estimates" should "handle overflows in the size estimates for a table" in {
-    fudgeSizeEstimatesTable("user", Long.MaxValue)
-    val partitions = sc.cassandraTable(ks, "user").partitions
+    fudgeSizeEstimatesTable("key_value", Long.MaxValue)
+    val partitions = sc.cassandraTable(ks, "key_value").partitions
     partitions.size should be <= (sc.defaultParallelism * 3)
   }
 
@@ -1370,7 +1370,7 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
       session.execute(
         """DELETE FROM system.size_estimates
           |where keyspace_name = ?
-          |AND table_name = ?""".stripMargin, ks, "overflow")
+          |AND table_name = ?""".stripMargin, ks, tableName)
 
       session.execute(
         """

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/CassandraRDDSpec.scala
@@ -9,6 +9,7 @@ import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql.{CassandraConnector, CassandraConnectorConf}
 import com.datastax.spark.connector.embedded.YamlTransformations
 import com.datastax.spark.connector.mapper.{DefaultColumnMapper, JavaBeanColumnMapper, JavaTestBean, JavaTestUDTBean}
+import com.datastax.spark.connector.rdd.partitioner.dht.TokenFactory
 import com.datastax.spark.connector.types.{CassandraOption, TypeConverter}
 import org.joda.time.{DateTime, LocalDate}
 
@@ -1346,5 +1347,49 @@ class CassandraRDDSpec extends SparkCassandraITFlatSpecBase {
       (10, 11, Some("1011")),
       (10, 12, Some("1012")))
 
+  }
+
+  "DataSize Estimates" should "handle overflows in the size estimates for a table" in {
+    fudgeSizeEstimatesTable("user", Long.MaxValue)
+    val partitions = sc.cassandraTable(ks, "user").partitions
+    partitions.size should be <= (sc.defaultParallelism * 3)
+  }
+
+
+  /**
+    * Fudges the size estimates information for the given table
+    * Attempts to replace all records for existing ranges with a single record
+    * giving a mean size of sizeFudgeInMB
+    */
+  def fudgeSizeEstimatesTable(tableName: String, sizeFudgeInMB: Long) = {
+
+    val meta = conn.withClusterDo(_.getMetadata)
+    val tokenFactory = TokenFactory.forSystemLocalPartitioner(conn)
+
+    conn.withSessionDo { case session =>
+      session.execute(
+        """DELETE FROM system.size_estimates
+          |where keyspace_name = ?
+          |AND table_name = ?""".stripMargin, ks, "overflow")
+
+      session.execute(
+        """
+          |INSERT INTO system.size_estimates (
+          |  keyspace_name,
+          |  table_name,
+          |  range_start,
+          |  range_end,
+          |  mean_partition_size,
+          |  partitions_count)
+          |  VALUES (?,?,?,?,?,?)
+        """.
+          stripMargin,
+        ks,
+        tableName,
+        tokenFactory.minToken.toString,
+        tokenFactory.maxToken.toString,
+        sizeFudgeInMB * 1024 * 1024: java.lang.Long,
+        1L: java.lang.Long)
+    }
   }
 }

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartitionGeneratorSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartitionGeneratorSpec.scala
@@ -1,9 +1,17 @@
 package com.datastax.spark.connector.rdd.partitioner
 
-import com.datastax.spark.connector.rdd.partitioner.dht.TokenFactory
+import com.datastax.driver.core.Row
+import org.apache.cassandra.tools.NodeProbe
+import org.scalatest.{FlatSpec, Inspectors, Matchers}
 import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
-import com.datastax.spark.connector.cql.{CassandraConnector, Schema}
+import com.datastax.spark.connector.cql.{CassandraConnector, CassandraConnectorConf, Schema}
+import com.datastax.spark.connector.embedded.{CassandraRunner, EmbeddedCassandra, SparkTemplate}
+import com.datastax.spark.connector.rdd.partitioner.dht.TokenFactory.{Murmur3TokenFactory, RandomPartitionerTokenFactory}
+import com.datastax.spark.connector.rdd.partitioner.dht.TokenFactory
+import com.datastax.spark.connector.rdd.{CqlWhereClause, ReadConf}
+import com.datastax.spark.connector.testkit.SharedEmbeddedCassandra
 import com.datastax.spark.connector.embedded.YamlTransformations
+
 
 class CassandraPartitionGeneratorSpec
   extends SparkCassandraITFlatSpecBase {


### PR DESCRIPTION
9e4c3c9 (Russell Spitzer, 4 days ago)
    SPARKC 492: Protect against Size Estimate Overflows

    ```scala val tokenRangeSizeInBytes = (totalDataSizeInBytes /
    ringFraction).toLong
    ```

    In datasize estimates has the possibility of overflowing when getting the
    size_estimates from a datacenter whose primary range contains a very tiny
    range BUT still also contains data. In these cases a tiny size in bytes
    will be divided by a miniscule range fraction leading to a huge value. This
    when converted toLong becomes Long.MaxValue.

    When these situations arise our size_estimates are no longer reliable so we
    need to fall back to a safer estimate. In 2.0 we can use the min Spark
    Nodes * 2 + 1 but in 1.6 we don't have that information. To keep our
    changes small, here we will just use the endpoints present in the target
    datacenter * 2 + 1.