### PR TITLE
Support partially specified writes from case classes

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/DefaultColumnMapper.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/mapper/DefaultColumnMapper.scala
@@ -102,10 +102,10 @@ class DefaultColumnMapper[T : TypeTag](columnNameOverride: Map[String, String] =
       } yield (getterName, columnRef)
     }.toMap
 
-    // Check if we have all the required columns:
+    // Check if all columns at start of table description are present in the case class:
     val mappedColumns = getterMap.values.toSet
     val unmappedColumns = selectedColumns.filterNot(mappedColumns)
-    require(unmappedColumns.isEmpty, s"Columns not found in $tpe: [${unmappedColumns.mkString(", ")}]")
+    require(selectedColumns.endsWith(unmappedColumns), s"Unmapped columns nust be at end of table definition: [${unmappedColumns.mkString(", ")}]")
 
     SimpleColumnMapForWriting(getterMap)
   }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/DefaultRowWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/DefaultRowWriter.scala
@@ -19,13 +19,12 @@ class DefaultRowWriter[T : TypeTag : ColumnMapper](
 
   override def readColumnValues(data: T, buffer: Array[Any]) = {
     val row = converter.convert(data)
-    for (i <- columnNames.indices)
+    for (i <- row.columnValues.indices)
       buffer(i) = row.getRaw(i)
   }
 }
 
 object DefaultRowWriter {
-
   def factory[T : ColumnMapper : TypeTag] = new RowWriterFactory[T] {
     override def rowWriter(tableDef: TableDef, selectedColumns: IndexedSeq[ColumnRef]) = {
       new DefaultRowWriter[T](tableDef, selectedColumns)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/MappedToGettableDataConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/MappedToGettableDataConverter.scala
@@ -166,7 +166,7 @@ private[connector] object MappedToGettableDataConverter extends Logging{
       }
 
       private val getters =
-        columnNames.map(getterByColumnName)
+        columnNames.flatMap(col => getterByColumnName.get(col))
 
       @transient
       private val scalaTypes: IndexedSeq[Type] =
@@ -179,7 +179,7 @@ private[connector] object MappedToGettableDataConverter extends Logging{
         new PropertyExtractor(cls, getters)
 
       private val converters = {
-        for (i <- columnNames.indices) yield {
+        for (i <- getters.indices) yield {
           try {
             val ct = columnTypes(i)
             val st = scalaTypes(i)

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/mapper/DefaultColumnMapperTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/mapper/DefaultColumnMapperTest.scala
@@ -205,11 +205,4 @@ class DefaultColumnMapperTest {
     new DefaultColumnMapper[DefaultColumnMapperTestClass1]()
       .columnMapForReading(table1, table1.columnRefs.tail)
   }
-
-  @Test(expected = classOf[IllegalArgumentException])
-  def testNotEnoughPropertiesForWriting(): Unit = {
-    new DefaultColumnMapper[DefaultColumnMapperTestClass1]()
-      .columnMapForWriting(table1, table1.columnRefs :+ ColumnName("missingColumn"))
-  }
-
 }


### PR DESCRIPTION
Currently, we cannot use `rdd.saveToCassandra` on an RDD[CaseClass] if `CaseClass` does not contain all of the fields from the target table.  This will currently result in the Error: 

```java.lang.IllegalArgumentException: requirement failed: Columns not found in CaseClass: [missing_field1, missing_field2]```

This can be limiting if the table has had columns added to it from an external process.  If this is the case, a job that writes to the table will automatically fail.  This PR proposes a resolution for this issue by making the failure case more permissive (if all of the first _n_ fields of the target table are matched by the case class, then we will attempt the write).