### PR TITLE
SPARKC-318: Nested columns in an MBean cannot be null

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
@@ -61,7 +61,6 @@ trait NullableTypeConverter[T] extends TypeConverter[T] {
 /** Chains together several converters converting to the same type.
   * This way you can extend functionality of any converter to support new input types. */
 class ChainedTypeConverter[T](converters: TypeConverter[T]*) extends NullableTypeConverter[T] {
-  def testAnyVal[T](x: T)(implicit evidence: T <:< AnyVal = null) = evidence != null
   def targetTypeTag = converters.head.targetTypeTag
   def convertPF = converters.map(_.convertPF).reduceLeft(_ orElse _)
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
@@ -50,7 +50,7 @@ trait TypeConverter[T] extends Serializable {
 }
 
 /** Handles nullable types and converts any null to null. */
-trait NullableTypeConverter[T <: AnyRef] extends TypeConverter[T] {
+trait NullableTypeConverter[T] extends TypeConverter[T] {
   override def convert(obj: Any): T =
     if (obj != null)
       super.convert(obj)
@@ -60,7 +60,8 @@ trait NullableTypeConverter[T <: AnyRef] extends TypeConverter[T] {
 
 /** Chains together several converters converting to the same type.
   * This way you can extend functionality of any converter to support new input types. */
-class ChainedTypeConverter[T](converters: TypeConverter[T]*) extends TypeConverter[T] {
+class ChainedTypeConverter[T](converters: TypeConverter[T]*) extends NullableTypeConverter[T] {
+  def testAnyVal[T](x: T)(implicit evidence: T <:< AnyVal = null) = evidence != null
   def targetTypeTag = converters.head.targetTypeTag
   def convertPF = converters.map(_.convertPF).reduceLeft(_ orElse _)
 }

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/reader/GettableDataToMappedTypeConverterSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/reader/GettableDataToMappedTypeConverterSpec.scala
@@ -347,6 +347,29 @@ class GettableDataToMappedTypeConverterSpec extends FlatSpec with Matchers {
     user.getAddress.getNumber shouldBe 5
   }
 
+  class LongBean {
+    private[this] var number: java.lang.Long = null
+    def getNumber: java.lang.Long = number
+    def setNumber(number: java.lang.Long): Unit = { this.number = number }
+  }
+
+  class NestedLongBean {
+    private[this] var long: LongBean = null
+    def getLong: LongBean = long
+    def setLong(l: LongBean) = { this.long = long }
+  }
+
+  it should "convert a CassandraRow with UDTs with Long null values to nested JavaBeans" in {
+    implicit val cm: ColumnMapper[NestedLongBean] = new JavaBeanColumnMapper[NestedLongBean]
+    val long = UDTValue.fromMap(Map("number" -> null))
+    val row = CassandraRow.fromMap(Map("long" -> long))
+    val converter = new GettableDataToMappedTypeConverter[NestedLongBean](
+      userTable, userTable.columnRefs
+    )
+    val user = converter.convert(row)
+    user.getLong shouldBe null
+  }
+
   class UnknownType
   case class UserWithUnknownType(login: String, password: UnknownType)
 


### PR DESCRIPTION
053d77c9 (Russell Spitzer, 55 seconds ago)
       SPARKC-318: Removed unused function
       This function was added in the initial PR but doesn't seem to be used
       anywhere. I've removed it and all the tests still pass.
    aab13f58 (Nick Rushton, 1 year, 5 months ago)
       Add tests for SPARKC-318 Fix mapping a column with null value
    22ad959e (Delyan Dimitrov, 1 year, 6 months ago)
       Fix mapping a column with null value