### PR TITLE
SPARKC-532: Change Str Literal Match to Be Greedy

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -245,14 +245,6 @@ read the Cassandra table into. This parameter is
 used in SparkSql and DataFrame Options.
       </td>
 </tr>
-<tr>
-  <td><code>splitCount</code></td>
-  <td>None</td>
-  <td>Specify the number of Spark partitions to
-read the Cassandra table into. This parameter is
-used in SparkSql and DataFrame Options.
-      </td>
-</tr>
 </table>
 
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/CqlWhereParser.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/CqlWhereParser.scala
@@ -53,7 +53,7 @@ object CqlWhereParser extends RegexParsers with Logging {
     s => BooleanLiteral(s.toBoolean)
   }
 
-  private def str = "'" ~> """(''|[^'])*""".r <~ "'" ^^ {
+  private def str = "'" ~> """(''|[^'])*+""".r <~ "'" ^^ {
     def unEscapeQuotes(s: String) = s.replace("''", "'")
     s => StringLiteral(unEscapeQuotes(s))
   }

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/util/CqlWhereParserTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/util/CqlWhereParserTest.scala
@@ -117,4 +117,11 @@ class CqlWhereParserTest extends FlatSpec with Matchers with Inside {
     )
   }
 
+  it should "handle long string requests" in {
+    val predval = "a" * 10000
+    parser.parse(s"""key = '$predval'""") should be (
+      List(EqPredicate("key", StringLiteral(predval)))
+    )
+  }
+
 }


### PR DESCRIPTION
Previous non greedy match would StackOverflow on long string literals.
New version does not.