### PR TITLE
SPARKC-426: Allow POJOS to be set as NULL

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/GettableDataToMappedTypeConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/reader/GettableDataToMappedTypeConverter.scala
@@ -104,8 +104,25 @@ private[connector] class GettableDataToMappedTypeConverter[T : TypeTag : ColumnM
         val valueConverter = converter(valueColumnType, valueScalaType)
         TypeConverter.forType[U](Seq(keyConverter, valueConverter))
 
-      case (_, _) =>
-        TypeConverter.forType[U]
+      case (_, _) => TypeConverter.forType[U]
+    }
+  }
+
+  /**
+    * Avoids getting a "Can not convert Null to X" on allowed nullable types.
+    *
+    * This is identical to the trait NullableTypeConverter but
+    * will end up throwing exceptions on null casting to scala types because of the lack of
+    * restrictions on T
+    *
+    * Since the below "tryConvert Method" will handle NPEs we don't have to worry about the
+    * fact that T ! <: AnyRef
+    */
+  override def convert(obj: Any): T = {
+    if (obj != null) {
+      super.convert(obj)
+    } else {
+      null.asInstanceOf[T]
     }
   }
 

--- a/spark-cassandra-connector/src/test/java/com/datastax/spark/connector/mapper/ClassWithUDTBean.java
+++ b/spark-cassandra-connector/src/test/java/com/datastax/spark/connector/mapper/ClassWithUDTBean.java
@@ -1,0 +1,136 @@
+package com.datastax.spark.connector.mapper;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class ClassWithUDTBean implements Serializable
+{
+    public static class AddressBean implements Serializable
+    {
+        private String street;
+        private String city;
+        private Integer zip;
+
+        public AddressBean() {}
+        public AddressBean(String street, String city, Integer zip) {
+            this.street = street;
+            this.city = city;
+            this.zip = zip;
+        }
+
+
+
+        public Integer getZip()
+        {
+            return zip;
+        }
+
+        public String getCity()
+        {
+            return city;
+        }
+
+        public String getStreet()
+        {
+            return street;
+        }
+
+        public void setCity(String city)
+        {
+            this.city = city;
+        }
+
+        public void setStreet(String street)
+        {
+            this.street = street;
+        }
+
+        public void setZip(Integer zip)
+        {
+            this.zip = zip;
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (!(obj instanceof AddressBean))
+                return false;
+
+            AddressBean that = (AddressBean) obj;
+            return Objects.equals(that.city, this.city) &&
+                    Objects.equals(that.street, this.street) &&
+                    Objects.equals(that.zip, this.zip);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(city, street, zip);
+        }
+    }
+
+    private Integer key;
+    private String name;
+    private AddressBean addr;
+
+    public ClassWithUDTBean() {}
+    public ClassWithUDTBean(Integer key, String name, AddressBean addr) {
+        this.key = key;
+        this.name = name;
+        this.addr = addr;
+    }
+
+    public AddressBean getAddr()
+    {
+        return addr;
+    }
+
+    public Integer getKey()
+    {
+        return key;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setAddr(AddressBean addr)
+    {
+        this.addr = addr;
+    }
+
+    public void setKey(Integer key)
+    {
+        this.key = key;
+    }
+
+    public void setName(String name)
+    {
+        this.name = name;
+    }
+
+    @Override
+    public String toString()
+    {
+        return key + " : " + name + " : " + addr;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (!(obj instanceof ClassWithUDTBean))
+            return false;
+
+        ClassWithUDTBean that = (ClassWithUDTBean) obj;
+        return Objects.equals(this.addr, that.addr) &&
+                Objects.equals(this.key, that.key) &&
+                Objects.equals(this.name, that.name);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(addr, key, name);
+    }
+}


### PR DESCRIPTION
Previously a null would hit trigger a `CannotConvert` error before
getting to the "nulls allowed" check in gettable mapped data. Now we
attempt to pass through the null and catch the exception if we cannot
cast the Null into the acceptable type.