### PR TITLE
Correct travis URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Spark Cassandra Connector [![Build Status](https://travis-ci.org/datastax/spark-cassandra-connector.svg)](https://travis-ci.org/datastax/spark-cassandra-connector)
+# Spark Cassandra Connector [![Build Status](https://travis-ci.org/datastax/spark-cassandra-connector.svg?branch=master)](https://travis-ci.org/datastax/spark-cassandra-connector)
 
 ## Quick Links
 


### PR DESCRIPTION
Fixes the URL for the build status from Travis CI. Seems like the old links shows a wrong broken build while master build is actually working.

I got the correct link from https://travis-ci.org/datastax/spark-cassandra-connector