### PR TITLE
DSP-12259: add support for date string parsing

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TimestampParser.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TimestampParser.scala
@@ -39,7 +39,8 @@ object TimestampParser {
     "yyyy-MM-dd'T'HH:mm:ss.SSS",
     "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
     "yyyy-MM-dd",
-    "yyyy-MM-ddZ")
+    "yyyy-MM-ddZ",
+    "yyyy")
 
   private val parsers =
     dateStringPatterns.map(DateTimeFormat.forPattern)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
@@ -8,11 +8,9 @@ import java.util.{Calendar, Date, GregorianCalendar, TimeZone, UUID}
 import scala.collection.JavaConversions._
 import scala.collection.immutable.{TreeMap, TreeSet}
 import scala.reflect.runtime.universe._
-
 import org.apache.commons.lang3.tuple
 import org.apache.spark.sql.catalyst.ReflectionLock.SparkReflectionLock
 import org.joda.time.{DateTime, LocalDate => JodaLocalDate}
-
 import com.datastax.driver.core.LocalDate
 import com.datastax.spark.connector.TupleValue
 import com.datastax.spark.connector.UDTValue.UDTValueConverter
@@ -333,6 +331,7 @@ object TypeConverter {
     def targetTypeTag = SqlDateTypeTag
 
     def convertPF = {
+      case x: String => SqlDateConverter.convert(JodaLocalDateConverter.convert(x))
       case x: Date => new java.sql.Date(x.getTime)
       case x: LocalDate => SqlDateConverter.convert(JodaLocalDateConverter.convert(x))
       case x: JodaLocalDate => new java.sql.Date(x.toDateTimeAtStartOfDay.getMillis)
@@ -355,9 +354,10 @@ object TypeConverter {
   implicit object JodaLocalDateConverter extends NullableTypeConverter[JodaLocalDate] {
     def targetTypeTag = JodaLocalDateTypeTag
     def convertPF = {
+      case x: String => JodaLocalDate.fromDateFields(TimestampParser.parse(x))
       case x: JodaLocalDate => x
       case x: LocalDate => new JodaLocalDate(x.getYear, x.getMonth, x.getDay)
-      case x: java.sql.Date => JodaLocalDate.fromDateFields(x)
+      case x: java.util.Date => JodaLocalDate.fromDateFields(x)
     }
   }
 

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/TypeConverterTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/types/TypeConverterTest.scala
@@ -158,9 +158,14 @@ class TypeConverterTest {
     val dateFormat = new SimpleDateFormat("yyyy-MM-dd")
     val utilDate = dateFormat.parse("2014-04-23")
 
+    assertEquals(targetDate, c.convert("2014-04-23"))
     assertEquals(targetDate, c.convert(localDate))
     assertEquals(targetDate, c.convert(jodaLocalDate))
     assertEquals(targetDate, c.convert(utilDate))
+
+    val targetYear = java.sql.Date.valueOf("2014-01-01")
+    assertEquals(targetYear, c.convert("2014"))
+
   }
 
   @Test


### PR DESCRIPTION
timestamp has one, to have a consistent story the date parser is added