### PR TITLE
Load Yaml Template from Proper ClassLoader

### DIFF
--- a/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/YamlTransformations.scala
+++ b/spark-cassandra-connector-embedded/src/main/scala/com/datastax/spark/connector/embedded/YamlTransformations.scala
@@ -47,11 +47,11 @@ object YamlTransformations {
 
   private def readTemplate(): JMap[String, AnyRef]@unchecked = {
     val exactTmplt =
-      Option(ClassLoader.getSystemResourceAsStream(s"cassandra-$YamlTemplateVersion.yaml.template"))
+      Option(getClass.getResourceAsStream(s"/cassandra-$YamlTemplateVersion.yaml.template"))
     lazy val fallbackTmplt = {
       System.err.println(s"Warning: Using fallback template for Cassandra 3.2 because " +
         s"the template for Cassandra $YamlTemplateVersion could not be found.")
-      Option(ClassLoader.getSystemResourceAsStream(s"cassandra-3.2.yaml.template"))
+      Option(getClass.getResourceAsStream(s"/cassandra-3.2.yaml.template"))
     }
 
     yaml.load(exactTmplt orElse fallbackTmplt orNull) match {


### PR DESCRIPTION
Loading from the system ClassLoader makes unnecessary (and in my situation, incorrect) assumptions about the classpath hierarchy.

It is more reliable to stick with the ClassLoader that loaded this class (and thus the spark-cassandra-connector-embedded Jar)