### PR TITLE
Cassandra/Spark data type documentation

### DIFF
--- a/doc/14_data_frames.md
+++ b/doc/14_data_frames.md
@@ -414,6 +414,40 @@ INFO  2015-08-26 00:56:37 org.apache.spark.sql.cassandra.CassandraSourceRelation
 INFO  2015-08-26 00:56:37 org.apache.spark.sql.cassandra.CassandraSourceRelation: pushdown filters: ArrayBuffer(EqualTo(clusterkey1,1), EqualTo(clusterkey2,1))
 ```
 
+
+### Data Types
+
+Cassandra data types are mapped to Spark data types as follows:
+
+Cassandra Type | Spark Type
+-------| --------
+`ascii` | `StringType`
+`text` | `StringType`
+`varchar` | `StringType`
+`boolean` | `BooleanType`
+`int` | `IntegerType`
+`bigint` | `LongType`
+`counter` | `LongType`
+`float` | `FloatType`
+`double` | `DoubleType`
+`smallint` | `ShortType`
+`tinyint` | `ByteType`
+`varint` | `DecimalType(38, 0)`
+`decimal` | `DecimalType(38, 18)`
+`timestamp` | `TimestampType`
+`inet` | `StringType`
+`uuid` | `StringType`
+`timeuuid` | `StringType`
+`blob` | `BinaryType`
+`date` | `DateType`
+`time` | `LongType`
+`set<t>` | `ArrayType(t)`
+`list<t>` | `ArrayType(t)`
+`map<t,u>` | `MapType(t,u)`
+`tuple` | `StructType`
+user defined | `StructType`
+
+
 #### What Happened to DataFrames?
 
 In Spark 2.0 DataFrames are now just a specific case of the Dataset API. In particular

--- a/doc/14_data_frames.md
+++ b/doc/14_data_frames.md
@@ -435,9 +435,9 @@ Cassandra Type | Spark Type
 `varint` | `DecimalType(38, 0)`
 `decimal` | `DecimalType(38, 18)`
 `timestamp` | `TimestampType`
-`inet` | `StringType`
-`uuid` | `StringType`
-`timeuuid` | `StringType`
+`inet` | `StringType` *
+`uuid` | `StringType` *
+`timeuuid` | `StringType` *
 `blob` | `BinaryType`
 `date` | `DateType`
 `time` | `LongType`
@@ -446,6 +446,8 @@ Cassandra Type | Spark Type
 `map<t,u>` | `MapType(t,u)`
 `tuple` | `StructType`
 user defined | `StructType`
+
+\* converted to/from strings using the same string representation as in CQL queries, like `"192.168.1.1"`, `"2001:0db8:85a3:0000:0000:8a2e:0370:7334"`, `"6ba7b810-9dad-11d1-80b4-00c04fd430c8"`.
 
 
 #### What Happened to DataFrames?


### PR DESCRIPTION
This PR adds to the DataFrames documentation a table of how Cassandra data types are mapped to Spark data types, as taken from DataTypeConverter.scala.