### PR TITLE
Bump version of sbt-coursier plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -28,6 +28,6 @@ addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.5")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M12")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")


### PR DESCRIPTION
Scalaz version used by previous version of that plugin wasn't compatible with sbtclipse
plugin, so bumping version of sbt-coursier plugin that uses newer version of scalaz,
resolved the issue