### PR TITLE
SPARKC-558: RegularStatements not Cached by SessionProxy

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/PreparedStatementCache.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/PreparedStatementCache.scala
@@ -24,6 +24,10 @@ object PreparedStatementCache extends Logging {
     statement
   }
 
+  private[datastax] def getSize(cluster: Cluster): Int = {
+    clusterCache.get(cluster).size
+  }
+
   /** Removes all statements associated with the `Cluster` from the cache. */
   def remove(cluster: Cluster) {
     synchronized {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/SessionProxy.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/SessionProxy.scala
@@ -21,7 +21,7 @@ class SessionProxy(session: Session, afterClose: Session => Any) extends Invocat
   override def invoke(proxy: Any, method: Method, args: Array[AnyRef]) = {
     try {
       val StringClass = classOf[String]
-      val RegularStatementClass = classOf[String]
+      val RegularStatementClass = classOf[RegularStatement]
 
       (method.getName, method.getParameterTypes) match {
         case ("close", Array()) =>


### PR DESCRIPTION
Previously the case matching in the SessionProxy incorrectly stated that
the RegularStatement class was a String, this meant that Regular
Statements would never actually get matched. To fix this we correct the
class type and in addition we add some tests to actually check the
cache. This still can't avoid all reprepares since the TrieMap is a "at
least once" guarentee and can generate extra calls sometimes.