### PR TITLE
SPARKC-501: added a histogram which records the distribution of the rows in batches

### DIFF
--- a/doc/11_metrics.md
+++ b/doc/11_metrics.md
@@ -33,17 +33,18 @@ configuration:
 - `spark.cassandra.output.metrics` - set to `false` to disable collection of output task metrics
 
 ### Available metrics
-Metric name            | Unit description
------------------------|---------------------------------------------------------------
-write-byte-meter       | Number of bytes written to Cassandra
-write-row-meter        | Number of rows written to Cassandra
-write-batch-timer      | Batch write time length
-write-batch-wait-timer | The length of time batches sit in the queue before being submitted to Cassandra
-write-task-timer       | Timer to measure time of writing a single partition
-write-success-counter  | Number successfully written batches
-write-failure-counter  | Number of failed batches
-read-byte-meter        | Number of bytes read from Cassandra
-read-row-meter         | Number of rows read from Cassandra
-read-task-timer        | Timer to measure time of reading a single partition
+Metric name                | Unit description
+---------------------------|---------------------------------------------------------------
+write-byte-meter           | Number of bytes written to Cassandra
+write-row-meter            | Number of rows written to Cassandra
+write-batch-timer          | Batch write time length
+write-batch-wait-timer     | The length of time batches sit in the queue before being submitted to Cassandra
+write-batch-size-histogram | The distribution of the rows in batches
+write-task-timer           | Timer to measure time of writing a single partition
+write-success-counter      | Number successfully written batches
+write-failure-counter      | Number of failed batches
+read-byte-meter            | Number of bytes read from Cassandra
+read-row-meter             | Number of rows read from Cassandra
+read-task-timer            | Timer to measure time of reading a single partition
 
 [Next - Building And Artifacts](12_building_and_artifacts.md)

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/metrics/CassandraConnectorSource.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/metrics/CassandraConnectorSource.scala
@@ -17,6 +17,7 @@ class CassandraConnectorSource extends Source {
   val writeBatchTimer = metricRegistry.timer("write-batch-timer")
   val writeBatchWaitTimer = metricRegistry.timer("write-batch-wait-timer")
   val writeTaskTimer = metricRegistry.timer("write-task-timer")
+  val writeBatchSizeHistogram = metricRegistry.histogram("write-batch-size-histogram")
 
   val writeSuccessCounter = metricRegistry.counter("write-success-counter")
   val writeFailureCounter = metricRegistry.counter("write-failure-counter")

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/metrics/OutputMetricsUpdater.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/metrics/OutputMetricsUpdater.scala
@@ -130,6 +130,7 @@ object OutputMetricsUpdater extends Logging {
         val t = System.nanoTime()
         source.writeBatchTimer.update(t - executionTimestamp, TimeUnit.NANOSECONDS)
         source.writeBatchWaitTimer.update(executionTimestamp - submissionTimestamp, TimeUnit.NANOSECONDS)
+        source.writeBatchSizeHistogram.update(count)
         source.writeRowMeter.mark(count)
         source.writeByteMeter.mark(dataLength)
         source.writeSuccessCounter.inc()

--- a/spark-cassandra-connector/src/test/scala/org/apache/spark/metrics/OutputMetricsUpdaterSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/org/apache/spark/metrics/OutputMetricsUpdaterSpec.scala
@@ -72,6 +72,8 @@ class OutputMetricsUpdaterSpec extends FlatSpec with Matchers with BeforeAndAfte
     ccs.writeByteMeter.getCount shouldBe 100L
     ccs.writeSuccessCounter.getCount shouldBe 1L
     ccs.writeFailureCounter.getCount shouldBe 0L
+    ccs.writeBatchSizeHistogram.getSnapshot.getMedian shouldBe 10
+    ccs.writeBatchSizeHistogram.getCount shouldBe 1
 
     updater.batchFinished(success = false, rc, ts, ts)
     ccs.writeRowMeter.getCount shouldBe 10L

--- a/spark-cassandra-connector/src/test/scala/org/apache/spark/metrics/OutputMetricsUpdaterSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/org/apache/spark/metrics/OutputMetricsUpdaterSpec.scala
@@ -72,14 +72,15 @@ class OutputMetricsUpdaterSpec extends FlatSpec with Matchers with BeforeAndAfte
     ccs.writeByteMeter.getCount shouldBe 100L
     ccs.writeSuccessCounter.getCount shouldBe 1L
     ccs.writeFailureCounter.getCount shouldBe 0L
-    ccs.writeBatchSizeHistogram.getSnapshot.getMedian shouldBe 10
-    ccs.writeBatchSizeHistogram.getCount shouldBe 1
+    ccs.writeBatchSizeHistogram.getSnapshot.getMedian shouldBe 10.0
+    ccs.writeBatchSizeHistogram.getCount shouldBe 1L
 
     updater.batchFinished(success = false, rc, ts, ts)
     ccs.writeRowMeter.getCount shouldBe 10L
     ccs.writeByteMeter.getCount shouldBe 100L
     ccs.writeSuccessCounter.getCount shouldBe 1L
     ccs.writeFailureCounter.getCount shouldBe 1L
+    ccs.writeBatchSizeHistogram.getCount shouldBe 1L
 
     updater.finish()
     ccs.writeTaskTimer.getCount shouldBe 1L


### PR DESCRIPTION
I added a histogram only for row count. If needed I can easily add similar histograms for bytes written, duration, even wait times.