### PR TITLE
Sparkc 577 round three

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/ColumnSelector.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/ColumnSelector.scala
@@ -1,49 +1,70 @@
 package com.datastax.spark.connector
 
-import scala.language.implicitConversions
+import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata
 
-import com.datastax.spark.connector.cql.TableDef
+import scala.language.implicitConversions
+import com.datastax.spark.connector.cql.{ColumnDef, StructDef, TableDef}
 
 sealed trait ColumnSelector {
   def aliases: Map[String, String]
   def selectFrom(table: TableDef): IndexedSeq[ColumnRef]
+  def selectFrom(table: TableMetadata): IndexedSeq[ColumnRef]
 }
 
 case object AllColumns extends ColumnSelector {
   override def aliases: Map[String, String] = Map.empty.withDefault(x => x)
   override def selectFrom(table: TableDef) =
     table.columns.map(_.ref)
+  override def selectFrom(table: TableMetadata) =
+    TableDef.columns(table).map(ColumnDef.toRef(_))
 }
 
 case object PartitionKeyColumns extends ColumnSelector {
   override def aliases: Map[String, String] = Map.empty.withDefault(x => x)
   override def selectFrom(table: TableDef) =
     table.partitionKey.map(_.ref).toIndexedSeq
+  override def selectFrom(table: TableMetadata) =
+    TableDef.partitionKey(table).map(ColumnDef.toRef(_)).toIndexedSeq
 }
 
 case object PrimaryKeyColumns extends ColumnSelector {
   override def aliases: Map[String, String] = Map.empty.withDefault(x => x)
   override def selectFrom(table: TableDef) =
     table.primaryKey.map(_.ref)
+  override def selectFrom(table: TableMetadata) =
+    TableDef.primaryKey(table).map(ColumnDef.toRef(_))
 }
 
 case class SomeColumns(columns: ColumnRef*) extends ColumnSelector {
+
+  private def columnsToCheck():Seq[ColumnRef] = columns flatMap {
+    case f: FunctionCallRef => f.requiredColumns //Replaces function calls by their required columns
+    case RowCountRef => Seq.empty //Filters RowCountRef from the column list
+    case other => Seq(other)
+  }
+
+  /** Compute the columns that are not present in the structure. */
+  private def missingColumns(table:StructDef, columnsToCheck: Seq[ColumnRef]): Seq[ColumnRef] =
+    for (c <- columnsToCheck if !table.columnByName.contains(c.columnName)) yield c
+
+  private def missingColumns(table:TableMetadata, columnsToCheck: Seq[ColumnRef]): Seq[ColumnRef] =
+    for (c <- columnsToCheck if !TableDef.containsColumn(c.columnName)(table)) yield c
 
   override def aliases: Map[String, String] = columns.map {
     case ref => (ref.selectedAs, ref.cqlValueName)
   }.toMap
 
   override def selectFrom(table: TableDef): IndexedSeq[ColumnRef] = {
-    val missing = table.missingColumns {
-      columns flatMap {
-        case f: FunctionCallRef => f.requiredColumns //Replaces function calls by their required columns
-        case RowCountRef => Seq.empty //Filters RowCountRef from the column list
-        case other => Seq(other)
-      }
-    }
+    val missing = missingColumns(table, columnsToCheck)
     if (missing.nonEmpty) throw new NoSuchElementException(
       s"Columns not found in table ${table.name}: ${missing.mkString(", ")}")
+    columns.toIndexedSeq
+  }
 
+  override def selectFrom(table: TableMetadata): IndexedSeq[ColumnRef] = {
+    val missing = missingColumns(table, columnsToCheck)
+    if (missing.nonEmpty) throw new NoSuchElementException(
+      s"Columns not found in table ${TableDef.tableName(table)}: ${missing.mkString(", ")}")
     columns.toIndexedSeq
   }
 }

--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraScanBuilder.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraScanBuilder.scala
@@ -287,6 +287,7 @@ case class CassandraScan(session: SparkSession,
   with Batch
   with SupportsReportPartitioning {
 
+  implicit val tableMetadataArg = tableMetadata
 
   private lazy val inputPartitions = partitionGenerator.getInputPartitions()
   private val partitionGenerator = ScanHelper.getPartitionGenerator(

--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/UnsafeRowReaderFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/UnsafeRowReaderFactory.scala
@@ -1,6 +1,7 @@
 package com.datastax.spark.connector.datasource
 
 import com.datastax.oss.driver.api.core.cql.Row
+import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata
 import com.datastax.spark.connector.cql.TableDef
 import com.datastax.spark.connector.rdd.reader.{RowReader, RowReaderFactory}
 import com.datastax.spark.connector.{CassandraRow, CassandraRowMetadata, ColumnRef}
@@ -12,7 +13,7 @@ import org.apache.spark.sql.{Row => SparkRow}
 
 class UnsafeRowReaderFactory(schema: StructType) extends RowReaderFactory[UnsafeRow] {
 
-  override def rowReader(table: TableDef, selectedColumns: IndexedSeq[ColumnRef]):
+  override def rowReader(table: TableMetadata, selectedColumns: IndexedSeq[ColumnRef]):
   RowReader[UnsafeRow] = new UnsafeRowReader(schema)
 
   override def targetClass: Class[UnsafeRow] = classOf[UnsafeRow]

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
@@ -138,11 +138,11 @@ class CassandraTableScanRDD[R] private[connector](
                  |${currentPartitioner.keyMapping}""".stripMargin)
             Some(
               newPartitioner
-                .withTableDef(tableDef)
+                .withTableMetadata(tableDef)
                 .withKeyMapping(currentPartitioner.keyMapping))
           case _ =>
             logDebug(s"Assigning new Partitioner $newPartitioner")
-            Some(newPartitioner.withTableDef(tableDef))
+            Some(newPartitioner.withTableMetadata(tableDef))
         }
       }
       case Some(other: Partitioner) => throw new IllegalArgumentException(

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/ClusteringOrder.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/ClusteringOrder.scala
@@ -1,22 +1,32 @@
 package com.datastax.spark.connector.rdd
 
-import com.datastax.spark.connector.cql.TableDef
+import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata
+import com.datastax.spark.connector.cql.{ColumnDef, TableDef}
 
 sealed trait ClusteringOrder extends Serializable {
   private[connector] def toCql(tableDef: TableDef): String
+  private[connector] def toCql(table: TableMetadata): String
 }
 
+// TODO: Keeping both TableDef and TableMetadata impls here to minimize intrusiveness of Java driver metadata changes
 object ClusteringOrder {
+
   private[connector] def cqlClause(tableDef: TableDef, order: String) =
     tableDef.clusteringColumns.headOption.map(cc => s"""ORDER BY "${cc.columnName}" $order""")
       .getOrElse(throw new IllegalArgumentException("Order by can be specified only if there are some clustering columns"))
 
+  private[connector] def cqlClause(table: TableMetadata, order: String) =
+    TableDef.clusteringColumns(table).headOption.map(cc => s"""ORDER BY "${ColumnDef.columnName(cc)}" $order""")
+      .getOrElse(throw new IllegalArgumentException("Order by can be specified only if there are some clustering columns"))
+
   case object Ascending extends ClusteringOrder {
     override private[connector] def toCql(tableDef: TableDef): String = cqlClause(tableDef, "ASC")
+    override private[connector] def toCql(table: TableMetadata): String = cqlClause(table, "ASC")
   }
 
   case object Descending extends ClusteringOrder {
     override private[connector] def toCql(tableDef: TableDef): String = cqlClause(tableDef, "DESC")
+    override private[connector] def toCql(table: TableMetadata): String = cqlClause(table, "DESC")
   }
 
 }

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartitioner.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/CassandraPartitioner.scala
@@ -1,11 +1,10 @@
 package com.datastax.spark.connector.rdd.partitioner
 
+import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata
+
 import scala.reflect.ClassTag
 import scala.util.Try
-
 import org.apache.spark.Partitioner
-
-import com.datastax.spark.connector.util.Logging
 import com.datastax.spark.connector.cql.{CassandraConnector, TableDef}
 import com.datastax.spark.connector.rdd.partitioner.dht.{Token, TokenFactory, TokenRange}
 import com.datastax.spark.connector.writer.RowWriterFactory
@@ -44,7 +43,7 @@ object TokenRangeWithPartitionIndex {
   */
 private[connector] class CassandraPartitioner[Key : ClassTag, V, T <: Token[V]](
   private val connector: CassandraConnector,
-  private val tableDef: TableDef,
+  private val tableMetadata: TableMetadata,
   val partitions: Seq[CassandraPartition[V, T]],
   val keyMapping: ColumnSelector = PartitionKeyColumns)(
 implicit
@@ -52,39 +51,39 @@ implicit
   private val rwf: RowWriterFactory[Key],
   tokenFactory: TokenFactory[V, T]) extends Partitioner with Logging {
 
-  /** Changes the tableDef target of this partitioner. Can only be done within a keyspace
+  /** Changes the tableMetadata target of this partitioner. Can only be done within a keyspace
     * verification of key mapping will occur with the call to [[verify()]] */
-  def withTableDef(tableDef: TableDef): CassandraPartitioner[Key, V, T] = {
-    if (tableDef.keyspaceName != this.tableDef.keyspaceName) {
+  def withTableMetadata(newTableMetadata: TableMetadata): CassandraPartitioner[Key, V, T] = {
+    if (TableDef.keyspaceName(newTableMetadata) != TableDef.keyspaceName(this.tableMetadata)) {
       throw new IllegalArgumentException(
         s"""Cannot apply partitioner from keyspace
-           |${this.tableDef.keyspaceName} to table
-           |${tableDef.keyspaceName}.${tableDef.tableName} because the keyspaces do
+           |${TableDef.keyspaceName(this.tableMetadata)} to table
+           |${TableDef.keyspaceName(newTableMetadata)}.${TableDef.tableName(newTableMetadata)} because the keyspaces do
            |not match""".stripMargin)
     }
 
-    new CassandraPartitioner(connector, tableDef, partitions, keyMapping)
+    new CassandraPartitioner(connector, newTableMetadata, partitions, keyMapping)
   }
 
   /** Changes the current key mapping for this partitioner. Verification of the mapping
     * occurs on call to [[verify()]] */
   def withKeyMapping(keyMapping: ColumnSelector): CassandraPartitioner[Key, V, T] =
-    new CassandraPartitioner(connector, tableDef, partitions, keyMapping)
+    new CassandraPartitioner(connector, tableMetadata, partitions, keyMapping)
 
   private lazy val partitionKeyNames =
-    PartitionKeyColumns.selectFrom(tableDef).map(_.columnName).toSet
+    PartitionKeyColumns.selectFrom(tableMetadata).map(_.columnName).toSet
 
   private lazy val partitionKeyMapping = keyMapping
-    .selectFrom(tableDef)
+    .selectFrom(tableMetadata)
     .filter( colRef => partitionKeyNames.contains(colRef.columnName))
 
   private lazy val partitionKeyWriter = {
     logDebug(
       s"""Building Partitioner with mapping
          |${partitionKeyMapping.map(x => (x.columnName, x.selectedAs))}
-         |for table $tableDef""".stripMargin)
+         |for table $tableMetadata""".stripMargin)
     implicitly[RowWriterFactory[Key]]
-      .rowWriter(tableDef, partitionKeyMapping)
+      .rowWriter(tableMetadata, partitionKeyMapping)
   }
 
   /** Builds and makes sure we can make a rowWriter with the current TableDef and keyMapper */
@@ -101,7 +100,7 @@ implicit
     * make sure it is not serialized to executors and is made fresh on each executor */
   @transient
   private lazy val tokenGenerator =
-    new TokenGenerator(connector, tableDef, partitionKeyWriter)
+    new TokenGenerator(connector, tableMetadata, partitionKeyWriter)
 
   private type ITR = TokenRangeWithPartitionIndex[V, T]
 
@@ -134,14 +133,14 @@ implicit
   override def equals(that: Any): Boolean = that match {
     case that: CassandraPartitioner[Key, V, T] =>
       (this.indexedTokenRanges == that.indexedTokenRanges
-        && this.tableDef.keyspaceName == that.tableDef.keyspaceName
+        && TableDef.keyspaceName(this.tableMetadata) == TableDef.keyspaceName(that.tableMetadata)
         && this.connector == that.connector)
     case _ =>
       false
   }
 
   override def hashCode: Int = {
-    indexedTokenRanges.hashCode() + tableDef.keyspaceName.hashCode * 31
+    indexedTokenRanges.hashCode() + TableDef.keyspaceName(tableMetadata).hashCode * 31
   }
 
 }

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/TokenGenerator.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/partitioner/TokenGenerator.scala
@@ -3,14 +3,12 @@ package com.datastax.spark.connector.rdd.partitioner
 import java.nio.ByteBuffer
 
 import com.datastax.driver.core.MetadataHook
-import com.datastax.oss.driver.api.core.cql.BoundStatement
+import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata
 import com.datastax.oss.driver.api.core.metadata.token.Token
-import com.datastax.spark.connector.cql.{CassandraConnector, QueryUtils, TableDef}
+import com.datastax.spark.connector.cql.{CassandraConnector, QueryUtils}
 import com.datastax.spark.connector.util.Logging
 import com.datastax.spark.connector.util.PatitionKeyTools._
-import com.datastax.spark.connector.writer.{BoundStatementBuilder, NullKeyColumnException, RowWriter}
-
-import scala.collection.JavaConverters._
+import com.datastax.spark.connector.writer.{BoundStatementBuilder, RowWriter}
 
 /**
   * A utility class for determining the token of a given key. Uses a bound statement to determine
@@ -18,7 +16,7 @@ import scala.collection.JavaConverters._
   */
 private[connector] class TokenGenerator[T] (
   connector: CassandraConnector,
-  tableDef: TableDef,
+  table: TableMetadata,
   rowWriter: RowWriter[T]) extends Serializable with Logging {
 
   val protocolVersion = connector.withSessionDo { session =>
@@ -26,7 +24,7 @@ private[connector] class TokenGenerator[T] (
   }
 
   //Makes a PreparedStatement which we use only to generate routing keys on the client
-  val stmt = connector.withSessionDo { session => prepareDummyStatement(session, tableDef) }
+  val stmt = connector.withSessionDo { session => prepareDummyStatement(session, table) }
   val metadata = connector.withSessionDo(_.getMetadata)
 
   val boundStmtBuilder = new BoundStatementBuilder(

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/reader/RowReaderFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/reader/RowReaderFactory.scala
@@ -3,8 +3,8 @@ package com.datastax.spark.connector.rdd.reader
 import java.io.Serializable
 
 import com.datastax.oss.driver.api.core.cql.Row
+import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata
 import com.datastax.spark.connector.{CassandraRow, CassandraRowMetadata, ColumnRef}
-import com.datastax.spark.connector.cql.TableDef
 import com.datastax.spark.connector.mapper.ColumnMapper
 import com.datastax.spark.connector.types.TypeConverter
 import com.datastax.spark.connector.util.MagicalTypeTricks.{DoesntHaveImplicit, IsNotSubclassOf}
@@ -16,14 +16,14 @@ import scala.reflect.runtime.universe._
 /** Creates [[RowReader]] objects prepared for reading rows from the given Cassandra table. */
 @implicitNotFound("No RowReaderFactory can be found for this type")
 trait RowReaderFactory[T] {
-  def rowReader(table: TableDef, selectedColumns: IndexedSeq[ColumnRef]): RowReader[T]
+  def rowReader(table: TableMetadata, selectedColumns: IndexedSeq[ColumnRef]): RowReader[T]
   def targetClass: Class[T]
 }
 
 /** Helper for implementing `RowReader` objects that can be used as `RowReaderFactory` objects. */
 trait ThisRowReaderAsFactory[T] extends RowReaderFactory[T] {
   this: RowReader[T] =>
-  def rowReader(table: TableDef, selectedColumns: IndexedSeq[ColumnRef]): RowReader[T] = this
+  def rowReader(table: TableMetadata, selectedColumns: IndexedSeq[ColumnRef]): RowReader[T] = this
 }
 
 trait LowPriorityRowReaderFactoryImplicits {

--- a/connector/src/main/scala/com/datastax/spark/connector/util/PatitionKeyTools.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/util/PatitionKeyTools.scala
@@ -4,6 +4,7 @@ import java.io.IOException
 
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.cql.PreparedStatement
+import com.datastax.oss.driver.api.core.metadata.schema.{ColumnMetadata, TableMetadata}
 import com.datastax.spark.connector.cql.{ColumnDef, TableDef}
 import com.datastax.spark.connector.util.Quote._
 
@@ -15,22 +16,22 @@ object PatitionKeyTools {
     * partition tokens from tables. We prepare a statement of the form SELECT * FROM keyspace.table
     * where x= .... This statement is never executed.
     */
-  private[connector] def querySelectUsingOnlyPartitionKeys(tableDef: TableDef): String = {
-    val partitionKeys = tableDef.partitionKey
-    def quotedColumnNames(columns: Seq[ColumnDef]) = partitionKeys.map(_.columnName).map(quote)
+  private[connector] def querySelectUsingOnlyPartitionKeys(table: TableMetadata): String = {
+    val partitionKeys = TableDef.partitionKey(table)
+    def quotedColumnNames(columns: Seq[ColumnMetadata]) = partitionKeys.map(ColumnDef.columnName(_)).map(quote)
     val whereClause = quotedColumnNames(partitionKeys).map(c => s"$c = :$c").mkString(" AND ")
-    s"SELECT * FROM ${quote(tableDef.keyspaceName)}.${quote(tableDef.tableName)} WHERE $whereClause"
+    s"SELECT * FROM ${quote(TableDef.keyspaceName(table))}.${quote(TableDef.tableName(table))} WHERE $whereClause"
   }
 
-  private[connector] def prepareDummyStatement(session: CqlSession, tableDef: TableDef): PreparedStatement = {
+  private[connector] def prepareDummyStatement(session: CqlSession, table: TableMetadata): PreparedStatement = {
     try {
-      session.prepare(querySelectUsingOnlyPartitionKeys(tableDef))
+      session.prepare(querySelectUsingOnlyPartitionKeys(table))
     }
     catch {
       case t: Throwable =>
         throw new IOException(
           s"""Failed to prepare statement
-             | ${querySelectUsingOnlyPartitionKeys(tableDef)}: """.stripMargin + t.getMessage, t)
+             | ${querySelectUsingOnlyPartitionKeys(table)}: """.stripMargin + t.getMessage, t)
     }
   }
 

--- a/connector/src/main/scala/com/datastax/spark/connector/util/package.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/util/package.scala
@@ -2,6 +2,7 @@ package com.datastax.spark.connector
 
 import com.datastax.dse.driver.api.core.auth.ProxyAuthentication
 import com.datastax.oss.driver.api.core.cql.Statement
+import com.datastax.oss.driver.api.core.metadata.schema.{KeyspaceMetadata, TableMetadata}
 import com.datastax.spark.connector.cql.{CassandraConnector, Schema, TableDef}
 
 /** Useful stuff that didn't fit elsewhere. */
@@ -16,17 +17,16 @@ package object util {
     }
   }
 
-  def schemaFromCassandra(
+  def keyspaceFromCassandra(
       connector: CassandraConnector,
-      keyspaceName: Option[String] = None,
-      tableName: Option[String] = None): Schema = {
-    connector.withSessionDo(Schema.fromCassandra(_, keyspaceName, tableName))
+      keyspaceName: String): KeyspaceMetadata = {
+    connector.withSessionDo(Schema.keyspaceFromCassandra(_, keyspaceName))
   }
 
   def tableFromCassandra(
       connector: CassandraConnector,
       keyspaceName: String,
-      tableName: String): TableDef = {
+      tableName: String): TableMetadata = {
     connector.withSessionDo(Schema.tableFromCassandra(_, keyspaceName, tableName))
   }
 

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/RowWriterFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/RowWriterFactory.scala
@@ -1,5 +1,7 @@
 package com.datastax.spark.connector.writer
 
+import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata
+
 import scala.reflect.runtime.universe._
 import com.datastax.spark.connector.ColumnRef
 import com.datastax.spark.connector.cql.TableDef
@@ -15,7 +17,7 @@ trait RowWriterFactory[T] {
     * @param table target table the user wants to write into
     * @param selectedColumns columns selected by the user; the user might wish to write only a
     *                        subset of columns */
-  def rowWriter(table: TableDef, selectedColumns: IndexedSeq[ColumnRef]): RowWriter[T]
+  def rowWriter(table: TableMetadata, selectedColumns: IndexedSeq[ColumnRef]): RowWriter[T]
 }
 
 /** Provides a low-priority implicit `RowWriterFactory` able to write objects of any class for which

--- a/connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraPredicateRules.scala
+++ b/connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraPredicateRules.scala
@@ -1,6 +1,6 @@
 package org.apache.spark.sql.cassandra
 
-import com.datastax.spark.connector.cql.TableDef
+import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.SparkConf
 
@@ -14,5 +14,5 @@ case class AnalyzedPredicates(
 }
 
 trait CassandraPredicateRules{
-  def apply(predicates: AnalyzedPredicates, tableDef: TableDef, conf: SparkConf): AnalyzedPredicates
+  def apply(predicates: AnalyzedPredicates, table: TableMetadata, conf: SparkConf): AnalyzedPredicates
 }

--- a/connector/src/main/scala/org/apache/spark/sql/cassandra/DsePredicateRules.scala
+++ b/connector/src/main/scala/org/apache/spark/sql/cassandra/DsePredicateRules.scala
@@ -5,7 +5,7 @@
  */
 package org.apache.spark.sql.cassandra
 
-import com.datastax.spark.connector.cql.{ColumnDef, TableDef}
+import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.sources.{EqualTo, Filter, In, IsNotNull}
 
@@ -17,10 +17,10 @@ object DsePredicateRules extends CassandraPredicateRules {
 
   override def apply(
     predicates: AnalyzedPredicates,
-    tableDef: TableDef,
+    tableMetadata: TableMetadata,
     sparkConf: SparkConf): AnalyzedPredicates = {
-    
-    pushOnlySolrQuery(predicates, tableDef)
+
+    pushOnlySolrQuery(predicates, tableMetadata)
   }
 
   /**
@@ -33,7 +33,7 @@ object DsePredicateRules extends CassandraPredicateRules {
     */
   def pushOnlySolrQuery(
     predicates: AnalyzedPredicates,
-    tableDef: TableDef): AnalyzedPredicates = {
+    table: TableMetadata): AnalyzedPredicates = {
 
     val allPredicates = predicates.handledByCassandra ++ predicates.handledBySpark
 

--- a/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinExec.scala
+++ b/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinExec.scala
@@ -36,13 +36,13 @@ case class CassandraDirectJoinExec(
 
   val keySource = child
   val connector = cassandraScan.connector
-  val keyspace = cassandraScan.tableDef.keyspaceName
-  val table = cassandraScan.tableDef.tableName
+  val keyspace = cassandraScan.tableMetadata.keyspaceName
+  val table = cassandraScan.tableMetadata.tableName
   val cqlQueryParts = cassandraScan.cqlQueryParts
   val whereClause = cqlQueryParts.whereClause
   val readConf = cassandraScan.readConf
   val selectedColumns = cqlQueryParts.selectedColumnRefs
-  val primaryKeys = cassandraScan.tableDef.primaryKey.map(_.columnName)
+  val primaryKeys = cassandraScan.tableMetadata.primaryKey.map(_.columnName)
   val cassandraSchema = cassandraPlan.schema
 
   val exprIdToCassandra = aliasMap.map(_.swap)


### PR DESCRIPTION
# Description

## How did the Spark Cassandra Connector Work or Not Work Before this Patch

Connector was using internal serializable reps for keyspace/table metadata because corresponding Java driver classes weren't serializable.  This changed in v4.6.0.

## General Design of the patch

Case classes TableDef, ColumnDef currently serve two distinct roles:

1. Metadata retrieval/access
2. As a definition/descriptor for future table creation

Majority of operations leverage the first role above.  This PR begins the process of converting these usages to the types provided by the Java driver now that they're serializable.  The existing TableDef, ColumnDef etc. case classes are preserved as-is to support future table creation.

This PR reflects only the changes necessary to support conversion of one fairly high-level class (CassandraScanBuilder).  It certainly isn't complete and the changes to various method signatures broke other things in the code which will also need to be fixed.  The intent of this PR is to demonstrate the basic process in order to get agreement on this approach going forward.

Fixes: [SPARKC-577](https://datastax-oss.atlassian.net/projects/SPARKC-577)

# How Has This Been Tested?

Still a WIP, hasn't been tested meaningfully yet

# Checklist:

- [X] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/projects/SPARKC)
- [ ] I have performed a self-review of my own code
- [ ] Locally all tests pass (make sure tests fail without your patch)
