### PR TITLE
SPARKC-554: Add support for custom rate limiters

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -228,6 +228,11 @@ OSS Cassandra this should never be used.</td>
   <td>Sets whether to record connector specific metrics on write</td>
 </tr>
 <tr>
+  <td><code>input.ratelimiterprovider</code></td>
+  <td>main.scala.com.datastax.spark.connector.writer.LeakyBucketRateLimiterProvider</td>
+  <td>Determines which rate limiter provider to use in reads</td>
+</tr>
+<tr>
   <td><code>input.reads_per_sec</code></td>
   <td>2147483647</td>
   <td>Sets max requests per core per second for joinWithCassandraTable and some Enterprise integrations</td>
@@ -313,6 +318,11 @@ finer control see the CassandraOption class</td>
   <td><code>output.metrics</code></td>
   <td>true</td>
   <td>Sets whether to record connector specific metrics on write</td>
+</tr>
+<tr>
+  <td><code>output.ratelimiterprovider</code></td>
+  <td>main.scala.com.datastax.spark.connector.writer.LeakyBucketRateLimiterProvider</td>
+  <td>Determines which rate limiter provider to use in writes</td>
 </tr>
 <tr>
   <td><code>output.throughput_mb_per_sec</code></td>

--- a/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/RDDAndDStreamCommonJavaFunctions.java
+++ b/spark-cassandra-connector/src/main/java/com/datastax/spark/connector/japi/RDDAndDStreamCommonJavaFunctions.java
@@ -178,7 +178,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                     new WriteConf(batchSize, writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                         writeConf.consistencyLevel(), writeConf.ifNotExists(), writeConf.ignoreNulls(),
                         writeConf.parallelismLevel(), writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(),
-                        writeConf.taskMetricsEnabled()));
+                        writeConf.taskMetricsEnabled(), writeConf.rateLimiterProvider()));
             else
                 return this;
         }
@@ -197,7 +197,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                     new WriteConf(writeConf.batchSize(), batchGroupingBufferSize, writeConf.batchGroupingKey(),
                         writeConf.consistencyLevel(), writeConf.ifNotExists(), writeConf.ignoreNulls(),
                         writeConf.parallelismLevel(), writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(),
-                        writeConf.taskMetricsEnabled()));
+                            writeConf.taskMetricsEnabled(), writeConf.rateLimiterProvider()));
             else
                 return this;
         }
@@ -216,7 +216,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), batchGroupingKey,
                         writeConf.consistencyLevel(), writeConf.ifNotExists(), writeConf.ignoreNulls(),
                         writeConf.parallelismLevel(), writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(),
-                        writeConf.taskMetricsEnabled()));
+                        writeConf.taskMetricsEnabled(), writeConf.rateLimiterProvider()));
             else
                 return this;
         }
@@ -234,7 +234,8 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                         consistencyLevel, writeConf.ifNotExists(), writeConf.ignoreNulls(), writeConf.parallelismLevel(),
-                        writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
+                        writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled(),
+                        writeConf.rateLimiterProvider()));
             else
                 return this;
         }
@@ -252,7 +253,8 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                         writeConf.consistencyLevel(), writeConf.ifNotExists(), writeConf.ignoreNulls(), parallelismLevel,
-                        writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
+                        writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled(),
+                        writeConf.rateLimiterProvider()));
             else
                 return this;
         }
@@ -271,7 +273,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                     new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                         writeConf.consistencyLevel(), writeConf.ifNotExists(), writeConf.ignoreNulls(),
                         writeConf.parallelismLevel(), throughputMBPS, writeConf.ttl(), writeConf.timestamp(),
-                        writeConf.taskMetricsEnabled()));
+                        writeConf.taskMetricsEnabled(), writeConf.rateLimiterProvider()));
             else
               return this;
         }
@@ -290,7 +292,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                         new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                                 writeConf.consistencyLevel(), writeConf.ifNotExists(), writeConf.ignoreNulls(),
                                 writeConf.parallelismLevel(), writeConf.throughputMiBPS(), writeConf.ttl(),
-                                writeConf.timestamp(), taskMetricsEnabled));
+                                writeConf.timestamp(), taskMetricsEnabled, writeConf.rateLimiterProvider()));
             else
                 return this;
         }
@@ -307,7 +309,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                         new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                                 writeConf.consistencyLevel(), ifNotExists, writeConf.ignoreNulls(), writeConf.parallelismLevel(),
-                                writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
+                                writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled(), writeConf.rateLimiterProvider()));
             else
                 return this;
         }
@@ -324,7 +326,7 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                 return withWriteConf(
                         new WriteConf(writeConf.batchSize(), writeConf.batchGroupingBufferSize(), writeConf.batchGroupingKey(),
                                 writeConf.consistencyLevel(), writeConf.ifNotExists(), ignoreNulls, writeConf.parallelismLevel(),
-                                writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled()));
+                                writeConf.throughputMiBPS(), writeConf.ttl(), writeConf.timestamp(), writeConf.taskMetricsEnabled(), writeConf.rateLimiterProvider()));
             else
                 return this;
         }
@@ -343,7 +345,8 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                     writeConf.throughputMiBPS(),
                     writeConf.ttl(),
                     timestamp,
-                    writeConf.taskMetricsEnabled()));
+                    writeConf.taskMetricsEnabled(),
+                    writeConf.rateLimiterProvider()));
         }
 
 
@@ -424,7 +427,8 @@ public abstract class RDDAndDStreamCommonJavaFunctions<T> {
                     writeConf.throughputMiBPS(),
                     ttl,
                     writeConf.timestamp(),
-                    writeConf.taskMetricsEnabled()));
+                    writeConf.taskMetricsEnabled(),
+                    writeConf.rateLimiterProvider()));
         }
 
         /**

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
@@ -31,7 +31,6 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
   implicit
     connector: CassandraConnector = CassandraConnector(sparkContext),
     rwf: RowWriterFactory[T]): Unit = {
-
     val writer = TableWriter(connector, keyspaceName, tableName, columns, writeConf)
     rdd.sparkContext.runJob(rdd, writer.write _)
   }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
@@ -4,6 +4,7 @@ import com.datastax.driver.core.{ResultSet, Session}
 import com.datastax.spark.connector._
 import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.rdd.reader._
+import com.datastax.spark.connector.util.RateLimiterUtil
 import com.datastax.spark.connector.writer._
 import com.google.common.util.concurrent.{FutureCallback, Futures, SettableFuture}
 import org.apache.spark.rdd.RDD
@@ -141,8 +142,10 @@ class CassandraLeftJoinRDD[L, R] private[connector](
     rowMetadata: CassandraRowMetadata,
     leftIterator: Iterator[L]
   ): Iterator[(L, Option[R])] = {
-    val rateLimiter = new RateLimiter(
-      readConf.readsPerSec, readConf.readsPerSec
+    val rateLimiter = RateLimiterUtil.getRateLimiter(
+      readConf.rateLimiterProvider,
+      readConf.readsPerSec,
+      readConf.readsPerSec
     )
 
     val queryExecutor = QueryExecutor(session, readConf.parallelismLevel,None, None)

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraRDD.scala
@@ -1,6 +1,5 @@
 package com.datastax.spark.connector.rdd
 
-import com.datastax.driver.core.HostDistance
 import com.datastax.spark.connector.cql._
 import com.datastax.spark.connector.rdd.ClusteringOrder.{Ascending, Descending}
 import com.datastax.spark.connector.rdd.reader._
@@ -26,7 +25,6 @@ abstract class CassandraRDD[R : ClassTag](
   type Self <: CassandraRDD[R]
   
   ConfigCheck.checkConfig(sc.getConf)
-
 
   protected[connector] def keyspaceName: String
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
@@ -15,7 +15,9 @@ import org.apache.spark.SparkConf
   * @param taskMetricsEnabled whether or not enable task metrics updates (requires Spark 1.2+)
   * @param readsPerSec maximum read throughput allowed per single core in requests/s while
   *                                  joining an RDD with C* table (joinWithCassandraTable operation)
-  *                                  also used by enterprise integrations*/
+  *                                  also used by enterprise integrations
+  * @param rateLimiterProvider fully qualified name to a custom rate limiter provider
+  */
 case class ReadConf(
   splitCount: Option[Int] = None,
   splitSizeInMB: Int = ReadConf.SplitSizeInMBParam.default,
@@ -23,7 +25,8 @@ case class ReadConf(
   consistencyLevel: ConsistencyLevel = ReadConf.ConsistencyLevelParam.default,
   taskMetricsEnabled: Boolean = ReadConf.TaskMetricParam.default,
   parallelismLevel: Int = ReadConf.ParallelismLevelParam.default,
-  readsPerSec: Int = ReadConf.ReadsPerSecParam.default
+  readsPerSec: Int = ReadConf.ReadsPerSecParam.default,
+  rateLimiterProvider: String = ReadConf.RateLimiterProviderParam.default
 )
 
 
@@ -93,6 +96,13 @@ object ReadConf extends Logging {
       """Sets max requests per core per second for joinWithCassandraTable and some Enterprise integrations"""
   )
 
+  val RateLimiterProviderParam = ConfigParameter[String] (
+    name = "spark.cassandra.read.ratelimiter.provider",
+    section = ReferenceSection,
+    default = "com.datastax.spark.connector.writer.LeakyBucketProvider",
+    description = """Determines which rate limiter provider to use in reads"""
+  )
+
   // Whitelist for allowed Read environment variables
   val Properties = Set(
     SplitCountParam,
@@ -102,7 +112,8 @@ object ReadConf extends Logging {
     SplitSizeInMBParam,
     TaskMetricParam,
     ThroughputJoinQueryPerSecParam,
-    ParallelismLevelParam
+    ParallelismLevelParam,
+    RateLimiterProviderParam
   )
 
   def fromSparkConf(conf: SparkConf): ReadConf = {
@@ -136,7 +147,8 @@ object ReadConf extends Logging {
       readsPerSec = conf.getInt(ReadsPerSecParam.name,
         throughtputJoinQueryPerSec.getOrElse(ReadsPerSecParam.default)),
       parallelismLevel = conf.getInt(ParallelismLevelParam.name, ParallelismLevelParam.default),
-      splitCount = conf.getOption(SplitCountParam.name).map(_.toInt)
+      splitCount = conf.getOption(SplitCountParam.name).map(_.toInt),
+      rateLimiterProvider = conf.get(RateLimiterProviderParam.name, RateLimiterProviderParam.default)
     )
   }
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/ReadConf.scala
@@ -1,7 +1,8 @@
 package com.datastax.spark.connector.rdd
 
 import com.datastax.driver.core.ConsistencyLevel
-import com.datastax.spark.connector.util.{ConfigParameter, ConfigCheck, Logging}
+import com.datastax.spark.connector.util.{ConfigCheck, ConfigParameter, Logging}
+import main.scala.com.datastax.spark.connector.writer.LeakyBucketRateLimiterProvider
 import org.apache.spark.SparkConf
 
 /** Read settings for RDD
@@ -97,9 +98,9 @@ object ReadConf extends Logging {
   )
 
   val RateLimiterProviderParam = ConfigParameter[String] (
-    name = "spark.cassandra.read.ratelimiter.provider",
+    name = "spark.cassandra.input.ratelimiterprovider",
     section = ReferenceSection,
-    default = "com.datastax.spark.connector.writer.LeakyBucketProvider",
+    default = new LeakyBucketRateLimiterProvider().getClass.getName,
     description = """Determines which rate limiter provider to use in reads"""
   )
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/RateLimiterUtil.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/RateLimiterUtil.scala
@@ -1,7 +1,6 @@
 package com.datastax.spark.connector.util
 
 import com.datastax.spark.connector.writer.{BaseRateLimiter, RateLimiterProvider}
-import main.scala.com.datastax.spark.connector.writer.LeakyBucketRateLimiterProvider
 
 /**
   * Exports a method to retrieve a custom rate limiter based on dynamic configuration.
@@ -21,9 +20,17 @@ object RateLimiterUtil extends Logging {
     try {
       provider = Class.forName(className).newInstance.asInstanceOf[RateLimiterProvider]
     } catch {
-      case e:Exception => {
+      case e:ClassNotFoundException => {
+        logError("Could not find custom rate limiter provider. Error: " + e)
+        throw e
+      }
+      case e:InstantiationException => {
         logError("Could not instantiate custom rate limiter provider. Error: " + e)
-        provider = LeakyBucketRateLimiterProvider
+        throw e
+      }
+      case e:Throwable => {
+        logError("Error: " + e)
+        throw e
       }
     }
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/RateLimiterUtil.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/RateLimiterUtil.scala
@@ -1,0 +1,36 @@
+package com.datastax.spark.connector.util
+
+import com.datastax.spark.connector.writer.{BaseRateLimiter, LeakyBucketProvider, RateLimiterProvider}
+
+object RateLimiterUtil {
+  var provider:RateLimiterProvider = _
+  var providerClassName:String = "com.datastax.spark.connector.writer.LeakyBucketProvider"
+
+  // get rate limiter from provider specified by className
+  def getRateLimiter(className: String, args: Any*): BaseRateLimiter = {
+    setProviderClassName(className)
+    println("Getting rate limiter with specified conf from " + provider.getClass.getName)
+    provider.getWithConf(args:_*)
+  }
+
+  // get standard rate limiter
+//  def getRateLimiter(args: Any*): BaseRateLimiter = {
+//    println("Getting rate limiter from " + provider.getClass.getName)
+//    provider.getWithConf(args:_*)
+//  }
+
+//  def setProvider(customProvider: RateLimiterProvider): Unit = {
+//    println("Setting rate limiter provider to be " + customProvider.getClass.getName)
+//    provider = customProvider
+//  }
+
+  private def setProviderClassName(className: String): Unit = {
+    providerClassName = className
+
+    try {
+      provider = Class.forName(providerClassName).newInstance.asInstanceOf[RateLimiterProvider]
+    } catch {
+      case e:Exception => println("ERROR: " + e)
+    }
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/BaseRateLimiter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/BaseRateLimiter.scala
@@ -1,5 +1,16 @@
 package com.datastax.spark.connector.writer
 
+/**
+  * Represents a rate limiter.
+  */
 trait BaseRateLimiter {
+
+  /**
+    * Processes a single packet and it is up to the implementing class to determine whether
+    * or not the thread should sleep.
+    *
+    * @param packetSize the size of the packet currently being processed
+    */
   def maybeSleep(packetSize: Long): Unit
+
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/BaseRateLimiter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/BaseRateLimiter.scala
@@ -1,0 +1,5 @@
+package com.datastax.spark.connector.writer
+
+trait BaseRateLimiter {
+  def maybeSleep(packetSize: Long): Unit
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/LeakyBucketRateLimiter.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/LeakyBucketRateLimiter.scala
@@ -22,11 +22,11 @@ import scala.annotation.tailrec
   * @param sleep a function to call to slow down the calling thread;
   *              must use the same time units as `time`
   */
-class RateLimiter(
-    rate: Long,
-    bucketSize: Long,
-    time: () => Long = System.currentTimeMillis,
-    sleep: Long => Any = Thread.sleep) {
+class LeakyBucketRateLimiter(
+  rate: Long,
+  bucketSize: Long,
+  time: () => Long = System.currentTimeMillis,
+  sleep: Long => Any = Thread.sleep) extends BaseRateLimiter {
 
   require(rate > 0, "A positive rate is required")
   require(bucketSize > 0, "A positive bucket size is required")
@@ -62,5 +62,4 @@ class RateLimiter(
     if (delay > 0L)
       sleep(delay)
   }
-
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/LeakyBucketRateLimiterProvider.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/LeakyBucketRateLimiterProvider.scala
@@ -1,0 +1,36 @@
+package main.scala.com.datastax.spark.connector.writer
+
+import com.datastax.spark.connector.util.Logging
+import com.datastax.spark.connector.writer.{BaseRateLimiter, LeakyBucketRateLimiter, RateLimiterProvider}
+
+/**
+  * Instantiates a leaky bucket rate limiter based on the supplied configuration.
+  */
+object LeakyBucketRateLimiterProvider extends RateLimiterProvider with Logging {
+  override def getRateLimiterWithConf(args: Any*): BaseRateLimiter = {
+    val rate = args(0).asInstanceOf[Number].longValue
+    val bucketSize = args(1).asInstanceOf[Number].longValue
+
+    /**
+      * If optional arguments are present and cannot be casted correctly,
+      * omit them and instantiate rate limiter with only rate and bucketSize
+      */
+    try {
+      if (args.size > 2) {
+        val time = args(2).asInstanceOf[() => Long]
+        if (args.size > 3) {
+          val sleep = args(3).asInstanceOf[Long => Any]
+          new LeakyBucketRateLimiter(rate, bucketSize, time, sleep)
+        }
+        new LeakyBucketRateLimiter(rate, bucketSize, time)
+      }
+    } catch {
+      case _: Exception => {
+        logError("Invalid optional arguments when instantiating leaky bucket rate limiter")
+        new LeakyBucketRateLimiter(rate, bucketSize)
+      }
+    }
+
+    new LeakyBucketRateLimiter(rate, bucketSize)
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/LeakyBucketRateLimiterProvider.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/LeakyBucketRateLimiterProvider.scala
@@ -6,7 +6,9 @@ import com.datastax.spark.connector.writer.{BaseRateLimiter, LeakyBucketRateLimi
 /**
   * Instantiates a leaky bucket rate limiter based on the supplied configuration.
   */
-object LeakyBucketRateLimiterProvider extends RateLimiterProvider with Logging {
+class LeakyBucketRateLimiterProvider extends RateLimiterProvider with Logging {
+  {}
+
   override def getRateLimiterWithConf(args: Any*): BaseRateLimiter = {
     val rate = args(0).asInstanceOf[Number].longValue
     val bucketSize = args(1).asInstanceOf[Number].longValue

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/RateLimiterProvider.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/RateLimiterProvider.scala
@@ -1,0 +1,26 @@
+package com.datastax.spark.connector.writer
+
+trait RateLimiterProvider {
+  def getWithConf(args: Any*): BaseRateLimiter
+}
+
+class LeakyBucketProvider extends RateLimiterProvider {
+  override def getWithConf(args: Any*): BaseRateLimiter = {
+    require(args.length >= 2)
+
+    val rate= args(0) match {
+      case x:Int => x.intValue()
+      case x:Long => x.longValue()
+    }
+
+    val bucketSize = args(1) match {
+      case x:Int => x.intValue()
+      case x:Long => x.longValue()
+    }
+
+    val time:() => Long = if (args.length >= 3) args(2).asInstanceOf[() => Long] else System.currentTimeMillis
+    val sleep:Long => Any = if (args.length >= 4) args(3).asInstanceOf[Long => Any] else Thread.sleep
+
+    new LeakyBucketRateLimiter(rate, bucketSize, time, sleep)
+  }
+}

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/RateLimiterProvider.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/RateLimiterProvider.scala
@@ -1,26 +1,14 @@
 package com.datastax.spark.connector.writer
 
+/**
+  * Represents a provider that creates and returns a rate limiter with possible configuration.
+  */
 trait RateLimiterProvider {
-  def getWithConf(args: Any*): BaseRateLimiter
-}
-
-class LeakyBucketProvider extends RateLimiterProvider {
-  override def getWithConf(args: Any*): BaseRateLimiter = {
-    require(args.length >= 2)
-
-    val rate= args(0) match {
-      case x:Int => x.intValue()
-      case x:Long => x.longValue()
-    }
-
-    val bucketSize = args(1) match {
-      case x:Int => x.intValue()
-      case x:Long => x.longValue()
-    }
-
-    val time:() => Long = if (args.length >= 3) args(2).asInstanceOf[() => Long] else System.currentTimeMillis
-    val sleep:Long => Any = if (args.length >= 4) args(3).asInstanceOf[Long => Any] else Thread.sleep
-
-    new LeakyBucketRateLimiter(rate, bucketSize, time, sleep)
-  }
+  /**
+    * Given a set of arguments, instantiates and returns a rate limiter.
+    *
+    * @param args sequence of arguments that can customize the returned rate limiter
+    * @return the created rate limiter
+    */
+  def getRateLimiterWithConf(args: Any*): BaseRateLimiter
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/writer/WriteConf.scala
@@ -6,6 +6,7 @@ import com.datastax.spark.connector.rdd.ReadConf
 import com.datastax.spark.connector.types.ColumnType
 import com.datastax.spark.connector.util.{ConfigCheck, ConfigParameter}
 import com.datastax.spark.connector.{BatchSize, BytesInBatch, RowsInBatch}
+import main.scala.com.datastax.spark.connector.writer.LeakyBucketRateLimiterProvider
 import org.apache.commons.configuration.ConfigurationException
 import org.apache.spark.SparkConf
 
@@ -158,9 +159,9 @@ object WriteConf {
   )
 
   val RateLimiterProviderParam = ConfigParameter[String](
-    name = "spark.cassandra.write.ratelimiter.provider",
+    name = "spark.cassandra.output.ratelimiterprovider",
     section = ReferenceSection,
-    default = "com.datastax.spark.connector.writer.LeakyBucketProvider",
+    default = new LeakyBucketRateLimiterProvider().getClass.getName,
     description = """Determines which rate limiter provider to use in writes"""
   )
 

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/ReadConfTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/rdd/ReadConfTest.scala
@@ -1,5 +1,6 @@
 package com.datastax.spark.connector.rdd
 
+import com.datastax.spark.connector.writer.WriteConf
 import org.apache.spark.SparkConf
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -25,6 +26,13 @@ class ReadConfTest extends FlatSpec with Matchers {
 
     val readConf = ReadConf.fromSparkConf(conf)
     readConf.readsPerSec should be (expected)
+  }
+
+  it should "allow to set custom rate limiter provider" in {
+    val conf = new SparkConf(false)
+      .set("spark.cassandra.input.ratelimiterprovider", "custom.ratelimiter.provider")
+    val readConf = ReadConf.fromSparkConf(conf)
+    readConf.rateLimiterProvider should be("custom.ratelimiter.provider")
   }
 
 }

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/util/RateLimiterUtilSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/util/RateLimiterUtilSpec.scala
@@ -1,0 +1,40 @@
+package com.datastax.spark.connector.util
+
+import java.lang.Thread.sleep
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{FlatSpec, Matchers}
+import com.datastax.spark.connector.writer.{BaseRateLimiter, RateLimiterProvider}
+import main.scala.com.datastax.spark.connector.writer.LeakyBucketRateLimiterProvider
+
+class RateLimiterUtilSpec extends FlatSpec with Matchers {
+
+  "RateLimiterUtil" should "return a custom rate limiter provider should that be specified" in {
+    val mockProvider = new MockProvider()
+    val rateLimiter = RateLimiterUtil.getRateLimiter(mockProvider.getClass.getName)
+    rateLimiter.getClass.getName should equal (mockProvider.getRateLimiterWithConf().getClass.getName)
+  }
+
+  it should "throw an error when custom rate limiter provider cannot be instantiated" in {
+    a [ClassNotFoundException] should be thrownBy RateLimiterUtil.getRateLimiter("non.existing.class")
+    an [InstantiationException] should be thrownBy RateLimiterUtil.getRateLimiter(NonInstantiable.getClass.getName)
+  }
+
+  // mock object that cannot be instantiable
+  object NonInstantiable {}
+}
+
+// mock provider with public constructor that can be instantiated
+class MockProvider extends RateLimiterProvider {
+  {}
+
+  override def getRateLimiterWithConf(args: Any*): BaseRateLimiter = {
+    new MockRateLimiter
+  }
+}
+
+// mock rate limiter that is returned by MockProvider
+class MockRateLimiter extends BaseRateLimiter {
+  override def maybeSleep(packetSize: Long): Unit = {}
+}
+

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/util/RateLimiterUtilSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/util/RateLimiterUtilSpec.scala
@@ -20,7 +20,7 @@ class RateLimiterUtilSpec extends FlatSpec with Matchers {
     an [InstantiationException] should be thrownBy RateLimiterUtil.getRateLimiter(NonInstantiable.getClass.getName)
   }
 
-  // mock object that cannot be instantiable
+  // mock object that cannot be instantiated
   object NonInstantiable {}
 }
 

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/LeakyBucketRateLimiterSpec.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/LeakyBucketRateLimiterSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.{FlatSpec, Matchers}
 
 
-class RateLimiterSpec extends FlatSpec with Matchers with MockFactory with Eventually{
+class LeakyBucketRateLimiterSpec extends FlatSpec with Matchers with MockFactory with Eventually{
 
  val TestRates = Seq(1L, 2L, 4L, 6L, 8L, 16L, 32L, WriteConf.ThroughputMiBPSParam.default.toLong)
 
@@ -14,7 +14,7 @@ class RateLimiterSpec extends FlatSpec with Matchers with MockFactory with Event
     val sleep = mockFunction[Long, Any]("sleep")
     sleep.expects(*).never()
 
-    val limiter = new RateLimiter(Long.MaxValue, 1000, () => now, sleep)
+    val limiter = new LeakyBucketRateLimiter(Long.MaxValue, 1000, () => now, sleep)
     for (i <- 1 to 1000000) {
       now += 1
       limiter.maybeSleep(1000)
@@ -33,7 +33,7 @@ class RateLimiterSpec extends FlatSpec with Matchers with MockFactory with Event
     // 10 units per second + 5 units burst allowed
     val bucketSize = 5
     val rate = 10
-    val limiter = new RateLimiter(rate, bucketSize, () => now, sleep)
+    val limiter = new LeakyBucketRateLimiter(rate, bucketSize, () => now, sleep)
 
     val iterations = 25
     for (i <- 1 to iterations)
@@ -53,7 +53,7 @@ class RateLimiterSpec extends FlatSpec with Matchers with MockFactory with Event
         now += delay
       }
 
-      val limiter = new RateLimiter(rate, rate * 2, () => now, sleep)
+      val limiter = new LeakyBucketRateLimiter(rate, rate * 2, () => now, sleep)
       for (leakNum <- 1 to 1000) {
         assert(
           limiter.bucketFill.get() >= 0,

--- a/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/WriteConfTest.scala
+++ b/spark-cassandra-connector/src/test/scala/com/datastax/spark/connector/writer/WriteConfTest.scala
@@ -78,5 +78,12 @@ class WriteConfTest extends FlatSpec with Matchers {
     writeConf.batchGroupingBufferSize should be(30000)
   }
 
+  it should "allow to set custom rate limiter provider" in {
+    val conf = new SparkConf(false)
+      .set("spark.cassandra.output.ratelimiterprovider", "custom.ratelimiter.provider")
+    val writeConf = WriteConf.fromSparkConf(conf)
+    writeConf.rateLimiterProvider should be("custom.ratelimiter.provider")
+  }
+
 
 }


### PR DESCRIPTION
There is a need for being able to supply custom rate limiters to replace the static, leaky bucket implementation and I have extended the connector with support for this use case. There is a document outlining the changes which is attached below.

[Enabling custom rate limiters in spark-cassandra-connector.pdf](https://github.com/datastax/spark-cassandra-connector/files/2621664/Enabling.custom.rate.limiters.in.spark-cassandra-connector.pdf)

