### PR TITLE
SPARKC-485: Fix ReplicaPartitioner Endpoint Call

### DIFF
--- a/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/CassandraRunner.scala
+++ b/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/CassandraRunner.scala
@@ -58,7 +58,7 @@ private[connector] class CassandraRunner(val configTemplate: String, props: Map[
   val location = Thread.currentThread().getStackTrace
     .filter(_.getClassName.startsWith("com.datastax")).lastOption
     .map(ste => s"   at ${ste.getFileName}:${ste.getLineNumber} (${ste.getClassName}.${ste.getMethodName}").getOrElse("")
-  println(s"--------======== Starting Embedded Cassandra on port ${props.get("native_transport_port").get} ========--------\n$location")
+  println(s"--------======== Starting Embedded Cassandra ${props.get("listen_address")} on port ${props.get("native_transport_port").get} ========--------\n$location")
 
   private[embedded] val process = new ProcessBuilder()
     .command(javaBin,
@@ -75,7 +75,7 @@ private[connector] class CassandraRunner(val configTemplate: String, props: Map[
     throw new IOException("Failed to start Cassandra.")
 
   def destroy() {
-    System.err.println(s"========-------- Stopping Embedded Cassandra at ${props.get("native_transport_port").get} --------========")
+    System.err.println(s"========-------- Stopping Embedded Cassandra  ${props.get("listen_address")} on port ${props.get("native_transport_port").get} --------========")
     process.destroy()
     process.waitFor()
     FileUtils.forceDelete(tempDir)

--- a/spark-cassandra-connector/src/it/resources/log4j.properties
+++ b/spark-cassandra-connector/src/it/resources/log4j.properties
@@ -27,6 +27,7 @@ log4j.appender.stdout.layout.ConversionPattern=%5p %d{HH:mm:ss,SSS} %C (%F:%L) -
 
 # Avoid "no host ID found" when starting a fresh node
 log4j.logger.org.apache.cassandra.db.SystemKeyspace=ERROR
+#log4j.logger.org.apache.cassandra=INFO
 
 # Avoid "address already in use" when starting multiple local Spark masters
 log4j.logger.org.eclipse.jetty.util.component.AbstractLifeCycle=ERROR

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/partitioner/ReplicaPartitionerSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/partitioner/ReplicaPartitionerSpec.scala
@@ -1,0 +1,113 @@
+package com.datastax.spark.connector.rdd.partitioner
+
+import java.net.{Inet4Address, Inet6Address, InetAddress}
+
+import com.datastax.spark.connector.{SomeColumns, SparkCassandraITFlatSpecBase}
+import com.datastax.spark.connector.cql.{CassandraConnector, CassandraConnectorConf, MultipleRetryPolicy}
+import com.datastax.driver.core.TokenRange
+import com.datastax.driver.core.policies.{RoundRobinPolicy, TokenAwarePolicy}
+import com.datastax.spark.connector.embedded.CassandraRunner
+import com.datastax.spark.connector.embedded.EmbeddedCassandra.cassandraPorts
+
+import scala.collection.JavaConversions._
+import org.scalatest.{BeforeAndAfterAll, Inspectors}
+import org.scalatest.concurrent.Eventually
+
+class ReplicaPartitionerSpec
+  extends SparkCassandraITFlatSpecBase with Inspectors with Eventually with BeforeAndAfterAll{
+
+  val min = 1
+  val max = 100
+
+  var runners: Seq[CassandraRunner] = Seq.empty
+
+  override val conn =
+    CassandraConnector(defaultConf
+      .set(CassandraConnectorConf.ConnectionHostParam.name, "127.0.0.2")
+      .set(CassandraConnectorConf.ConnectionPortParam.name, "9042")
+    )
+
+  override def beforeAll: Unit = {
+    val node1Conf = Map(
+      "seeds" -> "127.0.0.2",
+      "storage_port" -> "7000",
+      "ssl_storage_port" -> "7001",
+      "native_transport_port" -> "9042",
+      "jmx_port" -> "30000",
+      "rpc_address" -> s"127.0.0.2",
+      "listen_address" -> s"127.0.0.2",
+      "cluster_name" -> "ReplicaPartitionerSpec",
+      "keystore_path" -> ClassLoader.getSystemResource("keystore").getPath,
+      "truststore_path" -> ClassLoader.getSystemResource("truststore").getPath
+    )
+
+    val node2Conf = Map(
+      "seeds" -> "127.0.0.2",
+      "storage_port" -> "7000",
+      "ssl_storage_port" -> "7001",
+      "native_transport_port" -> "9042",
+      "jmx_port" -> "30001",
+      "rpc_address" -> s"127.0.0.3",
+      "listen_address" -> s"127.0.0.3",
+      "cluster_name" -> "ReplicaPartitionerSpec",
+      "keystore_path" -> ClassLoader.getSystemResource("keystore").getPath,
+      "truststore_path" -> ClassLoader.getSystemResource("truststore").getPath
+    )
+
+    val versionedTemplate = getVersionedConfigTemplate("cassandra-default.yaml.template")
+
+    runners = Seq(
+      new CassandraRunner(configTemplate = versionedTemplate, props = node1Conf),
+      new CassandraRunner(configTemplate = versionedTemplate, props = node2Conf))
+
+    eventually {
+      conn.withSessionDo { session =>
+        createKeyspace(session)
+        session.execute(s"CREATE TABLE $ks.kv (key INT PRIMARY KEY, value INT)")
+        (min to max)
+          .map(x => (x: java.lang.Integer, x: java.lang.Integer))
+          .map { case (x, y) =>
+            session.executeAsync(s"INSERT INTO $ks.kv (key, value) VALUES (?, ?)", x, y) }
+          .foreach(_.get)
+      }
+    }
+  }
+
+  override def afterAll() = {
+    runners.foreach(_.destroy)
+  }
+
+
+  "ReplicaPartitoner" should "should use token generator to get correct replica mapping" in conn.withClusterDo { cluster =>
+    val metadata = cluster.getMetadata
+    val allHosts = metadata.getAllHosts
+
+    val replicaPartitioner = new ReplicaPartitioner[(Int, Int)]("kv", ks, 1, SomeColumns("key"), conn)
+    val tokenGenerator = replicaPartitioner.tokenGenerator
+
+    val tap = new TokenAwarePolicy(new RoundRobinPolicy)
+    tap.init(cluster, allHosts)
+
+
+    val rows = (min to max).map( x => (x, x))
+
+    val bs = conn.withSessionDo(_.prepare(s"INSERT INTO $ks.kv (key, value) VALUES (?, ?)"))
+
+    for (row <- rows) {
+      val replicas = metadata.getReplicas(ks, tokenGenerator.getPartitionKeyBufferFor(row))
+      val hosts = tap.newQueryPlan(ks, bs.bind(row._1: java.lang.Integer, row._2: java.lang.Integer))
+      val firstHost = hosts.next
+      firstHost should be (replicas.head)
+    }
+  }
+
+  it should "partition our data into one partition per node of roughly equal size" in {
+    val rows = (min to max).map( x => (x, x))
+    val replicaPartitioner = new ReplicaPartitioner[(Int, Int)]("kv", ks, 1, SomeColumns("key"), conn)
+
+    val partitionedData = rows.groupBy(replicaPartitioner.getPartition(_))
+    partitionedData should have size (2) // There should be two partitions
+    partitionedData.foreach{ case (partition, contents) => contents.size should be > (max / 3).toInt} // Each should have roughly half the data
+  }
+
+}

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/partitioner/TokenGeneratorSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/rdd/partitioner/TokenGeneratorSpec.scala
@@ -5,7 +5,6 @@ import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.spark.connector.cql.Schema
 import com.datastax.driver.core.Token
 import com.datastax.spark.connector.writer.RowWriterFactory
-import org.scalatest.Inspectors
 
 import scala.collection.JavaConversions._
 import scala.concurrent.Future

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/TokenGenerator.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/TokenGenerator.scala
@@ -1,6 +1,8 @@
 package com.datastax.spark.connector.rdd.partitioner
 
-import com.datastax.driver.core.{Token, MetadataHook}
+import java.nio.ByteBuffer
+
+import com.datastax.driver.core.{MetadataHook, Token}
 import com.datastax.spark.connector.cql.{CassandraConnector, TableDef}
 import com.datastax.spark.connector.util.Logging
 import com.datastax.spark.connector.util.PatitionKeyTools._
@@ -32,7 +34,11 @@ private[connector] class TokenGenerator[T] (
     stmt,
     protocolVersion = protocolVersion)
 
+  def getPartitionKeyBufferFor(key: T): ByteBuffer = {
+    routingKeyGenerator.apply(boundStmtBuilder.bind(key))
+  }
+
   def getTokenFor(key: T): Token = {
-    MetadataHook.newToken(metadata, routingKeyGenerator.apply(boundStmtBuilder.bind(key)))
+    MetadataHook.newToken(metadata, getPartitionKeyBufferFor(key))
   }
 }


### PR DESCRIPTION
Previously endpoints were being calculated with the wrong ByteBuffer.
They needed to use the routing key but were using the Token buffer
instead. To fix this we change the buffer which was passed in to the key
buffer instead.

To fully test this the embedded cassandra class is extended so that it
can create a multi-node cluster. This is then used to make sure or
replica partitioner is accurately dividing nodes by replica and evenly
distributing the keys.