### PR TITLE
Requesting a pull to datastax:master from datastax:SPARKC-507-master

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -77,8 +77,9 @@ may also be used. ("127.0.0.1,192.168.0.1")
 </tr>
 <tr>
   <td><code>query.retry.count</code></td>
-  <td>10</td>
-  <td>Number of times to retry a timed-out query</td>
+  <td>60</td>
+  <td>Number of times to retry a timed-out query,
+Setting this to -1 means unlimited retries</td>
 </tr>
 <tr>
   <td><code>read.timeout_ms</code></td>
@@ -201,6 +202,11 @@ OSS Cassandra this should never be used.</td>
 
 <table class="table">
 <tr><th>Property Name</th><th>Default</th><th>Description</th></tr>
+<tr>
+  <td><code>concurrent.reads</code></td>
+  <td>512</td>
+  <td>Sets read parallelism for joinWithCassandra tables</td>
+</tr>
 <tr>
   <td><code>input.consistency.level</code></td>
   <td>LOCAL_ONE</td>

--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
@@ -908,4 +908,40 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase {
     results should contain theSameElementsAs Seq((1, "new"), (2, "new"))
   }
 
+  "Idempotent Queries" should "not be used with list append" in {
+    val listAppend = TableWriter(conn, ks, "collections_mod", SomeColumns("key", "lcol" append), WriteConf.fromSparkConf(sc.getConf))
+    listAppend.isIdempotent should be (false)
+  }
+
+  it should "not be used with list prepend" in {
+    val listPrepend = TableWriter(conn, ks, "collections_mod", SomeColumns("key", "lcol" prepend), WriteConf.fromSparkConf(sc.getConf))
+    listPrepend.isIdempotent should be (false)
+  }
+
+  it should "not be used with counter modifications" in {
+    val counterUpdate = TableWriter(conn, ks, "counters", SomeColumns("pkey", "ckey", "c1", "c2"), WriteConf.fromSparkConf(sc.getConf))
+    counterUpdate.isIdempotent should be (false)
+  }
+
+  it should "be used with ifNotExists updates" in {
+    val ifNotExists = TableWriter(conn, ks, "write_if_not_exists_test", AllColumns, writeConf = WriteConf(ifNotExists = true))
+    ifNotExists.isIdempotent should be (true)
+  }
+
+  it should "be used with generic writes" in {
+    val genericWrite = TableWriter(conn, ks, "key_value", AllColumns, WriteConf.fromSparkConf(sc.getConf))
+    genericWrite.isIdempotent should be (true)
+  }
+
+  it should "be used with collections that aren't lists" in {
+    val listOverwrite = TableWriter(conn, ks, "collections_mod", SomeColumns("key", "lcol" overwrite), WriteConf.fromSparkConf(sc.getConf))
+    listOverwrite.isIdempotent should be (true)
+    val setOverwrite = TableWriter(conn, ks, "collections_mod", SomeColumns("key", "scol" overwrite), WriteConf.fromSparkConf(sc.getConf))
+    setOverwrite.isIdempotent should be (true)
+    val mapOverwrite = TableWriter(conn, ks, "collections_mod", SomeColumns("key", "mcol" overwrite), WriteConf.fromSparkConf(sc.getConf))
+    mapOverwrite.isIdempotent should be (true)
+  }
+
+
+
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/driver/core/PreparedIdWorkaround.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/driver/core/PreparedIdWorkaround.scala
@@ -1,0 +1,15 @@
+package com.datastax.driver.core
+
+/**
+  * PreparedId's fields are all invisible inside of it's structure
+  * in the 3.X release of the Java Driver. We will have direct access
+  * in 4.0 but for now we use this backdoor to get the resultSetMetadata
+  * we want.
+  */
+object PreparedIdWorkaround {
+
+  def getResultMetadata(preparedId: PreparedId) = {
+    preparedId.resultSetMetadata
+  }
+
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -136,8 +136,10 @@ object CassandraConnectorConf extends Logging {
   val QueryRetryParam = ConfigParameter[Int](
     name = "spark.cassandra.query.retry.count",
     section = ReferenceSection,
-    default = 10,
-    description = """Number of times to retry a timed-out query""")
+    default = 60,
+    description =
+      """Number of times to retry a timed-out query,
+        |Setting this to -1 means unlimited retries""".stripMargin)
 
   val ReadTimeoutParam = ConfigParameter[Int](
     name = "spark.cassandra.read.timeout_ms",

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/AbstractCassandraJoin.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/AbstractCassandraJoin.scala
@@ -1,6 +1,8 @@
 package com.datastax.spark.connector.rdd
 
-import com.datastax.driver.core.Session
+import java.util.concurrent.Future
+
+import com.datastax.driver.core.{PreparedStatement, Session}
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.rdd.CassandraLimit._
 import com.datastax.spark.connector.util.CqlWhereParser.{EqPredicate, InListPredicate, InPredicate, RangePredicate}
@@ -11,6 +13,7 @@ import org.apache.spark.metrics.InputMetricsUpdater
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{Partition, TaskContext}
 
+import scala.collection.JavaConverters._
 /**
  * This trait contains shared methods from [[com.datastax.spark.connector.rdd.CassandraJoinRDD]] and
  * [[com.datastax.spark.connector.rdd.CassandraLeftJoinRDD]] to avoid code duplication.
@@ -30,6 +33,7 @@ private[rdd] trait AbstractCassandraJoin[L, R] {
   private[rdd] def fetchIterator(
     session: Session,
     bsb: BoundStatementBuilder[L],
+    rowMetadata: CassandraRowMetadata,
     lastIt: Iterator[L]
   ): Iterator[(L, R)]
 
@@ -133,11 +137,22 @@ private[rdd] trait AbstractCassandraJoin[L, R] {
     query
   }
 
+  private def getPreparedStatement(session: Session): PreparedStatement = {
+    session.prepare(singleKeyCqlQuery).setConsistencyLevel(consistencyLevel).setIdempotent(true)
+  }
+
+  private def getCassandraRowMetadata(session: Session) = {
+    val columnNames = selectedColumnRefs.map(_.selectedAs).toIndexedSeq
+    val id = getPreparedStatement(session).getPreparedId
+    CassandraRowMetadata.fromPreparedId(columnNames, id)
+  }
+
   private[rdd] def boundStatementBuilder(session: Session): BoundStatementBuilder[L] = {
     val protocolVersion = session.getCluster.getConfiguration.getProtocolOptions.getProtocolVersion
-    val stmt = session.prepare(singleKeyCqlQuery).setConsistencyLevel(consistencyLevel)
+    val stmt = getPreparedStatement(session)
     new BoundStatementBuilder[L](rowWriter, stmt, where.values, protocolVersion = protocolVersion)
   }
+
 
   /**
    * When computing a CassandraPartitionKeyRDD the data is selected via single CQL statements
@@ -147,8 +162,9 @@ private[rdd] trait AbstractCassandraJoin[L, R] {
   override def compute(split: Partition, context: TaskContext): Iterator[(L, R)] = {
     val session = connector.openSession()
     val bsb = boundStatementBuilder(session)
+    val rowMetadata = getCassandraRowMetadata(session)
     val metricsUpdater = InputMetricsUpdater(context, readConf)
-    val rowIterator = fetchIterator(session, bsb, left.iterator(split, context))
+    val rowIterator = fetchIterator(session, bsb, rowMetadata, left.iterator(split, context))
     val countingIterator = new CountingIterator(rowIterator, None)
 
     context.addTaskCompletionListener { (context) =>
@@ -182,6 +198,16 @@ private[rdd] trait AbstractCassandraJoin[L, R] {
       clusteringOrder = clusteringOrder,
       readConf = readConf
     )
+
+  /** Prefetches a batchSize of elements at a time **/
+  protected def slidingPrefetchIterator[T](it: Iterator[Future[T]], batchSize: Int): Iterator[T] = {
+    val (firstElements, lastElement) =  it
+      .grouped(batchSize)
+      .sliding(2)
+      .span(_ => it.hasNext)
+
+    (firstElements.map(_.head) ++ lastElement.flatten).flatten.map(_.get)
+  }
 
 }
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
@@ -138,14 +138,14 @@ class CassandraLeftJoinRDD[L, R] private[connector](
   private[rdd] def fetchIterator(
     session: Session,
     bsb: BoundStatementBuilder[L],
+    rowMetadata: CassandraRowMetadata,
     leftIterator: Iterator[L]
   ): Iterator[(L, Option[R])] = {
-    val columnNames = selectedColumnRefs.map(_.selectedAs).toIndexedSeq
     val rateLimiter = new RateLimiter(
       readConf.readsPerSec, readConf.readsPerSec
     )
 
-    val queryExecutor = QueryExecutor(session, None, None)
+    val queryExecutor = QueryExecutor(session, readConf.parallelismLevel,None, None)
 
 
     def pairWithRight(left: L): SettableFuture[Iterator[(L, Option[R])]] = {
@@ -156,10 +156,9 @@ class CassandraLeftJoinRDD[L, R] private[connector](
       Futures.addCallback(queryFuture, new FutureCallback[ResultSet] {
         def onSuccess(rs: ResultSet) {
           val resultSet = new PrefetchingResultSetIterator(rs, fetchSize)
-          val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames, rs)
           val rightSide = resultSet.isEmpty match {
             case true => Iterator.single(None)
-            case false => resultSet.map(r => Some(rowReader.read(r, columnMetaData)))
+            case false => resultSet.map(r => Some(rowReader.read(r, rowMetadata)))
           }
           resultFuture.set(leftSide.zip(rightSide))
         }
@@ -172,7 +171,7 @@ class CassandraLeftJoinRDD[L, R] private[connector](
     val queryFutures = leftIterator.map(left => {
       rateLimiter.maybeSleep(1)
       pairWithRight(left)
-    }).toList
-    queryFutures.iterator.flatMap(_.get)
+    })
+    slidingPrefetchIterator(queryFutures, readConf.parallelismLevel).flatMap(identity)
   }
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
@@ -306,7 +306,7 @@ class CassandraTableScanRDD[R] private[connector](
 
   private def createStatement(session: Session, cql: String, values: Any*): Statement = {
     try {
-      val stmt = session.prepare(cql)
+      val stmt = session.prepare(cql).setIdempotent(true)
       stmt.setConsistencyLevel(consistencyLevel)
       val converters = stmt.getVariables
         .map(v => ColumnType.converterToCassandra(v.getType))

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
@@ -22,6 +22,7 @@ case class ReadConf(
   fetchSizeInRows: Int = ReadConf.FetchSizeInRowsParam.default,
   consistencyLevel: ConsistencyLevel = ReadConf.ConsistencyLevelParam.default,
   taskMetricsEnabled: Boolean = ReadConf.TaskMetricParam.default,
+  parallelismLevel: Int = ReadConf.ParallelismLevelParam.default,
   readsPerSec: Int = ReadConf.ReadsPerSecParam.default
 )
 
@@ -64,6 +65,14 @@ object ReadConf extends Logging {
     description =
       "**Deprecated** Please use input.reads_per_sec. Maximum read throughput allowed per single core in query/s while joining RDD with Cassandra table")
 
+  val ParallelismLevelParam = ConfigParameter[Int] (
+    name = "spark.cassandra.concurrent.reads",
+    section = ReferenceSection,
+    default = 512,
+    description =
+       """Sets read parallelism for joinWithCassandra tables"""
+  )
+
 
   val ReadsPerSecParam = ConfigParameter[Int] (
     name = "spark.cassandra.input.reads_per_sec",
@@ -80,7 +89,8 @@ object ReadConf extends Logging {
     ReadsPerSecParam,
     SplitSizeInMBParam,
     TaskMetricParam,
-    ThroughputJoinQueryPerSecParam
+    ThroughputJoinQueryPerSecParam,
+    ParallelismLevelParam
   )
 
   def fromSparkConf(conf: SparkConf): ReadConf = {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TupleType.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TupleType.scala
@@ -36,7 +36,7 @@ case class TupleType(componentTypes: TupleFieldDef*)
       throw new IllegalArgumentException(s"Invalid tuple component index: ${c.index}. Expected: $i")
   }
 
-  override def columns = componentTypes.toIndexedSeq
+  override val columns = componentTypes.toIndexedSeq
 
   override def scalaTypeTag = TupleValue.TypeTag
 
@@ -92,7 +92,7 @@ case class TupleType(componentTypes: TupleFieldDef*)
     s"frozen<tuple<${types.mkString(", ")}>>"
   }
 
-  override def name = cqlTypeName
+  override val name = cqlTypeName
 
 }
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/QueryExecutor.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/QueryExecutor.scala
@@ -23,11 +23,12 @@ object QueryExecutor {
     */
   def apply(
     session: Session,
+    parallelismLevel: Int,
     successHandler: Option[Handler[RichStatement]],
     failureHandler: Option[Handler[RichStatement]]): QueryExecutor = {
 
     val poolingOptions = session.getCluster.getConfiguration.getPoolingOptions
-    val maxConcurrentQueries = (poolingOptions.getMaxRequestsPerConnection(HostDistance.LOCAL))
+    val maxConcurrentQueries = (parallelismLevel)
     new QueryExecutor(session, maxConcurrentQueries, successHandler, failureHandler)
   }
 }

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/cql/MultipleRetrySpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/cql/MultipleRetrySpec.scala
@@ -1,0 +1,91 @@
+package com.datastax.spark.connector.cql
+
+import java.net.InetSocketAddress
+
+import com.datastax.driver.core.{ConsistencyLevel, SimpleStatement, WriteType}
+import com.datastax.driver.core.exceptions._
+import com.datastax.driver.core.policies.RetryPolicy.RetryDecision
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.JavaConverters._
+
+class MultipleRetrySpec extends FlatSpec with Matchers {
+
+  private val statement = new SimpleStatement("foobuzz")
+  private val cl = ConsistencyLevel.THREE
+
+  def throwExceptionInPolicy(
+                              policy: MultipleRetryPolicy,
+                              exception: DriverException,
+                              nbRetry: Int = 1): RetryDecision.Type = {
+
+    exception match {
+      case e: ReadTimeoutException => policy.onReadTimeout(
+        statement,
+        cl,
+        3,
+        1,
+        false,
+        nbRetry
+      )
+      case e: WriteTimeoutException => policy.onWriteTimeout(
+        statement,
+        cl,
+        WriteType.SIMPLE,
+        3,
+        1,
+        nbRetry
+      )
+      case e: UnavailableException => policy.onUnavailable(
+        statement,
+        cl,
+        3,
+        1,
+        nbRetry
+      )
+      case e: DriverException => policy.onRequestError(
+        statement,
+        cl,
+        e,
+        nbRetry
+      )
+    }
+  }.getType
+
+  val writeTimeout =  new WriteTimeoutException(cl, WriteType.SIMPLE,3, 1)
+  val readTimeout = new ReadTimeoutException(cl, 3, 1, false)
+  val unavailableException = new UnavailableException(cl, 3, 1)
+  val retry = RetryDecision.retry(null).getType
+  val rethrow = RetryDecision.rethrow().getType
+
+  "MultipleRetryPolicy" should "retry always if maxRetry is -1" in {
+    val policy = new MultipleRetryPolicy(-1)
+    for (nbRetry <- 1 to 100) {
+      throwExceptionInPolicy(policy, writeTimeout, nbRetry) should be (retry)
+      throwExceptionInPolicy(policy, readTimeout, nbRetry) should be (retry)
+    }
+  }
+
+  it should "not retry past maxRetry" in {
+    val policy = new MultipleRetryPolicy(5)
+    for (nbRetry <- 6 to 10) {
+      throwExceptionInPolicy(policy, writeTimeout, nbRetry) should be (rethrow)
+      throwExceptionInPolicy(policy, readTimeout, nbRetry) should be (rethrow)
+    }
+  }
+
+  it should "not retry authentication errors" in {
+    val policy = new MultipleRetryPolicy(5)
+    throwExceptionInPolicy(policy,
+      new AuthenticationException(new InetSocketAddress(400),"oops"),
+      1) should be (rethrow)
+  }
+
+  it should "retry all of our accepted exceptions" in {
+    val policy = new MultipleRetryPolicy(5)
+    throwExceptionInPolicy(policy, writeTimeout) should be(retry)
+    throwExceptionInPolicy(policy, readTimeout) should be(retry)
+    throwExceptionInPolicy(policy, unavailableException) should be(retry)
+  }
+}


### PR DESCRIPTION
Write a message for this pull request. The first block
 of text is the title and the rest is the description.

 Changes:

 885c7862 (Russell Spitzer, 30 minutes ago)
    SPARKC-507: Change Async Method in JoinWithCasasndraTable

    New concurrent.reads parameter allows users to limit read paralleism in the
    same way they could limit write parallelism. This is only applied to
    concurrent requests during direct join point lookups.

    Previously joinWithCassandraTable would issue all futures using a toList
    operation on the query iterator. This would end up putting all of the
    futures in memory causing OOM if there were many keys in the partition.

    To fix this we remove the list call and instead use a sliding iterator
    which will always be pulling new futures from the iterator.

 f95f84ba (Russell Spitzer, 3 hours ago)
    SPARKC-507: Remove excess object creation

    Previously there were several places in the read path which ended up
    generating objects which were never used or could have been cached. In
    particular we change the usage of CassandraRowMetadata which previously was
    created for every query. Now only a single metadata will be made per task
    in CassandraJoinRDDs.

 273b689d (Russell Spitzer, 3 weeks ago)
    SPARKC-507: Infinite Retries and  Mark all Idmepotent Queries

    Changes our retry policy to retry all exceptions that are temporary. This
    will move burden to users to detect when the system is beyond hope but will
    allow a momentarily troubled cluster recover from issues.

    Some queries will not be retried regardless of the retry policy. To fix
    this we mark all of our idempotent queries so the driver will retry them.