### PR TITLE
SPARKC-496: Fix Shuffling of a Set in Local Node FirstPolicy

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/LocalNodeFirstLoadBalancingPolicy.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/LocalNodeFirstLoadBalancingPolicy.scala
@@ -128,7 +128,7 @@ object LocalNodeFirstLoadBalancingPolicy {
     } - None
 
     grouped.toSeq.sortBy(_._1.get).flatMap {
-      case (_, hosts) => random.shuffle(hosts).toSeq
+      case (_, hosts) => random.shuffle(hosts.toIndexedSeq)
     }
   }
 


### PR DESCRIPTION
Shuffling a set doesn't actually do anything so this would end up giving
the rest of the hosts in order regardless of the shuffle.

Problem found and fix written by Loki Coyote @lokkju on Github