### PR TITLE
SPARKC-615 temp workaround for inconsistent C* versioning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,8 +26,7 @@ ThisBuild / version := Publishing.Version
 
 Global / resolvers ++= Seq(
   DefaultMavenRepository,
-  Resolver.sonatypeRepo("public"),
-  "Staging for SparkcRc3" at "https://repository.apache.org/content/repositories/orgapachespark-1350/"
+  Resolver.sonatypeRepo("public")
 )
 
 lazy val IntegrationTest = config("it") extend Test

--- a/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
@@ -10,7 +10,7 @@ import com.datastax.spark.connector.types.TypeAdapters.{ValueByNameAdapter, Valu
 import com.datastax.spark.connector.types.{NullableTypeConverter, TypeConverter}
 import com.datastax.spark.connector.util.ConfigCheck.ConnectorConfigurationException
 import com.datastax.spark.connector.util.DriverUtil.toAddress
-import com.datastax.spark.connector.util.{Logging, SerialShutdownHooks}
+import com.datastax.spark.connector.util.{DriverUtil, Logging, SerialShutdownHooks}
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.{SparkConf, SparkContext, SparkFiles}
 
@@ -71,7 +71,7 @@ class CassandraConnector(val conf: CassandraConnectorConf)
         .values
         .asScala
         .filter(_.getDistance == NodeDistance.LOCAL)
-        .flatMap(node => Option(node.getBroadcastAddress.orElse(null)))
+        .flatMap(DriverUtil.toAddress)
         .toSet
     }
 

--- a/test-support/src/main/scala/com/datastax/spark/connector/ccm/CcmConfig.scala
+++ b/test-support/src/main/scala/com/datastax/spark/connector/ccm/CcmConfig.scala
@@ -163,9 +163,9 @@ object CcmConfig {
   /** Stores the given resource in `/tmp/ccm_resources` directory. Stored file name is prefixed with the given prefix */
   def storeResource(prefix: String, resource: String): String = {
     val resourceName = Paths.get(resource).getFileName.toString
-    var file = Paths.get("/tmp/ccm_resources").resolve(s"${prefix}_${resourceName}").toFile
+    val file = Paths.get("/tmp/ccm_resources").resolve(s"${prefix}_${resourceName}").toFile
     file.getParentFile.mkdirs()
 
-    store(resource, file).getAbsolutePath.toString
+    store(resource, file).getAbsolutePath
   }
 }


### PR DESCRIPTION
remove this workaround once C* 4.0.0 is released