### PR TITLE
Support for scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ sudo: required
 dist: trusty
 scala:
   - 2.11.12
+  - 2.12.9
 
 env:
  - CASSANDRA_VERSION=2.1.15

--- a/dev/run-real-tests.sh
+++ b/dev/run-real-tests.sh
@@ -12,7 +12,7 @@ if [ "$#" -ne "2" ]; then
     echo "Usage: dev/run-real-tests.sh <Spark version> <Scala version>"
     echo "where"
     echo "  <Spark version> is one of the versions available on Apache mirror"
-    echo "  <Scala version> is either 2.10 or 2.11"
+    echo "  <Scala version> is either 2.11 or 2.12"
     exit 1
 fi
 
@@ -23,8 +23,8 @@ TARGET_SPARK_VERSION="$1"
 TARGET_SCALA_VERSION="$2"
 
 scala211=""
-if [ "$TARGET_SCALA_VERSION" = "2.11" ]; then
-    scala211="-Dscala-2.11=true"
+if [ "$TARGET_SCALA_VERSION" = "2.12" ]; then
+    scala211="-Dscala-2.12=true"
 fi
 
 function downloadSpark {
@@ -33,8 +33,8 @@ function downloadSpark {
     sparkVersion="$1"
     scalaVersion="$2"
     scalaVersionSuffix=""
-    if [ "$scalaVersion" = "2.11" ]; then
-        scalaVersionSuffix="-scala2.11"
+    if [ "$scalaVersion" = "2.12" ]; then
+        scalaVersionSuffix="-scala2.12"
     fi
     targetFile="$SPARK_ARCHIVES_DIR/spark-$sparkVersion-$scalaVersion.tgz"
     if [ -f "$targetFile" ]; then

--- a/dev/run-tests.sh
+++ b/dev/run-tests.sh
@@ -1,26 +1,26 @@
 #!/bin/sh
 
-echo "Running tests for Scala 2.10"
-sbt/sbt clean package test it:test assembly
-s210r="$?"
-
 echo "Running tests for Scala 2.11"
-sbt/sbt -Dscala-2.11=true clean package test it:test assembly
+sbt/sbt clean package test it:test assembly
+s211r="$?"
+
+echo "Running tests for Scala 2.12"
+sbt/sbt -Dscala-2.12=true clean package test it:test assembly
 s211r="$?"
 
 retval=0
-
-if [ "$s210r" = "0" ]; then
-  echo "Tests for Scala 2.10 succeeded"
-else
-  echo "Tests for Scala 2.10 failed"
-  retval=1
-fi
 
 if [ "$s211r" = "0" ]; then
   echo "Tests for Scala 2.11 succeeded"
 else
   echo "Tests for Scala 2.11 failed"
+  retval=1
+fi
+
+if [ "$s212r" = "0" ]; then
+  echo "Tests for Scala 2.12 succeeded"
+else
+  echo "Tests for Scala 2.12 failed"
   retval=1
 fi
 

--- a/generateDocs.sh
+++ b/generateDocs.sh
@@ -12,7 +12,7 @@ for VERSION in $@ ;do
         continue
     fi
     sbt clean
-    sbt -Dscala-2.11=true doc
+    sbt doc
     mkdir $OUTPUT/$VERSION
     
     for MODULE in spark-cassandra-connector spark-cassandra-connector-embedded; do

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -46,6 +46,7 @@ object Settings extends Build {
     organization         := "com.datastax.spark",
     version in ThisBuild := currentVersion,
     scalaVersion         := Versions.scalaVersion,
+    crossScalaVersions   := Versions.crossScala,
     crossVersion         := CrossVersion.binary,
     versionStatus        := Versions.status(scalaVersion.value, scalaBinaryVersion.value)
   )

--- a/project/SparkInstaller.scala
+++ b/project/SparkInstaller.scala
@@ -97,12 +97,12 @@ object SparkInstaller {
   }
 
   private def installSpark(rootDir: Path, scalaVersion: String): Unit = {
-    val `scala_2.11` = scalaVersion != "2.10"
+    val `scala_2.12` = scalaVersion != "2.11"
 
-    if (`scala_2.11`) {
+    if (`scala_2.12`) {
       val cmd = List(
         Paths.get("dev").resolve("change-scala-version.sh").toString,
-        "2.11"
+        "2.12"
       )
       val result = sbt.Process(cmd, rootDir.toFile) ! StdProcessLogger
       if (result != 0)
@@ -114,7 +114,7 @@ object SparkInstaller {
       "--force",
       "--batch-mode",
       "-DskipTests"
-    ) ::: (if (`scala_2.11`) List("-Dscala-2.11") else Nil) :::
+    ) ::: (if (`scala_2.12`) List("-Dscala-2.12") else Nil) :::
       "install" :: Nil
 
     val result = sbt.Process(cmd, rootDir.toFile, "AMPLAB_JENKINS" -> "1") ! StdProcessLogger

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -17,11 +17,16 @@ import scala.util.Properties
  */
 object Versions {
 
+  val crossScala = Seq("2.12.9", "2.11.12")
 
-  lazy val scalaVersion = "2.11.12"
+  /* Leverages optional Spark 'scala-2.12' profile optionally set by the user via -Dscala-2.12=true if enabled */
+  lazy val scalaVersion = sys.props.get("scala-2.12") match {
+    case Some(is) if is.nonEmpty && is.toBoolean => crossScala.head
+    case crossBuildFor                           => crossScala.last
+  }
 
   /* For `scalaBinaryVersion.value outside an sbt task. */
-  lazy val scalaBinary = scalaVersion.dropRight(2)
+  lazy val scalaBinary = scalaVersion.take(4)
 
   val Akka            = "2.3.4"
   val Cassandra       = "3.11.3"
@@ -59,9 +64,11 @@ object Versions {
 
   val doNotInstallSpark = true
 
+  val hint = (binary: String) => if (binary == "2.11") "[To build against Scala 2.12 use '-Dscala-2.12=true']" else ""
+
   val status = (versionInReapply: String, binaryInReapply: String) =>
     println(s"""
-        |  Scala: $versionInReapply
+        |  Scala: $versionInReapply ${hint(binaryInReapply)}
         |  Scala Binary: $binaryInReapply
         |  Java: target=$JDK user=${Properties.javaVersion}
         |  Cassandra version for testing: ${Testing.cassandraTestVersion} [can be overridden by specifying '-Dtest.cassandra.version=<version>']

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,7 +20,7 @@ addSbtPlugin("com.scalapenos" % "sbt-prompt" % "1.0.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.4.0")
 
 //SbtAssembly 0.12.0 is included in sbt-spark-package
 resolvers += "Spark Packages Main repo" at "https://dl.bintray.com/spark-packages/maven" 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/AbstractCassandraJoin.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/AbstractCassandraJoin.scala
@@ -167,7 +167,7 @@ private[rdd] trait AbstractCassandraJoin[L, R] {
     val rowIterator = fetchIterator(session, bsb, rowMetadata, left.iterator(split, context))
     val countingIterator = new CountingIterator(rowIterator, None)
 
-    context.addTaskCompletionListener { (context) =>
+    context.addTaskCompletionListener[Unit] { (context) =>
       val duration = metricsUpdater.finish() / 1000000000d
       logDebug(
         f"Fetched ${countingIterator.count} rows " +

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
@@ -367,7 +367,7 @@ class CassandraTableScanRDD[R] private[connector](
       fetchTokenRange(scanner, _: CqlTokenRange[_, _], metricsUpdater))
     val countingIterator = new CountingIterator(rowIterator, limitForIterator(limit))
 
-    context.addTaskCompletionListener { (context) =>
+    context.addTaskCompletionListener[Unit] { (context) =>
       val duration = metricsUpdater.finish() / 1000000000d
       logDebug(f"Fetched ${countingIterator.count} rows from $keyspaceName.$tableName " +
         f"for partition ${partition.index} in $duration%.3f s.")

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/Reflect.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/Reflect.scala
@@ -18,4 +18,3 @@ private[connector] object Reflect {
     }
   }
 }
-


### PR DESCRIPTION
I've been using my own for of spark-cassandra-connector with scala-2.12 from the day one and it works without any problems. This PR brings back cross-version build and adds scala-2.12 to it.
`sbt test` and `sbt assembly` succeed for both version of scala.

If it looks good then documentation should be tweaked as well.

One problem that I faced: when I try to load the project into Intellij or run integration tests it tries to pull 'spark-1.4.0' for some reason:

> [error] (cassandra-server/*:coursierResolutions) coursier.ResolutionException: Encountered 1 error(s) in dependency resolution:
[error]     org.apache.spark:spark-core_2.12:1.4.0:

Not sure where it comes from. Is 'cassandra-server' project still relevant?
