### PR TITLE
[SPARKC-524] Generate a CQL Create Table from DataFrame with options

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/DatasetFunctions.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/DatasetFunctions.scala
@@ -17,11 +17,11 @@ class DatasetFunctions[K: Encoder](dataset: Dataset[K]) extends Serializable {
   }
 
   /**
-    *  Creates a C* table based on the Dataset Struct provided. Optionally
-    *  takes in a list of partition columns or clustering columns names. When absent
-    *  the first column will be used as the partition key and there will be no clustering
-    *  keys.
-    */
+   *  Creates a C* table based on the Dataset Struct provided. Optionally
+   *  takes in a list of partition columns or clustering columns names. When absent
+   *  the first column will be used as the partition key and there will be no clustering
+   *  keys.
+   */
   def createCassandraTable(
     keyspaceName: String,
     tableName: String,
@@ -31,20 +31,42 @@ class DatasetFunctions[K: Encoder](dataset: Dataset[K]) extends Serializable {
     connector: CassandraConnector = CassandraConnector(sparkContext)): Unit = {
 
     val protocolVersion = connector.withSessionDo(_.getContext.getProtocolVersion)
+    val rawTable = new DataFrameColumnMapper(dataset.schema).newTable(keyspaceName, tableName, protocolVersion)
+    val partitionKeyNames = partitionKeyColumns.getOrElse(rawTable.partitionKey.map(_.columnName))
+    val clusteringKeyNames = clusteringKeyColumns.getOrElse(Seq.empty)
+
+    createCassandraTableEx(keyspaceName, tableName, partitionKeyNames,
+      clusteringKeyNames.map((_, ClusteringColumn.Ascending)))(connector)
+  }
+
+    /**
+    *  Creates a C* table based on the Dataset Struct provided.
+    *  Takes in a list of partition columns, clustering columns names, and optionally, the table options.
+    */
+  def createCassandraTableEx(
+    keyspaceName: String,
+    tableName: String,
+    partitionKeyColumns: Seq[String],
+    clusteringKeyColumns: Seq[(String, ClusteringColumn.SortingOrder)],
+    ifNotExists: Boolean = false,
+    tableOptions: Map[String, String] = Map())(
+  implicit
+    connector: CassandraConnector = CassandraConnector(sparkContext)): Unit = {
+
+    val protocolVersion = connector.withSessionDo(_.getContext.getProtocolVersion)
 
     val rawTable = new DataFrameColumnMapper(dataset.schema).newTable(keyspaceName, tableName, protocolVersion)
     val columnMapping = rawTable.columnByName
 
     val columnNames = columnMapping.keys.toSet
-    val partitionKeyNames = partitionKeyColumns.getOrElse(rawTable.partitionKey.map(_.columnName))
-    val clusteringKeyNames = clusteringKeyColumns.getOrElse(Seq.empty)
+    val partitionKeyNames = partitionKeyColumns
+    val clusteringKeyNames = clusteringKeyColumns.map(_._1)
     val regularColumnNames = (columnNames -- (partitionKeyNames ++ clusteringKeyNames)).toSeq
 
     def missingColumnException(columnName: String, columnType: String) = {
       new IllegalArgumentException(
         s""""$columnName" not Found. Unable to make specified column $columnName a $columnType.
           |Available Columns: $columnNames""".stripMargin)
-
     }
 
     val table = rawTable.copy (
@@ -54,18 +76,23 @@ class DatasetFunctions[K: Encoder](dataset: Dataset[K]) extends Serializable {
               throw missingColumnException(partitionKeyName, "Partition Key Column")))
           .map(_.copy(columnRole = PartitionKeyColumn))
       ,
-      clusteringColumns = clusteringKeyNames
-          .map(clusteringKeyName =>
-            columnMapping.getOrElse(clusteringKeyName,
-              throw missingColumnException(clusteringKeyName, "Clustering Column")))
+      clusteringColumns = clusteringKeyColumns
+          .map(clusteringKey =>
+            (columnMapping.getOrElse(clusteringKey._1,
+              throw missingColumnException(clusteringKey._1, "Clustering Column")),
+              clusteringKey._2))
           .zipWithIndex
-          .map { case (col, index) => col.copy(columnRole = ClusteringColumn(index))}
+          .map { case (col, index) => col._1.copy(columnRole = ClusteringColumn(index, col._2))}
       ,
       regularColumns = regularColumnNames
           .map(regularColumnName =>
              columnMapping.getOrElse(regularColumnName,
                   throw missingColumnException(regularColumnName, "Regular Column")))
           .map(_.copy(columnRole = RegularColumn))
+      ,
+      ifNotExists = ifNotExists
+      ,
+      tableOptions = tableOptions
     )
 
     connector.withSessionDo(session => session.execute(table.cql))

--- a/doc/14_data_frames.md
+++ b/doc/14_data_frames.md
@@ -260,13 +260,15 @@ options(CassandraConnectorConf.ReadTimeoutParam.sqlOption("7000") ++ ReadConf.Ta
 ```
 
 ### Creating a New Cassandra Table From a Dataset Schema
-Spark Cassandra Connector adds a method to `Dataset` that allows it to create a new Cassandra table from
+Spark Cassandra Connector adds methods to `Dataset` that allows it to create a new Cassandra table from
 the `StructType` schema of the Dataset. This is convenient for persisting a Dataset to a new table, especially
 when the schema of the Dataset is not known (fully or at all) ahead of time (at compile time of your application).
 Once the new table is created, you can persist the Dataset to the new table using the save function described above.
 
 The partition key and clustering key of the newly generated table can be set by passing in a list of 
-names of columns which should be used as partition key and clustering key.
+names of columns which should be used as partition key and clustering key.  The
+`createCassandraTableEx` method allows further customize table structure by specifying
+sorting direction for clustering columns, and additional table options.
 
 #### Example Creating a Cassandra Table from a Dataset
 ```scala

--- a/doc/5_saving.md
+++ b/doc/5_saving.md
@@ -453,9 +453,11 @@ val collection = sc.parallelize(Seq(WordCount("dog", 50), WordCount("cow", 60)))
 collection.saveAsCassandraTableEx(table2, SomeColumns("word", "count"))
 ```
 
-To create a table with a custom definition, and define which columns are to be partition and clustering column keys:
+To create a table with a custom definition, and define which columns are to be partition
+and clustering column keys with non-default sorting, plus additional table options:
 
 #### Example Creating a New Table Using a Completely Custom Definition
+
 ```scala
 import com.datastax.spark.connector.cql.{ColumnDef, RegularColumn, TableDef, ClusteringColumn, PartitionKeyColumn}
 import com.datastax.spark.connector.types._
@@ -466,16 +468,18 @@ case class outData(col1:UUID, col2:UUID, col3: Double, col4:Int)
 // Define columns
 val p1Col = new ColumnDef("col1",PartitionKeyColumn,UUIDType)
 val c1Col = new ColumnDef("col2",ClusteringColumn(0),UUIDType)
-val c2Col = new ColumnDef("col3",ClusteringColumn(1),DoubleType)
+val c2Col = new ColumnDef("col3",ClusteringColumn(1, ClusteringColumn.Descending),DoubleType)
 val rCol = new ColumnDef("col4",RegularColumn,IntType)
 
 // Create table definition
-val table = TableDef("test","words",Seq(p1Col),Seq(c1Col, c2Col),Seq(rCol))
+val table = TableDef("test","words",Seq(p1Col),Seq(c1Col, c2Col),Seq(rCol),
+  tableOptions = Map("gc_grace_seconds"-> "86400" ))
 
 // Map rdd into custom data structure and create table
 val rddOut = rdd.map(s => outData(s._1, s._2(0), s._2(1), s._3))
 rddOut.saveAsCassandraTableEx(table, SomeColumns("col1", "col2", "col3", "col4"))
 ```
+
 ## Deleting Rows and Columns
 `RDD.deleteFromCassandra(keyspaceName, tableName)` deletes specific rows 
 from the specified Cassandra table. The values in the RDD are 

--- a/driver/src/test/scala/com/datastax/spark/connector/cql/TableDefSpec.scala
+++ b/driver/src/test/scala/com/datastax/spark/connector/cql/TableDefSpec.scala
@@ -3,6 +3,8 @@ package com.datastax.spark.connector.cql
 import com.datastax.spark.connector.types._
 import org.scalatest.{Matchers, WordSpec}
 
+import scala.collection.SortedMap
+
 class TableDefSpec extends WordSpec with Matchers {
 
   "A TableDef#cql method" should {
@@ -64,6 +66,55 @@ class TableDefSpec extends WordSpec with Matchers {
             |  "c2" map<bigint, varchar>,
             |  PRIMARY KEY (("c1"))
             |)""".stripMargin
+        )
+      }
+
+      "it contains compound partition key, if not exists, multiple clustering columns with sorting and options" in {
+        val column1 = ColumnDef("c1", PartitionKeyColumn, IntType)
+        val column2 = ColumnDef("c2", PartitionKeyColumn, VarCharType)
+        val column3 = ColumnDef("c3", ClusteringColumn(0), VarCharType)
+        val column4 = ColumnDef("c4", ClusteringColumn(1, ClusteringColumn.Descending), VarCharType)
+        val column5 = ColumnDef("c5", RegularColumn, VarCharType)
+        //
+        val tableDefSortOnly = TableDef("keyspace", "table", Seq(column1, column2), Seq(column3, column4),
+          Seq(column5), ifNotExists = true)
+        tableDefSortOnly.cql should be(
+          """CREATE TABLE IF NOT EXISTS "keyspace"."table" (
+            |  "c1" int,
+            |  "c2" varchar,
+            |  "c3" varchar,
+            |  "c4" varchar,
+            |  "c5" varchar,
+            |  PRIMARY KEY (("c1", "c2"), "c3", "c4")
+            |) WITH CLUSTERING ORDER BY ("c3" ASC, "c4" DESC)""".stripMargin
+        )
+        //
+        val tableDefSortAndOptions = TableDef("keyspace", "table", Seq(column1, column2),
+          Seq(column3, column4), Seq(column5), ifNotExists = true,
+          tableOptions = Map("dclocal_read_repair_chance"-> "0.1" ))
+        tableDefSortAndOptions.cql should be(
+          """CREATE TABLE IF NOT EXISTS "keyspace"."table" (
+            |  "c1" int,
+            |  "c2" varchar,
+            |  "c3" varchar,
+            |  "c4" varchar,
+            |  "c5" varchar,
+            |  PRIMARY KEY (("c1", "c2"), "c3", "c4")
+            |) WITH CLUSTERING ORDER BY ("c3" ASC, "c4" DESC)
+            |  AND dclocal_read_repair_chance = 0.1""".stripMargin
+        )
+        //
+        val tableDefOptionsOnly = TableDef("keyspace", "table", Seq(column1, column2),
+          Seq(column3), Seq(column5), ifNotExists = true,
+          tableOptions = Map("dclocal_read_repair_chance"-> "0.1"))
+        tableDefOptionsOnly.cql should be(
+          """CREATE TABLE IF NOT EXISTS "keyspace"."table" (
+            |  "c1" int,
+            |  "c2" varchar,
+            |  "c3" varchar,
+            |  "c5" varchar,
+            |  PRIMARY KEY (("c1", "c2"), "c3")
+            |) WITH dclocal_read_repair_chance = 0.1""".stripMargin
         )
       }
     }


### PR DESCRIPTION
Generate a CQL Create Table statement using a DataFrame and all the parameters required to
construct the CREATE Table statement, like, `IF NOT EXISTS`, `WITH CLUSTERING ORDER BY`,
etc.