### PR TITLE
Created a local reflection lock in order to work with spark 2.3.0.

### DIFF
--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/catalyst/ReflectionLock.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/catalyst/ReflectionLock.scala
@@ -2,5 +2,7 @@ package org.apache.spark.sql.catalyst
 
 object ReflectionLock {
 
-  val SparkReflectionLock = ScalaReflectionLock
+  protected object ScalaReflectionLockFallback
+
+  val SparkReflectionLock = ScalaReflectionLockFallback
 }


### PR DESCRIPTION
Patch to make the connector work with Spark 2.3.0.

In Spark, this commit https://github.com/apache/spark/commit/425c4ada4c24e338b45d0e9987071f05c5766fa5 removes Scala 2.10 support. One of the things removed is the workarounds using `ScalaReflectionLock`, which causes a `java.lang.NoClassDefFoundError` when using the connector.

This pull request can potentially help resolve https://datastax-oss.atlassian.net/projects/SPARKC/issues/SPARKC-530.

While removing Scala 2.10 support might be the right way to go, as Spark seems to be going in this direction, it turned out to be a much more intrusive change.