### PR TITLE
SPARKC-541: Ignore Solr_query when setting up Writing

### DIFF
--- a/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
+++ b/spark-cassandra-connector/src/it/scala/com/datastax/spark/connector/writer/TableWriterSpec.scala
@@ -48,6 +48,9 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase {
         session.execute( s"""CREATE TABLE $ks.key_value (key INT, group BIGINT, value TEXT, PRIMARY KEY (key, group))""")
       },
       Future {
+        session.execute( s"""CREATE TABLE $ks.solr_query (key INT, group BIGINT, value TEXT, PRIMARY KEY (key))""")
+      },
+      Future {
         session.execute( s"""CREATE TABLE $ks.nulls (key INT PRIMARY KEY, text_value TEXT, int_value INT)""")
       },
       Future {
@@ -122,6 +125,12 @@ class TableWriterSpec extends SparkCassandraITFlatSpecBase {
     val col = Seq((1, 1L, "value1"), (2, 2L, "value2"), (3, 3L, "value3"))
     sc.parallelize(col).saveToCassandra(ks, "key_value", SomeColumns("key", "group", "value"))
     verifyKeyValueTable("key_value")
+  }
+
+  it should "write to a table with a solr_query containing table without requiring that column" in {
+    val col = Seq((1, 1L, "value1"), (2, 2L, "value2"), (3, 3L, "value3"))
+    sc.parallelize(col).saveToCassandra(ks, "solr_query")
+    verifyKeyValueTable("solr_query")
   }
 
   it should "write RDD of tuples to a new table" in {


### PR DESCRIPTION
DSE includes a virtual column "solr_query" which was used for
interacting with Solr in DSE. This column cannot actually be written too
so we should remove references to the column when writing.