### PR TITLE
SPARKC-490 Pushdown filter for composite partition keys doesn't work …

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 2.0.5
+ * Allow IN predicates for composite partition keys and clustering keys to be pushed down to Cassandra (SPARKC-490)
  * Allow 'YYYY' format LocalDate
  * Add metrics for write batch Size (SPARKC-501)
  * Type Converters for java.time.localdate (SPARKC-495)

--- a/spark-cassandra-connector/src/test/scala/org/apache/spark/sql/cassandra/PredicatePushDownSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/org/apache/spark/sql/cassandra/PredicatePushDownSpec.scala
@@ -132,12 +132,12 @@ class PredicatePushDownSpec extends FlatSpec with Matchers {
     ppd.predicatesToPreserve shouldBe empty
   }
 
-  it should "not push down an IN partition key predicate on the non-last partition key column" in {
+  it should "push down an IN partition key predicate on the non-last or any partition key column" in {
     val f1 = InFilter("pk1")
     val f2 = EqFilter("pk2")
     val ppd = new BasicCassandraPredicatePushDown(Set[Filter](f1, f2), table)
-    ppd.predicatesToPushDown shouldBe empty
-    ppd.predicatesToPreserve should contain allOf(f1, f2)
+    ppd.predicatesToPushDown should contain allOf(f1, f2)
+    ppd.predicatesToPreserve shouldBe empty
   }
 
   it should "push down the first clustering column predicate" in {
@@ -203,13 +203,13 @@ class PredicatePushDownSpec extends FlatSpec with Matchers {
     ppd.predicatesToPreserve should contain only f3
   }
 
-  it should "not push down IN restriction on non-last column" in {
+  it should "push down IN restriction on non-last or any column" in {
     val f1 = EqFilter("c1")
     val f2 = InFilter("c2")
     val f3 = EqFilter("c3")
     val ppd = new BasicCassandraPredicatePushDown(Set[Filter](f1, f2, f3), table)
-    ppd.predicatesToPushDown should contain only f1
-    ppd.predicatesToPreserve should contain only (f2, f3)
+    ppd.predicatesToPushDown should contain allOf(f1, f2, f3)
+    ppd.predicatesToPreserve shouldBe empty
   }
 
   it should "not push down any clustering column predicates, if the first clustering column is missing" in {

--- a/spark-cassandra-connector/src/test/scala/org/apache/spark/sql/cassandra/PredicatePushDownSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/org/apache/spark/sql/cassandra/PredicatePushDownSpec.scala
@@ -132,6 +132,14 @@ class PredicatePushDownSpec extends FlatSpec with Matchers {
     ppd.predicatesToPreserve shouldBe empty
   }
 
+  it should "not push down an IN partition key predicate on the non-last partition key column in P3" in {
+    val f1 = InFilter("pk1")
+    val f2 = EqFilter("pk2")
+    val ppd = new BasicCassandraPredicatePushDown(Set[Filter](f1, f2), table,ProtocolVersion.V3)
+    ppd.predicatesToPushDown shouldBe empty
+    ppd.predicatesToPreserve should contain allOf(f1, f2)
+  }
+
   it should "push down an IN partition key predicate on the non-last or any partition key column" in {
     val f1 = InFilter("pk1")
     val f2 = EqFilter("pk2")
@@ -201,6 +209,15 @@ class PredicatePushDownSpec extends FlatSpec with Matchers {
     val ppd = new BasicCassandraPredicatePushDown(Set[Filter](f1, f2, f3), table)
     ppd.predicatesToPushDown should contain only(f1, f2)
     ppd.predicatesToPreserve should contain only f3
+  }
+
+  it should "not push down IN restriction on non-last column in P3" in {
+    val f1 = EqFilter("c1")
+    val f2 = InFilter("c2")
+    val f3 = EqFilter("c3")
+    val ppd = new BasicCassandraPredicatePushDown(Set[Filter](f1, f2, f3), table,ProtocolVersion.V3)
+    ppd.predicatesToPushDown should contain only f1
+    ppd.predicatesToPreserve should contain only (f2, f3)
   }
 
   it should "push down IN restriction on non-last or any column" in {


### PR DESCRIPTION
SPARKC-490  Pushdown filter for composite partition keys doesn't work when IN is used
I have a cassandra table with PRIMARY KEY - ((date,billing_country,offering,category,name),ts,realm_id)
**Running a spark Query** - val results = spark.sql("select * from event where dt in ( to_date('2018-02-14'),to_date('2018-02-15')) and billing_country ='us' and  offering ='qbn subscription' and category ='billing' and name = 'billing_attempt' and ts in (cast ('2018-02-14 01:19:40.000000+0000' as timestamp),cast('2018-02-14 01:19:41.000000+0000' as timestamp)) and realm_id > '783813150'")

18/03/13 17:50:52 DEBUG CassandraSourceRelation: Final Pushdown filters:
C* Filters: [In(ts, [2018-02-13 17:19:40.0,2018-02-13 17:19:41.0], GreaterThan(realm_id,783813150), In(dt, [2018-02-14,2018-02-15], EqualTo(category,billing), EqualTo(name,billing_attempt), EqualTo(offering,qbn subscription), EqualTo(billing_country,us)]
Spark Filters [IsNotNull(category), IsNotNull(billing_country), IsNotNull(realm_id), IsNotNull(name), IsNotNull(offering)]
18/03/13 17:50:52 DEBUG CassandraTableScanRDD: Created total 1 partitions for htap.event





