### PR TITLE
SPARKC-599 exclude org.apache.tinkerpop

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,6 +31,7 @@ object Dependencies
 
     def driverCoreExclude(): ModuleID = module
       .exclude("com.datastax.oss", "java-driver-core") // doesn't shade guava
+      .exclude("org.apache.tinkerpop", "*")
   }
 
   object TestCommon {
@@ -69,7 +70,7 @@ object Dependencies
   }
 
   object Driver {
-    val driverCore = "com.datastax.oss" % "java-driver-core-shaded" % DataStaxJavaDriver
+    val driverCore = "com.datastax.oss" % "java-driver-core-shaded" % DataStaxJavaDriver driverCoreExclude()
     val driverMapper = "com.datastax.oss" % "java-driver-mapper-runtime" % DataStaxJavaDriver driverCoreExclude()
 
     val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % Versions.ScalaLogging

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,6 +32,8 @@ object Dependencies
     def driverCoreExclude(): ModuleID = module
       .exclude("com.datastax.oss", "java-driver-core") // doesn't shade guava
       .exclude("org.apache.tinkerpop", "*")
+      // until SPARK-20075 is fixed we fallback to java workarounds for native calls
+      .exclude("com.github.jnr", "jnr-posix")
   }
 
   object TestCommon {

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -6,7 +6,7 @@ object Versions {
   val Paranamer       = "2.8"
   val ScalaLogging    = "3.5.0"
 
-  val DataStaxJavaDriver = "4.5.0"
+  val DataStaxJavaDriver = "4.7.2"
   val ReactiveStreams = "1.0.2"
 
   val ScalaCheck      = "1.14.0"


### PR DESCRIPTION
As it is not used in SCC and it's transitive dependencies
cause ERRORs during spark-submit bootstrap (only when executed
with --packages argument).
