### PR TITLE
SPARKC-507: Infinite Retries

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -70,8 +70,9 @@ may also be used. ("127.0.0.1,192.168.0.1")
 </tr>
 <tr>
   <td><code>query.retry.count</code></td>
-  <td>10</td>
-  <td>Number of times to retry a timed-out query</td>
+  <td>60</td>
+  <td>Number of times to retry a timed-out query,
+Setting this to -1 means unlimited retries</td>
 </tr>
 <tr>
   <td><code>query.retry.delay</code></td>

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -207,6 +207,11 @@ OSS Cassandra this should never be used.</td>
 <table class="table">
 <tr><th>Property Name</th><th>Default</th><th>Description</th></tr>
 <tr>
+  <td><code>concurrent.reads</code></td>
+  <td>512</td>
+  <td>Sets read parallelism for joinWithCassandra tables</td>
+</tr>
+<tr>
   <td><code>input.consistency.level</code></td>
   <td>LOCAL_ONE</td>
   <td>Consistency level to use when reading	</td>

--- a/project/SparkCassandraConnectorBuild.scala
+++ b/project/SparkCassandraConnectorBuild.scala
@@ -162,7 +162,7 @@ object CassandraSparkBuild extends Build {
   lazy val refDoc = Project(
     id = s"$namespace-doc",
     base = file(s"$namespace-doc"),
-    settings = defaultSettings ++ Seq(libraryDependencies ++= Dependencies.spark)
+    settings = defaultSettings ++ Seq(libraryDependencies ++= (Dependencies.spark ++ Dependencies.cassandra))
   ) dependsOn connectorDistribution
 
   lazy val perf = Project(

--- a/spark-cassandra-connector/src/main/scala/com/datastax/driver/core/PreparedIdWorkaround.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/driver/core/PreparedIdWorkaround.scala
@@ -1,0 +1,15 @@
+package com.datastax.driver.core
+
+/**
+  * PreparedId's fields are all invisible inside of it's structure
+  * in the 3.X release of the Java Driver. We will have direct access
+  * in 4.0 but for now we use this backdoor to get the resultSetMetadata
+  * we want.
+  */
+object PreparedIdWorkaround {
+
+  def getResultMetadata(preparedId: PreparedId) = {
+    preparedId.resultSetMetadata
+  }
+
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -186,8 +186,10 @@ object CassandraConnectorConf extends Logging {
   val QueryRetryParam = ConfigParameter[Int](
     name = "spark.cassandra.query.retry.count",
     section = ReferenceSection,
-    default = 10,
-    description = """Number of times to retry a timed-out query""")
+    default = 60,
+    description =
+      """Number of times to retry a timed-out query,
+        |Setting this to -1 means unlimited retries""".stripMargin)
 
   @deprecated("delayed retrying has been disabled; see SPARKC-360", "1.2.6, 1.3.2, 1.4.3, 1.5.1")
   val QueryRetryDelayParam = ConfigParameter[RetryDelayConf](

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/AbstractCassandraJoin.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/AbstractCassandraJoin.scala
@@ -134,7 +134,7 @@ private[rdd] trait AbstractCassandraJoin[L, R] {
 
   private[rdd] def boundStatementBuilder(session: Session): BoundStatementBuilder[L] = {
     val protocolVersion = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersion
-    val stmt = session.prepare(singleKeyCqlQuery).setConsistencyLevel(consistencyLevel)
+    val stmt = session.prepare(singleKeyCqlQuery).setConsistencyLevel(consistencyLevel).setIdempotent(true)
     new BoundStatementBuilder[L](rowWriter, stmt, where.values, protocolVersion = protocolVersion)
   }
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
@@ -142,8 +142,9 @@ class CassandraJoinRDD[L, R] private[connector](
     val queryFutures = leftIterator.map(left => {
       rateLimiter.maybeSleep(1)
       pairWithRight(left)
-    }).toList
-    queryFutures.iterator.flatMap(_.get)
+    })
+
+    slidingPrefetchIterator(queryFutures, readConf.parallelismLevel).flatMap(identity)
   }
 
   /**

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraJoinRDD.scala
@@ -115,9 +115,9 @@ class CassandraJoinRDD[L, R] private[connector](
   private[rdd] def fetchIterator(
     session: Session,
     bsb: BoundStatementBuilder[L],
+    rowMetadata: CassandraRowMetadata,
     leftIterator: Iterator[L]
   ): Iterator[(L, R)] = {
-    val columnNames = selectedColumnRefs.map(_.selectedAs).toIndexedSeq
     val rateLimiter = new RateLimiter(
       readConf.throughputJoinQueryPerSec, readConf.throughputJoinQueryPerSec
     )
@@ -130,8 +130,7 @@ class CassandraJoinRDD[L, R] private[connector](
       Futures.addCallback(queryFuture, new FutureCallback[ResultSet] {
         def onSuccess(rs: ResultSet) {
           val resultSet = new PrefetchingResultSetIterator(rs, fetchSize)
-          val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames, rs);
-          val rightSide = resultSet.map(rowReader.read(_, columnMetaData))
+          val rightSide = resultSet.map(rowReader.read(_, rowMetadata))
           resultFuture.set(leftSide.zip(rightSide))
         }
         def onFailure(throwable: Throwable) {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
@@ -168,7 +168,7 @@ class CassandraLeftJoinRDD[L, R] private[connector](
     val queryFutures = leftIterator.map(left => {
       rateLimiter.maybeSleep(1)
       pairWithRight(left)
-    }).toList
-    queryFutures.iterator.flatMap(_.get)
+    })
+    slidingPrefetchIterator(queryFutures, readConf.parallelismLevel).flatMap(identity)
   }
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
@@ -274,7 +274,7 @@ class CassandraTableScanRDD[R] private[connector](
 
   private def createStatement(session: Session, cql: String, values: Any*): Statement = {
     try {
-      val stmt = session.prepare(cql)
+      val stmt = session.prepare(cql).setIdempotent(true)
       stmt.setConsistencyLevel(consistencyLevel)
       val converters = stmt.getVariables
         .map(v => ColumnType.converterToCassandra(v.getType))

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
@@ -21,7 +21,8 @@ case class ReadConf(
   fetchSizeInRows: Int = ReadConf.FetchSizeInRowsParam.default,
   consistencyLevel: ConsistencyLevel = ReadConf.ConsistencyLevelParam.default,
   taskMetricsEnabled: Boolean = ReadConf.TaskMetricParam.default,
-  throughputJoinQueryPerSec: Long = ReadConf.ThroughputJoinQueryPerSecParam.default
+  throughputJoinQueryPerSec: Long = ReadConf.ThroughputJoinQueryPerSecParam.default,
+   parallelismLevel: Int = ReadConf.ParallelismLevelParam.default
 )
 
 
@@ -60,13 +61,22 @@ object ReadConf {
     description =
       "Maximum read throughput allowed per single core in query/s while joining RDD with C* table")
 
+  val ParallelismLevelParam = ConfigParameter[Int] (
+    name = "spark.cassandra.concurrent.reads",
+    section = ReferenceSection,
+    default = 512,
+    description =
+       """Sets read parallelism for joinWithCassandra tables"""
+  )
+
   // Whitelist for allowed Read environment variables
   val Properties = Set(
     SplitSizeInMBParam,
     FetchSizeInRowsParam,
     ConsistencyLevelParam,
     TaskMetricParam,
-    ThroughputJoinQueryPerSecParam
+    ThroughputJoinQueryPerSecParam,
+    ParallelismLevelParam
   )
 
   def fromSparkConf(conf: SparkConf): ReadConf = {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TupleType.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TupleType.scala
@@ -36,7 +36,7 @@ case class TupleType(componentTypes: TupleFieldDef*)
       throw new IllegalArgumentException(s"Invalid tuple component index: ${c.index}. Expected: $i")
   }
 
-  override def columns = componentTypes.toIndexedSeq
+  override val columns = componentTypes.toIndexedSeq
 
   override def scalaTypeTag = TupleValue.TypeTag
 
@@ -92,7 +92,7 @@ case class TupleType(componentTypes: TupleFieldDef*)
     s"frozen<tuple<${types.mkString(", ")}>>"
   }
 
-  override def name = cqlTypeName
+  override val name = cqlTypeName
 
 }
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -6,7 +6,7 @@ import com.datastax.driver.core.BatchStatement.Type
 import com.datastax.driver.core._
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql._
-import com.datastax.spark.connector.types.{ListType, MapType}
+import com.datastax.spark.connector.types.{CollectionColumnType, ListType, MapType}
 import com.datastax.spark.connector.util.Quote._
 import com.datastax.spark.connector.util.Logging
 import com.datastax.spark.connector.util.CountingIterator
@@ -108,10 +108,32 @@ class TableWriter[T] private (
   private val containsCollectionBehaviors =
     columnSelector.exists(_.isInstanceOf[CollectionColumnName])
 
+  private[connector] val isIdempotent: Boolean = {
+    //All counter operations are not Idempotent
+    if (columns.filter(_.isCounterColumn).nonEmpty) {
+        false
+    } else {
+      columnSelector.forall {
+        //Any appends or prepends to a list are non-idempotent
+        case cn: CollectionColumnName =>
+          val name = cn.columnName
+          val behavior = cn.collectionBehavior
+          val isNotList = !tableDef.columnByName(name).columnType.isInstanceOf[ListType[_]]
+          behavior match {
+            case CollectionPrepend => isNotList
+            case CollectionAppend => isNotList
+            case _ => true
+          }
+        //All other operations on regular columns are idempotent
+        case regularColumn: ColumnRef => true
+      }
+    }
+  }
+
 
   private def prepareStatement(queryTemplate:String, session: Session): PreparedStatement = {
     try {
-      session.prepare(queryTemplate)
+      session.prepare(queryTemplate).setIdempotent(isIdempotent)
     }
     catch {
       case t: Throwable =>
@@ -164,7 +186,7 @@ class TableWriter[T] private (
 
   /**
     * Cql DELETE statement
-    * @param columns columns to delete, the row will be deleted comletely if the list is empty
+    * @param columns columns to delete, the row will be deleted completely if the list is empty
     * @param taskContext
     * @param data primary key values to select delete rows
     */

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/cql/MultipleRetrySpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/cql/MultipleRetrySpec.scala
@@ -1,0 +1,91 @@
+package com.datastax.spark.connector.cql
+
+import java.net.InetSocketAddress
+
+import com.datastax.driver.core.{ConsistencyLevel, SimpleStatement, WriteType}
+import com.datastax.driver.core.exceptions._
+import com.datastax.driver.core.policies.RetryPolicy.RetryDecision
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.JavaConverters._
+
+class MultipleRetrySpec extends FlatSpec with Matchers {
+
+  private val statement = new SimpleStatement("foobuzz")
+  private val cl = ConsistencyLevel.THREE
+
+  def throwExceptionInPolicy(
+                              policy: MultipleRetryPolicy,
+                              exception: DriverException,
+                              nbRetry: Int = 1): RetryDecision.Type = {
+
+    exception match {
+      case e: ReadTimeoutException => policy.onReadTimeout(
+        statement,
+        cl,
+        3,
+        1,
+        false,
+        nbRetry
+      )
+      case e: WriteTimeoutException => policy.onWriteTimeout(
+        statement,
+        cl,
+        WriteType.SIMPLE,
+        3,
+        1,
+        nbRetry
+      )
+      case e: UnavailableException => policy.onUnavailable(
+        statement,
+        cl,
+        3,
+        1,
+        nbRetry
+      )
+      case e: DriverException => policy.onRequestError(
+        statement,
+        cl,
+        e,
+        nbRetry
+      )
+    }
+  }.getType
+
+  val writeTimeout =  new WriteTimeoutException(cl, WriteType.SIMPLE,3, 1)
+  val readTimeout = new ReadTimeoutException(cl, 3, 1, false)
+  val unavailableException = new UnavailableException(cl, 3, 1)
+  val retry = RetryDecision.retry(null).getType
+  val rethrow = RetryDecision.rethrow().getType
+
+  "MultipleRetryPolicy" should "retry always if maxRetry is -1" in {
+    val policy = new MultipleRetryPolicy(-1)
+    for (nbRetry <- 1 to 100) {
+      throwExceptionInPolicy(policy, writeTimeout, nbRetry) should be (retry)
+      throwExceptionInPolicy(policy, readTimeout, nbRetry) should be (retry)
+    }
+  }
+
+  it should "not retry past maxRetry" in {
+    val policy = new MultipleRetryPolicy(5)
+    for (nbRetry <- 6 to 10) {
+      throwExceptionInPolicy(policy, writeTimeout, nbRetry) should be (rethrow)
+      throwExceptionInPolicy(policy, readTimeout, nbRetry) should be (rethrow)
+    }
+  }
+
+  it should "not retry authentication errors" in {
+    val policy = new MultipleRetryPolicy(5)
+    throwExceptionInPolicy(policy,
+      new AuthenticationException(new InetSocketAddress(400),"oops"),
+      1) should be (rethrow)
+  }
+
+  it should "retry all of our accepted exceptions" in {
+    val policy = new MultipleRetryPolicy(5)
+    throwExceptionInPolicy(policy, writeTimeout) should be(retry)
+    throwExceptionInPolicy(policy, readTimeout) should be(retry)
+    throwExceptionInPolicy(policy, unavailableException) should be(retry)
+  }
+}


### PR DESCRIPTION
Changes our retry policy to retry all exceptions which can possible be
temporary. This will move burden to users to detect when the system is
beyond hope but will allow a momentarily troubled cluster recover from
issues.