### PR TITLE
SPARKC-531: Allow non-cluster prefixed options in sqlConf

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -245,14 +245,6 @@ read the Cassandra table into. This parameter is
 used in SparkSql and DataFrame Options.
       </td>
 </tr>
-<tr>
-  <td><code>splitCount</code></td>
-  <td>None</td>
-  <td>Specify the number of Spark partitions to
-read the Cassandra table into. This parameter is
-used in SparkSql and DataFrame Options.
-      </td>
-</tr>
 </table>
 
 

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSourceRelation.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSourceRelation.scala
@@ -315,11 +315,13 @@ object CassandraSourceRelation {
     val ks = tableRef.keyspace
     //Keyspace/Cluster level settings
     for (prop <- DefaultSource.confProperties) {
+      val lowerCasedProp = prop.toLowerCase(Locale.ROOT)
       val value = Seq(
-        tableConf.get(prop.toLowerCase(Locale.ROOT)),
+        tableConf.get(lowerCasedProp),
         sqlConf.get(s"$cluster:$ks/$prop"),
         sqlConf.get(s"$cluster/$prop"),
-        sqlConf.get(s"default/$prop")).flatten.headOption
+        sqlConf.get(s"default/$prop"),
+        sqlConf.get(prop)).flatten.headOption
       value.foreach(conf.set(prop, _))
     }
     //Set all user properties

--- a/spark-cassandra-connector/src/test/scala/org/apache/spark/sql/cassandra/ConsolidateSettingsSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/org/apache/spark/sql/cassandra/ConsolidateSettingsSpec.scala
@@ -1,10 +1,12 @@
 package org.apache.spark.sql.cassandra
 
+import java.util.Locale
+
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.cassandra.CassandraSourceRelation._
 import org.scalatest.{FlatSpec, Matchers}
-
 import com.datastax.spark.connector.rdd.ReadConf
+import com.datastax.spark.connector.writer.WriteConf
 
 class ConsolidateSettingsSpec extends FlatSpec with Matchers {
 
@@ -18,13 +20,14 @@ class ConsolidateSettingsSpec extends FlatSpec with Matchers {
       sqlContextConf: Map[String, String],
       tableConf: Map[String, String],
       value: Option[String],
-      valueForDefaultCluster: Option[String]): Unit = {
+      valueForDefaultCluster: Option[String],
+      checkParam: String = param.name): Unit = {
     val sc = this.sparkConf.clone().setAll(sparkConf)
 
     val consolidatedConf1 = consolidateConfs(sc, sqlContextConf, tableRef, tableConf)
     val consolidatedConf2 = consolidateConfs(sc, sqlContextConf, tableRefDefaultCluster, Map.empty)
-    consolidatedConf1.getOption(param.name) shouldBe value
-    consolidatedConf2.getOption(param.name) shouldBe valueForDefaultCluster
+    consolidatedConf1.getOption(checkParam) shouldBe value
+    consolidatedConf2.getOption(checkParam) shouldBe valueForDefaultCluster
   }
 
   it should "use SparkConf settings by default" in {
@@ -79,4 +82,14 @@ class ConsolidateSettingsSpec extends FlatSpec with Matchers {
       value = Some("50"),
       valueForDefaultCluster = Some("20"))
   }
+
+  it should "accept sqlConf settings without a cluster set" in {
+    verify(
+      sparkConf = Map.empty,
+      sqlContextConf = Map(param.name -> "20"),
+      tableConf = Map.empty,
+      value = Some("20"),
+      valueForDefaultCluster = Some("20"))
+  }
+
 }


### PR DESCRIPTION
Previously, parameters set in the SqlConf via "SET ? = ?"
required setting cluster/parameter. With default/parameter
being the catch all for non specific clusters. In this patch
we allow setting a parameter without any cluster prefix.