### PR TITLE
allow custom type converters to be utilized for collection types

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/CollectionColumnType.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/CollectionColumnType.scala
@@ -2,6 +2,9 @@ package com.datastax.spark.connector.types
 
 import scala.language.existentials
 import scala.reflect.runtime.universe._
+import scala.reflect.ClassTag
+import com.datastax.spark.connector.types.TypeConverter.{MapConverter, VectorConverter, SetConverter}
+
 
 import org.apache.spark.sql.catalyst.ReflectionLock.SparkReflectionLock
 
@@ -10,47 +13,45 @@ trait CollectionColumnType[T] extends ColumnType[T] {
 }
 
 case class ListType[T](elemType: ColumnType[T]) extends CollectionColumnType[Vector[T]] {
-
-  @transient
-  lazy val scalaTypeTag = SparkReflectionLock.synchronized {
-    implicit val elemTypeTag = elemType.scalaTypeTag
-    implicitly[TypeTag[Vector[T]]]
-  }
-
+  @transient implicit lazy val elemTypeTag = SparkReflectionLock.synchronized { elemType.scalaTypeTag }
+  @transient lazy val scalaTypeTag = SparkReflectionLock.synchronized { implicitly[TypeTag[Vector[T]]] }
   def cqlTypeName = s"list<${elemType.cqlTypeName}>"
 
   override def converterToCassandra: TypeConverter[_ <: AnyRef] =
-    new TypeConverter.OptionToNullConverter(TypeConverter.listConverter(elemType.converterToCassandra))
+    TypeConverter.forType[Vector[T]] match {
+      case tc: VectorConverter[_] =>
+          new TypeConverter.OptionToNullConverter(TypeConverter.listConverter(elemType.converterToCassandra))
+      case tc => tc
+    }
 }
 
 case class SetType[T](elemType: ColumnType[T]) extends CollectionColumnType[Set[T]] {
-
-  @transient
-  lazy val scalaTypeTag = SparkReflectionLock.synchronized {
-    implicit val elemTypeTag = elemType.scalaTypeTag
-    implicitly[TypeTag[Set[T]]]
-  }
-
+  @transient implicit lazy val elemTypeTag = SparkReflectionLock.synchronized { elemType.scalaTypeTag }
+  @transient lazy val scalaTypeTag = SparkReflectionLock.synchronized { implicitly[TypeTag[Set[T]]] }
   def cqlTypeName = s"set<${elemType.cqlTypeName}>"
 
   override def converterToCassandra: TypeConverter[_ <: AnyRef] =
-    new TypeConverter.OptionToNullConverter(TypeConverter.setConverter(elemType.converterToCassandra))
+    TypeConverter.forType[Set[T]] match {
+      case tc: SetConverter[_] =>
+        new TypeConverter.OptionToNullConverter(
+          TypeConverter.setConverter(elemType.converterToCassandra))
+      case tc => tc
+    }
 }
 
 case class MapType[K, V](keyType: ColumnType[K], valueType: ColumnType[V])
   extends CollectionColumnType[Map[K, V]] {
-
-  @transient
-  lazy val scalaTypeTag = SparkReflectionLock.synchronized {
-    implicit val keyTypeTag = keyType.scalaTypeTag
-    implicit val valueTypeTag = valueType.scalaTypeTag
-    implicitly[TypeTag[Map[K, V]]]
-  }
-
+  @transient implicit lazy val keyTypeTag = SparkReflectionLock.synchronized { keyType.scalaTypeTag }
+  @transient implicit lazy val valueTypeTag = SparkReflectionLock.synchronized { valueType.scalaTypeTag }
+  @transient lazy val scalaTypeTag = SparkReflectionLock.synchronized { implicitly[TypeTag[Map[K, V]]] }
   def cqlTypeName = s"map<${keyType.cqlTypeName}, ${valueType.cqlTypeName}>"
 
   override def converterToCassandra: TypeConverter[_ <: AnyRef] =
-    new TypeConverter.OptionToNullConverter(
-      TypeConverter.mapConverter(keyType.converterToCassandra, valueType.converterToCassandra))
+    TypeConverter.forType[Map[K, V]] match {
+      case tc: MapConverter[_, _] =>
+        new TypeConverter.OptionToNullConverter(
+          TypeConverter.mapConverter(keyType.converterToCassandra, valueType.converterToCassandra))
+      case tc => tc
+    }
 }
 


### PR DESCRIPTION
Currently, the connector limits users' ability to create custom type converters for collection types. Instead, it only allows the use of the default collection converters, which just apply in-scope converters to the elements of a collection, while ignoring any user-defined converters for the collection type. This prevents use cases where a converter is being used to convert a non-collection type into a collection, or where a collection is being converted into another collection (for instance we want to only store the keys of a map as a list). Currently, when such a custom converter is specified, it will fail with the following exception:
``
[info] - should write to a table with HLLs *** FAILED ***
[info]   org.apache.spark.SparkException: Job aborted due to stage failure: Task 11 in stage 0.0 failed 1 times, most recent failure: Lost task 11.0 in stage 0.0 (TID 11, localhost, executor driver): com.datastax.spark.connector.types.TypeConversionException: Cannot convert object OurType(14,16384,0.7212525005219688) of type class com.us.commons.internal.util.fn.OurType to Map[AnyRef,AnyRef].
[info] 	at com.datastax.spark.connector.types.TypeConverter$$anonfun$convert$1.apply(TypeConverter.scala:45)
[info] 	at com.datastax.spark.connector.types.TypeConverter$CollectionConverter$$anonfun$convertPF$35.applyOrElse(TypeConverter.scala:694)
[info] 	at com.datastax.spark.connector.types.TypeConverter$class.convert(TypeConverter.scala:43)
[info] 	at com.datastax.spark.connector.types.TypeConverter$CollectionConverter.convert(TypeConverter.scala:682)``
This is because of lines like [this one](https://github.com/datastax/spark-cassandra-connector/blob/df554bf841132ee378c67b57a39f31a453cb1527/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/CollectionColumnType.scala#L51) that don't try to look for the correct type converter in scope. The proposed change keeps the current functionality of using the default collection converters, but only when a custom one isn't also in scope.

JIRA Ticket: https://datastax-oss.atlassian.net/browse/SPARKC-556