### PR TITLE
Fix the hyperlink to save modes in the latest Spark documentation

### DIFF
--- a/doc/15_python.md
+++ b/doc/15_python.md
@@ -46,7 +46,7 @@ source and by specifying keyword arguments for `keyspace` and `table`.
 
 ### Saving a DataFrame in Python to Cassandra
 
-A DataFrame can be saved to an *existing* Cassandra table by using the the `org.apache.spark.sql.cassandra` source and by specifying keyword arguments for `keyspace` and `table` and saving mode (`append`, `overwrite`, `error` or `ignore`, see [Data Sources API doc](https://spark.apache.org/docs/latest/sql-programming-guide.html#save-modes)).
+A DataFrame can be saved to an *existing* Cassandra table by using the the `org.apache.spark.sql.cassandra` source and by specifying keyword arguments for `keyspace` and `table` and saving mode (`append`, `overwrite`, `error` or `ignore`, see [Data Sources API doc](https://spark.apache.org/docs/latest/sql-data-sources-load-save-functions.html#save-modes)).
 
 #### Example Saving to a Cassanra Table as a Pyspark DataFrame
 ```python


### PR DESCRIPTION
Fix the hyperlink to save modes in the latest Spark documentation