### PR TITLE
SPARKC-575: Change Dse Prefixed Parameters

### DIFF
--- a/connector/src/it/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinSpec.scala
+++ b/connector/src/it/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinSpec.scala
@@ -650,14 +650,14 @@ class CassandraDirectJoinSpec extends SparkCassandraITFlatSpecBase with DefaultC
     }
   }
 
-  def getDirectJoin(df: Dataset[_]): Option[DSEDirectJoinExec] = {
+  def getDirectJoin(df: Dataset[_]): Option[CassandraDirectJoinExec] = {
     val plan = df.queryExecution.sparkPlan
-    plan.collectFirst{ case x: DSEDirectJoinExec => x }
+    plan.collectFirst{ case x: CassandraDirectJoinExec => x }
   }
 
   def getDirectJoin(stream: StreamingQueryWrapper) = {
     val plan = stream.streamingQuery.lastExecution.executedPlan
-    plan.collectFirst { case x: DSEDirectJoinExec => x }
+    plan.collectFirst { case x: CassandraDirectJoinExec => x }
   }
 
   def planDetails(df: Dataset[_]): String = {

--- a/connector/src/main/scala/com/datastax/spark/connector/CassandraSparkExtensions.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/CassandraSparkExtensions.scala
@@ -1,15 +1,15 @@
 package com.datastax.spark.connector
 
 import org.apache.spark.sql.{SparkSessionExtensions, catalyst}
-import org.apache.spark.sql.cassandra.execution.DSEDirectJoinStrategy
+import org.apache.spark.sql.cassandra.execution.CassandraDirectJoinStrategy
 import org.apache.spark.sql.cassandra.{CassandraMetaDataRule, CassandraMetadataFunction}
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import com.datastax.spark.connector.util.Logging
 import org.apache.spark.sql.catalyst.expressions.Expression
 
-class DseSparkExtensions extends (SparkSessionExtensions => Unit) with Logging {
+class CassandraSparkExtensions extends (SparkSessionExtensions => Unit) with Logging {
   override def apply(extensions: SparkSessionExtensions): Unit = {
-    extensions.injectPlannerStrategy(DSEDirectJoinStrategy.apply)
+    extensions.injectPlannerStrategy(CassandraDirectJoinStrategy.apply)
     extensions.injectResolutionRule( session => CassandraMetaDataRule)
     try {
       val injectFunction =

--- a/connector/src/main/scala/com/datastax/spark/connector/DseSparkExtensions.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/DseSparkExtensions.scala
@@ -29,7 +29,7 @@ class DseSparkExtensions extends (SparkSessionExtensions => Unit) with Logging {
         (input: Seq[Expression]) => CassandraMetadataFunction.cassandraTTLFunctionBuilder(input)))
     } catch {
       case e @ (_:NoSuchMethodException | _:NoSuchMethodError) => logWarning(
-        """Unable to register DSE Specific functions CassandraTTL and CassandraWriteTime
+        """Unable to register Cassandra Specific functions CassandraTTL and CassandraWriteTime
           |because of Spark version, use functionRegistry.registerFunction to add
           |the functions.""".stripMargin)
     }

--- a/connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSourceRelation.scala
+++ b/connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSourceRelation.scala
@@ -513,6 +513,7 @@ object CassandraSourceRelation extends Logging {
   private lazy val hiveConf = new HiveConf()
 
   val ReferenceSection = "Cassandra Datasource Parameters"
+  val TableOptions = "Cassandra Datasource Table Options"
 
   val TableSizeInBytesParam = ConfigParameter[Option[Long]](
     name = "spark.cassandra.table.size.in.bytes",
@@ -525,7 +526,7 @@ object CassandraSourceRelation extends Logging {
 
   val WriteTimeParam = ConfigParameter[Option[String]](
     name = "writetime",
-    section = ReferenceSection,
+    section = TableOptions,
     default = None,
     description =
       """Surfaces the Cassandra Row Writetime as a Column
@@ -536,7 +537,7 @@ object CassandraSourceRelation extends Logging {
 
   val TTLParam = ConfigParameter[Option[String]](
     name = "ttl",
-    section = ReferenceSection,
+    section = TableOptions,
     default = None,
     description =
       """Surfaces the Cassandra Row TTL as a Column
@@ -583,7 +584,7 @@ object CassandraSourceRelation extends Logging {
 
   val DirectJoinSizeRatioParam = ConfigParameter[Double] (
     name = "directJoinSizeRatio",
-    section = ReferenceSection,
+    section = TableOptions,
     default = 0.9d,
     description =
       s"""
@@ -595,7 +596,7 @@ object CassandraSourceRelation extends Logging {
 
   val DirectJoinSettingParam = ConfigParameter[String] (
     name = "directJoinSetting",
-    section = ReferenceSection,
+    section = TableOptions,
     default = "auto",
     description =
       s"""Acceptable values, "on", "off", "auto"
@@ -605,8 +606,9 @@ object CassandraSourceRelation extends Logging {
       """.stripMargin
   )
 
+
   val InClauseToJoinWithTableConversionThreshold = ConfigParameter[Long](
-    name = "spark.sql.dse.inClauseToJoinConversionThreshold",
+    name = "spark.cassandra.sql.inClauseToJoinConversionThreshold",
     section = ReferenceSection,
     default = 2500L,
     description =
@@ -617,8 +619,15 @@ object CassandraSourceRelation extends Logging {
          """.stripMargin
   )
 
+  val DseInClauseToJoinWithTableConversionThreshold = DeprecatedConfigParameter[Long](
+    name = "spark.sql.dse.inClauseToJoinConversionThreshold",
+    replacementParameter = Some(InClauseToJoinWithTableConversionThreshold),
+    deprecatedSince = "3.0.0",
+    rational = "Renamed since this is no longer DSE Specific"
+  )
+
   val InClauseToFullTableScanConversionThreshold = ConfigParameter[Long](
-    name = "spark.sql.dse.inClauseToFullScanConversionThreshold",
+    name = "spark.cassandra.sql.inClauseToFullScanConversionThreshold",
     section = ReferenceSection,
     default = 20000000L,
     description =
@@ -631,9 +640,16 @@ object CassandraSourceRelation extends Logging {
          """.stripMargin
   )
 
+  val DseInClauseToFullTableScanConversionThreshold = DeprecatedConfigParameter[Long](
+    name = "spark.sql.dse.inClauseToFullScanConversionThreshold",
+    replacementParameter = Some(InClauseToFullTableScanConversionThreshold),
+    deprecatedSince = "3.0.0",
+    rational = "Renamed because this is no longer DSE Specific"
+  )
+
   val IgnoreMissingMetaColumns = ConfigParameter[Boolean] (
     name = "ignoreMissingMetaColumns",
-    section = ReferenceSection,
+    section = TableOptions,
     default = false,
     description =
       s"""Acceptable values, "true", "false"

--- a/connector/src/main/scala/org/apache/spark/sql/cassandra/DsePredicateRules.scala
+++ b/connector/src/main/scala/org/apache/spark/sql/cassandra/DsePredicateRules.scala
@@ -9,6 +9,10 @@ import com.datastax.spark.connector.cql.{ColumnDef, TableDef}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.sources.{EqualTo, Filter, In, IsNotNull}
 
+
+/**
+  *  A series of pushdown rules that only apply when connecting to Datastax Enterprise
+  */
 object DsePredicateRules extends CassandraPredicateRules {
 
   override def apply(

--- a/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinExec.scala
+++ b/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinExec.scala
@@ -14,7 +14,7 @@ import org.apache.spark.sql.execution.metric.SQLMetrics
 /**
   * A physical plan for performing a join against a CassandraTable given a set of keys.
   */
-case class DSEDirectJoinExec(
+case class CassandraDirectJoinExec(
   leftKeys: Seq[Expression],
   rightKeys: Seq[Expression],
   joinType: JoinType,
@@ -213,6 +213,6 @@ case class DSEDirectJoinExec(
       .map{ case (colref: Attribute, exp) => s"${attributeToCassandra(colref)} = ${exp}"}
       .mkString(", ")
 
-    s"DSE Direct Join [${joinString}] $keyspace.$table - $selectString${pushedWhere} "
+    s"Cassandra Direct Join [${joinString}] $keyspace.$table - $selectString${pushedWhere} "
   }
 }

--- a/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinStrategy.scala
+++ b/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinStrategy.scala
@@ -20,8 +20,8 @@ import org.apache.spark.sql.execution.{DataSourceScanExec, ProjectExec, SparkPla
   * Converts logical plans where the join target is a Cassandra derived branch with joinWithCassandraTable
   * style Join
   */
-case class DSEDirectJoinStrategy(spark: SparkSession) extends Strategy with Serializable {
-  import DSEDirectJoinStrategy._
+case class CassandraDirectJoinStrategy(spark: SparkSession) extends Strategy with Serializable {
+  import CassandraDirectJoinStrategy._
 
   val conf = spark.sqlContext.conf
 
@@ -51,7 +51,7 @@ case class DSEDirectJoinStrategy(spark: SparkSession) extends Strategy with Seri
         case PhysicalOperation(attributes, _, LogicalRelation(_: CassandraSourceRelation, _, _, _)) =>
 
           val directJoin =
-            DSEDirectJoinExec(
+            CassandraDirectJoinExec(
             leftKeys,
             rightKeys,
             joinType,
@@ -67,7 +67,7 @@ case class DSEDirectJoinStrategy(spark: SparkSession) extends Strategy with Seri
           val newOutput = (newPlan.head.outputSet, newPlan.head.output.map(_.name))
           val oldOutput = (plan.outputSet, plan.output.map(_.name))
           val noMissingOutput = oldOutput._1.subsetOf(newPlan.head.outputSet)
-          require(noMissingOutput, s"DSE DirectJoin Optimization produced invalid output. Original plan output: " +
+          require(noMissingOutput, s"Cassandra DirectJoin Optimization produced invalid output. Original plan output: " +
             s"${oldOutput} was not part of ${newOutput} \nOld Plan\n${plan}\nNew Plan\n${newPlan}")
 
           newPlan
@@ -143,7 +143,7 @@ case class DSEDirectJoinStrategy(spark: SparkSession) extends Strategy with Seri
 
 }
 
-object DSEDirectJoinStrategy extends Logging {
+object CassandraDirectJoinStrategy extends Logging {
 
   /**
     * Recursively search the dependencies of an RDD for a CassandraTableScanRDD
@@ -244,7 +244,7 @@ object DSEDirectJoinStrategy extends Logging {
     *
     * This should only be called on optimized Physical Plans
     */
-  def reorderPlan(plan: SparkPlan, directJoin: DSEDirectJoinExec): SparkPlan = {
+  def reorderPlan(plan: SparkPlan, directJoin: CassandraDirectJoinExec): SparkPlan = {
     val reordered = plan match {
       //This may be the only node in the Plan
       case dataSourceScan: DataSourceScanExec

--- a/connector/src/test/scala/com/datastax/spark/connector/embedded/SparkTemplate.scala
+++ b/connector/src/test/scala/com/datastax/spark/connector/embedded/SparkTemplate.scala
@@ -24,7 +24,7 @@ object SparkTemplate {
     .set("spark.ui.showConsoleProgress", "false")
     .set("spark.ui.enabled", "false")
     .set("spark.cleaner.ttl", "3600")
-    .set("spark.sql.extensions","com.datastax.spark.connector.DseSparkExtensions")
+    .set("spark.sql.extensions","com.datastax.spark.connector.CassandraSparkExtensions")
     .setMaster(sys.env.getOrElse("IT_TEST_SPARK_MASTER", "local[2]"))
     .setAppName("Test")
     .setAll(HiveMetastoreConfig)

--- a/doc/14_data_frames.md
+++ b/doc/14_data_frames.md
@@ -321,7 +321,7 @@ Spark plans and provide unique C* specific optimizations. To load these rules yo
 directly add the extensions to your Spark environment or they can be added via a configuration property
 
 ```
-spark.sql.extensions = com.datastax.spark.connector.DseSparkExtensions
+spark.sql.extensions = com.datastax.spark.connector.CassandraSparkExtensions
 ```
 
 Within this file are the triggers for handling `ttl`, `writetime` functions (`ttl` and

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -131,6 +131,58 @@ Setting this to -1 means unlimited retries
 <table class="table">
 <tr><th>Property Name</th><th>Default</th><th>Description</th></tr>
 <tr>
+  <td><code>spark.cassandra.sql.inClauseToFullScanConversionThreshold</code></td>
+  <td>20000000</td>
+  <td>Queries with `IN` clause(s) are not converted to JoinWithCassandraTable operation if the size of cross
+product of all `IN` value sets exceeds this value. It is meant to stop conversion for huge `IN` values sets
+that may cause memory problems. If this limit is exceeded full table scan is performed.
+This setting takes precedence over spark.cassandra.sql.inClauseToJoinConversionThreshold.
+Query `select * from t where k1 in (1,2,3) and k2 in (1,2) and k3 in (1,2,3,4)` has 3 sets of `IN` values.
+Cross product of these values has size of 24.
+         </td>
+</tr>
+<tr>
+  <td><code>spark.cassandra.sql.inClauseToJoinConversionThreshold</code></td>
+  <td>2500</td>
+  <td>Queries with `IN` clause(s) are converted to JoinWithCassandraTable operation if the size of cross
+product of all `IN` value sets exceeds this value. To disable `IN` clause conversion, set this setting to 0.
+Query `select * from t where k1 in (1,2,3) and k2 in (1,2) and k3 in (1,2,3,4)` has 3 sets of `IN` values.
+Cross product of these values has size of 24.
+         </td>
+</tr>
+<tr>
+  <td><code>spark.cassandra.sql.pushdown.additionalClasses</code></td>
+  <td></td>
+  <td>A comma separated list of classes to be used (in order) to apply additional
+ pushdown rules for Cassandra Dataframes. Classes must implement CassandraPredicateRules
+      </td>
+</tr>
+<tr>
+  <td><code>spark.cassandra.table.size.in.bytes</code></td>
+  <td>None</td>
+  <td>Used by DataFrames Internally, will be updated in a future release to
+retrieve size from Cassandra. Can be set manually now</td>
+</tr>
+<tr>
+  <td><code>spark.sql.dse.search.autoRatio</code></td>
+  <td>0.03</td>
+  <td>When Search Predicate Optimization is set to auto, Search optimizations will be preformed if this parameter * the total number of rows is greater than the number of rowsto be returned by the solr query</td>
+</tr>
+<tr>
+  <td><code>spark.sql.dse.search.enableOptimization</code></td>
+  <td>auto</td>
+  <td>Enables SparkSQL to automatically replace Cassandra Pushdowns with DSE Search
+Pushdowns utilizing lucene indexes. Valid options are On, Off, and Auto. Auto enables
+optimizations when the solr query will pull less than spark.sql.dse.search.autoRatio * the
+total table record count</td>
+</tr>
+</table>
+
+
+## Cassandra Datasource Table Options
+<table class="table">
+<tr><th>Property Name</th><th>Default</th><th>Description</th></tr>
+<tr>
   <td><code>directJoinSetting</code></td>
   <td>auto</td>
   <td>Acceptable values, "on", "off", "auto"
@@ -155,52 +207,6 @@ Setting this to -1 means unlimited retries
 "true" ignore missing meta properties
 "false" throw error if missing property is requested
       </td>
-</tr>
-<tr>
-  <td><code>spark.cassandra.sql.pushdown.additionalClasses</code></td>
-  <td></td>
-  <td>A comma separated list of classes to be used (in order) to apply additional
- pushdown rules for Cassandra Dataframes. Classes must implement CassandraPredicateRules
-      </td>
-</tr>
-<tr>
-  <td><code>spark.cassandra.table.size.in.bytes</code></td>
-  <td>None</td>
-  <td>Used by DataFrames Internally, will be updated in a future release to
-retrieve size from Cassandra. Can be set manually now</td>
-</tr>
-<tr>
-  <td><code>spark.sql.dse.inClauseToFullScanConversionThreshold</code></td>
-  <td>20000000</td>
-  <td>Queries with `IN` clause(s) are not converted to JoinWithCassandraTable operation if the size of cross
-product of all `IN` value sets exceeds this value. It is meant to stop conversion for huge `IN` values sets
-that may cause memory problems. If this limit is exceeded full table scan is performed.
-This setting takes precedence over spark.sql.dse.inClauseToJoinConversionThreshold.
-Query `select * from t where k1 in (1,2,3) and k2 in (1,2) and k3 in (1,2,3,4)` has 3 sets of `IN` values.
-Cross product of these values has size of 24.
-         </td>
-</tr>
-<tr>
-  <td><code>spark.sql.dse.inClauseToJoinConversionThreshold</code></td>
-  <td>2500</td>
-  <td>Queries with `IN` clause(s) are converted to JoinWithCassandraTable operation if the size of cross
-product of all `IN` value sets exceeds this value. To disable `IN` clause conversion, set this setting to 0.
-Query `select * from t where k1 in (1,2,3) and k2 in (1,2) and k3 in (1,2,3,4)` has 3 sets of `IN` values.
-Cross product of these values has size of 24.
-         </td>
-</tr>
-<tr>
-  <td><code>spark.sql.dse.search.autoRatio</code></td>
-  <td>0.03</td>
-  <td>When Search Predicate Optimization is set to auto, Search optimizations will be preformed if this parameter * the total number of rows is greater than the number of rowsto be returned by the solr query</td>
-</tr>
-<tr>
-  <td><code>spark.sql.dse.search.enableOptimization</code></td>
-  <td>auto</td>
-  <td>Enables SparkSQL to automatically replace Cassandra Pushdowns with DSE Search
-Pushdowns utilizing lucene indexes. Valid options are On, Off, and Auto. Auto enables
-optimizations when the solr query will pull less than spark.sql.dse.search.autoRatio * the
-total table record count</td>
 </tr>
 <tr>
   <td><code>ttl</code></td>


### PR DESCRIPTION
The DS Merge brought in a few parameters for DSE Specific features which
didn't follow the spark.cassandra pattern of everything else. We changed
all the parameters which don't work specifically with dse to generic
spark.cassandra.

Options for Datasource Tables exclusively are also moved into their own
section.