### PR TITLE
SPARKC-614 add WithSessionBenchmark

### DIFF
--- a/performance/src/test/scala/com/datastax/spark/connector/cql/WithSessionBenchmark.scala
+++ b/performance/src/test/scala/com/datastax/spark/connector/cql/WithSessionBenchmark.scala
@@ -1,0 +1,29 @@
+package com.datastax.spark.connector.cql
+
+import java.util.concurrent.TimeUnit
+
+import com.datastax.oss.driver.api.core.cql.ResultSet
+import com.datastax.spark.connector.SparkCassandraITSpecBase
+import com.datastax.spark.connector.cluster.DefaultCluster
+import org.openjdk.jmh.annotations._
+
+import scala.util.Random
+
+@State(Scope.Thread)
+@Measurement(time = 30, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+class WithSessionBenchmark extends SparkCassandraITSpecBase with DefaultCluster {
+
+  override lazy val conn: CassandraConnector = CassandraConnector(
+    defaultConf.set(CassandraConnectorConf.KeepAliveMillisParam.name, "0"))
+
+  @Benchmark
+  def createKeyspace: ResultSet = {
+    val keyspace = Random.alphanumeric.take(10).mkString("")
+    conn.withSessionDo { s =>
+      s.execute(s"""CREATE KEYSPACE IF NOT EXISTS "$keyspace" WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };""")
+    }
+  }
+
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.0")


### PR DESCRIPTION
This benchmark serves as a check for a community reported
perf degradation in CassandraConnector.withSession and/or
CREATE KEYSPACE.
Although this is not really a microbenchmark it should give
us a way to verify if there is a perf degradation between
2.5.x and 3.0.x.