### PR TITLE
SPARKC-503: Retry PoolBusy Exceptions, Throttle JWCT Calls

### DIFF
--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
@@ -200,7 +200,7 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase {
         .saveToCassandra(ks, "key_value")
     }
 
-    ioException.getMessage should include ("Invalid null value in condition for column group")
+    ioException.getMessage should include ("Invalid null value")
   }
 
   it should "write to a table with only partition key and static columns without clustering" in {

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
@@ -6,12 +6,12 @@ import scala.collection.JavaConversions._
 import scala.concurrent.Future
 import com.datastax.driver.core.ProtocolVersion
 import com.datastax.driver.core.ProtocolVersion._
-
 import com.datastax.spark.connector.{SomeColumns, _}
 import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.embedded.YamlTransformations
 import com.datastax.spark.connector.mapper.DefaultColumnMapper
 import com.datastax.spark.connector.types._
+import org.apache.spark.SparkException
 
 case class Address(street: String, city: String, zip: Int)
 case class KV(key: Int, value: String)
@@ -192,6 +192,15 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase {
     )
     sc.parallelize(col).saveToCassandra(ks, "key_value")
     verifyKeyValueTable("key_value")
+  }
+
+  it should "pass the exception back to the driver on a write failure" in {
+    val ioException = intercept[SparkException] {
+      sc.parallelize[(Int, Option[Long], String)](Seq((1, None, "Hello")))
+        .saveToCassandra(ks, "key_value")
+    }
+
+    ioException.getMessage should include ("Invalid null value in condition for column group")
   }
 
   it should "write to a table with only partition key and static columns without clustering" in {

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/ThrottlingSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/ThrottlingSpec.scala
@@ -1,0 +1,50 @@
+package com.datastax.spark.connector.writer
+
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.{SomeColumns, SparkCassandraITFlatSpecBase}
+import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.embedded.YamlTransformations
+
+import scala.concurrent.Future
+
+class ThrottlingSpec extends SparkCassandraITFlatSpecBase {
+  useCassandraConfig(Seq(YamlTransformations.Default))
+  useSparkConf(defaultConf)
+
+  override val conn = CassandraConnector(defaultConf)
+
+
+
+
+  conn.withSessionDo { session =>
+    createKeyspace(session)
+
+    awaitAll(
+      Future {
+        session.execute( s"""CREATE TABLE $ks.key_value (key INT, group BIGINT, value TEXT, PRIMARY KEY (key, group))""")
+      })
+  }
+
+  "Throttling" should "prevent failures based on driver max queue size while writing" in {
+      conn.withClusterDo{cluster =>
+        val poolingOptions = cluster.getConfiguration.getPoolingOptions
+        poolingOptions.setMaxQueueSize(1)
+        poolingOptions.setMaxConnectionsPerHost(com.datastax.driver.core.HostDistance.LOCAL, 1)
+      }
+      val rows = (1 to 10000).map(x => (x, x.toLong, x.toString))
+      sc.parallelize(rows).saveToCassandra(ks, "key_value")
+      sc.cassandraTable(ks, "key_value").cassandraCount() should be(10000)
+  }
+
+  it should "prevent failures based on driver pooling limits while joining" in {
+    conn.withClusterDo{cluster =>
+      val poolingOptions = cluster.getConfiguration.getPoolingOptions
+      poolingOptions.setMaxQueueSize(1)
+      poolingOptions.setMaxConnectionsPerHost(com.datastax.driver.core.HostDistance.LOCAL, 1)
+    }
+
+    val rows = (1 to 100000).map(Tuple1(_))
+    val results = sc.parallelize(rows).joinWithCassandraTable(ks, "key_value")
+    results.count should be(10000)
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
@@ -122,11 +122,13 @@ class CassandraJoinRDD[L, R] private[connector](
       readConf.readsPerSec, readConf.readsPerSec
     )
 
+    val queryExecutor = QueryExecutor(session, None, None)
+
     def pairWithRight(left: L): SettableFuture[Iterator[(L, R)]] = {
       val resultFuture = SettableFuture.create[Iterator[(L, R)]]
       val leftSide = Iterator.continually(left)
 
-      val queryFuture = session.executeAsync(bsb.bind(left))
+      val queryFuture = queryExecutor.executeAsync(bsb.bind(left))
       Futures.addCallback(queryFuture, new FutureCallback[ResultSet] {
         def onSuccess(rs: ResultSet) {
           val resultSet = new PrefetchingResultSetIterator(rs, fetchSize)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
@@ -145,11 +145,14 @@ class CassandraLeftJoinRDD[L, R] private[connector](
       readConf.readsPerSec, readConf.readsPerSec
     )
 
+    val queryExecutor = QueryExecutor(session, None, None)
+
+
     def pairWithRight(left: L): SettableFuture[Iterator[(L, Option[R])]] = {
       val resultFuture = SettableFuture.create[Iterator[(L, Option[R])]]
       val leftSide = Iterator.continually(left)
 
-      val queryFuture = session.executeAsync(bsb.bind(left))
+      val queryFuture = queryExecutor.executeAsync(bsb.bind(left))
       Futures.addCallback(queryFuture, new FutureCallback[ResultSet] {
         def onSuccess(rs: ResultSet) {
           val resultSet = new PrefetchingResultSetIterator(rs, fetchSize)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/AsyncExecutor.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/AsyncExecutor.scala
@@ -6,9 +6,10 @@ import com.datastax.spark.connector.util.Logging
 import com.google.common.util.concurrent.{FutureCallback, Futures, ListenableFuture, SettableFuture}
 
 import scala.collection.concurrent.TrieMap
+import scala.collection.JavaConverters._
 import scala.util.Try
-
 import AsyncExecutor.Handler
+import com.datastax.driver.core.exceptions.{BusyPoolException, NoHostAvailableException}
 
 /** Asynchronously executes tasks but blocks if the limit of unfinished tasks is reached. */
 class AsyncExecutor[T, R](asyncAction: T => ListenableFuture[R], maxConcurrentTasks: Int,
@@ -18,6 +19,7 @@ class AsyncExecutor[T, R](asyncAction: T => ListenableFuture[R], maxConcurrentTa
 
   private val semaphore = new Semaphore(maxConcurrentTasks)
   private val pendingFutures = new TrieMap[ListenableFuture[R], Boolean]
+  var latestExeception: Option[Throwable] = None
 
   /** Executes task asynchronously or blocks if more than `maxConcurrentTasks` limit is reached */
   def executeAsync(task: T): ListenableFuture[R] = {
@@ -28,28 +30,43 @@ class AsyncExecutor[T, R](asyncAction: T => ListenableFuture[R], maxConcurrentTa
     pendingFutures.put(settable, true)
 
     val executionTimestamp = System.nanoTime()
-    val future = asyncAction(task)
 
-    Futures.addCallback(future, new FutureCallback[R] {
-      def release() {
-        semaphore.release()
-        pendingFutures.remove(settable)
-      }
-      def onSuccess(result: R) {
-        release()
-        settable.set(result)
-        successHandler.foreach(_(task, submissionTimestamp, executionTimestamp))
-      }
-      def onFailure(throwable: Throwable) {
-        logError("Failed to execute: " + task, throwable)
-        if (_successful) _successful = false
-        release()
-        settable.setException(throwable)
-        failureHandler.foreach(_(task, submissionTimestamp, executionTimestamp))
-      }
-    })
+    def tryFuture(): SettableFuture[R] = {
+      val future = asyncAction(task)
 
-    settable
+      Futures.addCallback(future, new FutureCallback[R] {
+        def release() {
+          semaphore.release()
+          pendingFutures.remove(settable)
+        }
+
+        def onSuccess(result: R) {
+          release()
+          settable.set(result)
+          successHandler.foreach(_ (task, submissionTimestamp, executionTimestamp))
+        }
+
+        def onFailure(throwable: Throwable) {
+          throwable match {
+            case nHAE: NoHostAvailableException if nHAE.getErrors.asScala.values.exists(_.isInstanceOf[BusyPoolException]) =>
+              logWarning("BusyPoolException ... Retrying")
+              tryFuture()
+
+            case otherException =>
+              logError("Failed to execute: " + task, throwable)
+              if (_successful) _successful = false
+              release()
+              settable.setException(throwable)
+              latestExeception = Some(throwable)
+              failureHandler.foreach(_ (task, submissionTimestamp, executionTimestamp))
+          }
+        }
+      })
+
+      settable
+    }
+
+    tryFuture()
   }
 
   /** Waits until the tasks being currently executed get completed.     

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/QueryExecutor.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/QueryExecutor.scala
@@ -1,11 +1,33 @@
 package com.datastax.spark.connector.writer
 
-import com.datastax.driver.core.{ResultSet, Statement, Session}
-
+import com.datastax.driver.core.{HostDistance, ResultSet, Session, Statement}
 import AsyncExecutor.Handler
+import org.apache.spark.SparkEnv
 
-class QueryExecutor(session: Session, maxConcurrentQueries: Int,
-    successHandler: Option[Handler[RichStatement]], failureHandler: Option[Handler[RichStatement]])
+class QueryExecutor(
+ session: Session,
+ maxConcurrentQueries: Int,
+ successHandler: Option[Handler[RichStatement]],
+ failureHandler: Option[Handler[RichStatement]])
 
-    extends AsyncExecutor[RichStatement, ResultSet](
-      stmt => session.executeAsync(stmt.asInstanceOf[Statement]), maxConcurrentQueries, successHandler, failureHandler)
+  extends AsyncExecutor[RichStatement, ResultSet](
+    stmt => session.executeAsync(stmt.asInstanceOf[Statement]),
+    maxConcurrentQueries,
+    successHandler,
+    failureHandler)
+
+object QueryExecutor {
+
+  /**
+    * Builds a query executor whose max requests per connection is limited to the MaxRequests per Connection
+    */
+  def apply(
+    session: Session,
+    successHandler: Option[Handler[RichStatement]],
+    failureHandler: Option[Handler[RichStatement]]): QueryExecutor = {
+
+    val poolingOptions = session.getCluster.getConfiguration.getPoolingOptions
+    val maxConcurrentQueries = (poolingOptions.getMaxRequestsPerConnection(HostDistance.LOCAL))
+    new QueryExecutor(session, maxConcurrentQueries, successHandler, failureHandler)
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -203,14 +203,16 @@ class TableWriter[T] private (
 
       queryExecutor.waitForCurrentlyExecutingTasks()
 
-      if (!queryExecutor.successful)
-        throw new IOException(
-          s"""Failed to write statements to $keyspaceName.$tableName. The
-             |latest exception was
-             |  ${queryExecutor.latestExeception.map( _.getMessage).getOrElse("Unable to determine")}
-             |
-             |Please check the executor logs for more exceptions and information
-           """.stripMargin)
+      queryExecutor.getLatestException().map {
+        case exception =>
+          throw new IOException(
+            s"""Failed to write statements to $keyspaceName.$tableName. The
+               |latest exception was
+               |  ${exception.getMessage}
+               |
+               |Please check the executor logs for more exceptions and information
+             """.stripMargin)
+      }
 
       val duration = updater.finish() / 1000000000d
       logInfo(f"Wrote ${rowIterator.count} rows to $keyspaceName.$tableName in $duration%.3f s.")

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -204,7 +204,13 @@ class TableWriter[T] private (
       queryExecutor.waitForCurrentlyExecutingTasks()
 
       if (!queryExecutor.successful)
-        throw new IOException(s"Failed to write statements to $keyspaceName.$tableName.")
+        throw new IOException(
+          s"""Failed to write statements to $keyspaceName.$tableName. The
+             |latest exception was
+             |  ${queryExecutor.latestExeception.map( _.getMessage).getOrElse("Unable to determine")}
+             |
+             |Please check the executor logs for more exceptions and information
+           """.stripMargin)
 
       val duration = updater.finish() / 1000000000d
       logInfo(f"Wrote ${rowIterator.count} rows to $keyspaceName.$tableName in $duration%.3f s.")

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/AsyncExecutorTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/AsyncExecutorTest.scala
@@ -40,7 +40,7 @@ class AsyncExecutorTest {
     asyncExecutor.waitForCurrentlyExecutingTasks()
     assertEquals(maxParallel, maxParallelCounter.get())
     assertEquals(taskCount, totalFinishedExecutionsCounter.get())
-    assertEquals(true, asyncExecutor.successful)
+    assertEquals(None, asyncExecutor.getLatestException())
   }
 
 


### PR DESCRIPTION
A change in the Cassandra Java driver has caused the executeAsync method
to become fully asynchronous. This means that executeAsync calls can
sometimes return an exception of BusyPoolException, meaning that queries
were issued and no open execution pathway could be found. These
exceptions are always retryable because they indicate the local driver
state is temporarly busy. So we will retry these exceptions.

To make sure we don't have too many retries we will also make sure to
limit the number of max concurrent requests to the current
"requestsPerConnection" as specified in the pooling options. We are
already setting the maxPool size to the number of cores per executor so
this should prohibit having more requests in flight than we have open
connections.