### PR TITLE
SPARKC-598 return proper name of the catalog

### DIFF
--- a/connector/src/it/scala/com/datastax/spark/connector/datasource/CassandraCatalogNamespaceSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/datasource/CassandraCatalogNamespaceSpec.scala
@@ -7,7 +7,7 @@ import scala.collection.JavaConverters._
 class CassandraCatalogNamespaceSpec extends CassandraCatalogSpecBase {
 
   "A Cassandra Catalog Namespace Support" should "initialize successfully" in {
-    spark.sessionState.catalogManager.currentCatalog.name() should be(catalogName)
+    spark.sessionState.catalogManager.currentCatalog.name() should be(defaultCatalog)
   }
 
   it should "list available keyspaces" in {
@@ -21,13 +21,13 @@ class CassandraCatalogNamespaceSpec extends CassandraCatalogSpecBase {
     spark.sql(s"CREATE DATABASE IF NOT EXISTS $defaultKs WITH DBPROPERTIES (class='SimpleStrategy',replication_factor='5')")
     waitForKeyspaceToExist(defaultKs)
     //Using Catalog and DefaultKS triggers listNamespaces(namespace) pathway
-    val result = spark.sql(s"SHOW NAMESPACES FROM $catalogName.$defaultKs").collect
+    val result = spark.sql(s"SHOW NAMESPACES FROM $defaultCatalog.$defaultKs").collect
     result shouldBe empty
   }
 
   it should "give no keyspace found when looking up a keyspace which doesn't exist" in {
     intercept[NoSuchNamespaceException]{
-      spark.sql(s"SHOW NAMESPACES FROM $catalogName.fakenotreal").collect
+      spark.sql(s"SHOW NAMESPACES FROM $defaultCatalog.fakenotreal").collect
     }
   }
 

--- a/connector/src/it/scala/com/datastax/spark/connector/datasource/CassandraCatalogNamespaceSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/datasource/CassandraCatalogNamespaceSpec.scala
@@ -7,7 +7,7 @@ import scala.collection.JavaConverters._
 class CassandraCatalogNamespaceSpec extends CassandraCatalogSpecBase {
 
   "A Cassandra Catalog Namespace Support" should "initialize successfully" in {
-    spark.sessionState.catalogManager.currentCatalog.name() should include("Catalog cassandra")
+    spark.sessionState.catalogManager.currentCatalog.name() should be(catalogName)
   }
 
   it should "list available keyspaces" in {
@@ -111,5 +111,11 @@ class CassandraCatalogNamespaceSpec extends CassandraCatalogSpecBase {
     waitForKeyspaceToExist(defaultKs)
     spark.sql(s"DROP DATABASE $defaultKs")
     waitForKeyspaceToExist(defaultKs, false)
+  }
+
+  it should "allow to switch a catalog" in {
+    val otherCatalog = "itsatrap"
+    spark.conf.set(s"spark.sql.catalog.$otherCatalog", classOf[CassandraCatalog].getCanonicalName)
+    spark.sql(s"USE $otherCatalog")
   }
 }

--- a/connector/src/it/scala/com/datastax/spark/connector/datasource/CassandraCatalogSpecBase.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/datasource/CassandraCatalogSpecBase.scala
@@ -19,6 +19,7 @@ class CassandraCatalogSpecBase
   override def conn: CassandraConnector = CassandraConnector(sparkConf)
 
   val defaultKs = "catalogtestks"
+  val defaultCatalog = "cassandra"
 
   val EmptyInputPartition = CassandraPartition(0, Array.empty, Iterable.empty, 0)
 
@@ -48,11 +49,9 @@ class CassandraCatalogSpecBase
 
   implicit val patienceConfig = PatienceConfig(scaled(5 seconds), scaled(200 millis))
 
-  val catalogName = "cassandra"
-
   override def beforeClass: Unit = {
     super.beforeClass
-    spark.conf.set(s"spark.sql.catalog.$catalogName", classOf[CassandraCatalog].getCanonicalName)
+    spark.conf.set(s"spark.sql.catalog.$defaultCatalog", classOf[CassandraCatalog].getCanonicalName)
     spark.conf.set(SQLConf.DEFAULT_CATALOG.key, "cassandra")
   }
 

--- a/connector/src/it/scala/com/datastax/spark/connector/datasource/CassandraCatalogTableReadSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/datasource/CassandraCatalogTableReadSpec.scala
@@ -19,7 +19,7 @@ class CassandraCatalogTableReadSpec extends CassandraCatalogSpecBase {
   }
 
   "A Cassandra Catalog Table Read Support" should "initialize successfully" in {
-    spark.sessionState.catalogManager.currentCatalog.name() should include("Catalog cassandra")
+    spark.sessionState.catalogManager.currentCatalog.name() should be(defaultCatalog)
   }
 
   it should "read from an empty table" in {

--- a/connector/src/it/scala/com/datastax/spark/connector/datasource/CassandraCatalogTableSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/datasource/CassandraCatalogTableSpec.scala
@@ -9,7 +9,7 @@ import scala.collection.JavaConverters._
 class CassandraCatalogTableSpec extends CassandraCatalogSpecBase {
 
   "A Cassandra Catalog Table Support" should "initialize successfully" in {
-    spark.sessionState.catalogManager.currentCatalog.name() should include("Catalog cassandra")
+    spark.sessionState.catalogManager.currentCatalog.name() should be(defaultCatalog)
   }
 
   val testTable = "testTable"

--- a/connector/src/it/scala/com/datastax/spark/connector/datasource/CassandraCatalogTableWriteSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/datasource/CassandraCatalogTableWriteSpec.scala
@@ -18,7 +18,7 @@ class CassandraCatalogTableWriteSpec extends CassandraCatalogSpecBase {
   }
 
   "A Cassandra Catalog Table Write Support" should "initialize successfully" in {
-    spark.sessionState.catalogManager.currentCatalog.name() should include("Catalog cassandra")
+    spark.sessionState.catalogManager.currentCatalog.name() should be(defaultCatalog)
   }
 
   it should "support CTAS" in {

--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraCatalog.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraCatalog.scala
@@ -87,7 +87,7 @@ class CassandraCatalog extends CatalogPlugin
     nameIdentifier = connector.conf.contactInfo.endPointStr()
   }
 
-  override def name(): String = s"Catalog $catalogName For Cassandra Cluster At $nameIdentifier " //TODO add identifier here
+  override def name(): String = catalogName
 
   override def listNamespaces(): Array[Array[String]] = {
     getMetadata(connector)
@@ -440,7 +440,7 @@ object CassandraCatalog {
     * is used to quickly bail out if the namespace is not compatible with Cassandra
     */
   def checkNamespace(namespace: Array[String]): Unit = {
-    if (namespace.length != 1) throw new NoSuchNamespaceException(s"$OnlyOneNamespace : $namespace")
+    if (namespace.length != 1) throw new NoSuchNamespaceException(s"""$OnlyOneNamespace: ${namespace.mkString(".")}""")
   }
 
   //Currently these exceptions are not always propagated to the user so Suggestions will not appear for all executions


### PR DESCRIPTION
The CatalogPlugin requires the actual name in name() as it is
used in matching with spark.sql.catalog.<name> setting.
