### PR TITLE
SPARKC-458 Scala 2.12 support

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+2.4.2
+  * Support for Scala 2.12 (SPARKC-458)
+
 2.4.1
  * Includes all up to 2.3.3
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -45,7 +45,8 @@ object Settings extends Build {
   lazy val buildSettings = Seq(
     organization         := "com.datastax.spark",
     version in ThisBuild := currentVersion,
-    scalaVersion         := Versions.scalaVersion,
+    scalaVersion         := Versions.scala211,
+    crossScalaVersions   := Seq(Versions.scala211, Versions.scala212),
     crossVersion         := CrossVersion.binary,
     versionStatus        := Versions.status(scalaVersion.value, scalaBinaryVersion.value)
   )

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -18,10 +18,11 @@ import scala.util.Properties
 object Versions {
 
 
-  lazy val scalaVersion = "2.12.8"
+  lazy val scala211 = "2.11.7"
+  lazy val scala212 = "2.12.8"
 
   /* For `scalaBinaryVersion.value outside an sbt task. */
-  lazy val scalaBinary = scalaVersion.dropRight(2)
+  lazy val scalaBinary = scala212.dropRight(2)
 
   val Akka            = "2.3.4"
   val Cassandra       = "3.11.3"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -18,7 +18,7 @@ import scala.util.Properties
 object Versions {
 
 
-  lazy val scalaVersion = "2.11.12"
+  lazy val scalaVersion = "2.12.8"
 
   /* For `scalaBinaryVersion.value outside an sbt task. */
   lazy val scalaBinary = scalaVersion.dropRight(2)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,8 +20,6 @@ addSbtPlugin("com.scalapenos" % "sbt-prompt" % "1.0.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
-
 //SbtAssembly 0.12.0 is included in sbt-spark-package
 resolvers += "Spark Packages Main repo" at "https://dl.bintray.com/spark-packages/maven" 
 addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.5")

--- a/spark-cassandra-connector/scala-2.12/src/main/scala/com/datastax/spark/connector/util/Reflect.scala
+++ b/spark-cassandra-connector/scala-2.12/src/main/scala/com/datastax/spark/connector/util/Reflect.scala
@@ -1,0 +1,21 @@
+package com.datastax.spark.connector.util
+
+import scala.reflect.runtime.universe._
+
+private[connector] object Reflect {
+
+  def constructor(tpe: Type): Symbol = tpe.decl(termNames.CONSTRUCTOR)
+
+  def member(tpe: Type, name: String): Symbol = tpe.member(TermName(name))
+
+  def methodSymbol(tpe: Type): MethodSymbol = {
+    val constructors = constructor(tpe).asTerm.alternatives.map(_.asMethod)
+    val paramCount = constructors.map(_.paramLists.flatten.size).max
+    constructors.filter(_.paramLists.flatten.size == paramCount) match {
+      case List(onlyOne) => onlyOne
+      case _             => throw new IllegalArgumentException(
+        "Multiple constructors with the same number of parameters not allowed.")
+    }
+  }
+}
+


### PR DESCRIPTION
# Motivation

As Spark now supports Scala 2.12 ([SPARK-14220](https://issues.apache.org/jira/browse/SPARK-14220)), this connector should also support Scala 2.12, to not prevent users from upgrading.

Here is the corresponding Jira ticket : [SPARKC-458](https://datastax-oss.atlassian.net/projects/SPARKC/issues/SPARKC-458?filter=allopenissues&orderby=priority%20DESC&keyword=2.12)

# Status of this PR
- The submodule `spark-cassandra-connector` compiles
- Unit tests are ok
- Integration tests don't work because it tries to run them against Spark 1.4.0 and Spark 2.4.x is required for Scala 2.12
- scoverage has been deactived (cf https://github.com/datastax/spark-cassandra-connector/pull/1216/commits/8169a61180ffe743166b9d5484a248642470f5c1)