### PR TITLE
SPARKC-606 honor ContinuousPaging properties

### DIFF
--- a/connector/src/main/scala/com/datastax/bdp/spark/ContinuousPagingScanner.scala
+++ b/connector/src/main/scala/com/datastax/bdp/spark/ContinuousPagingScanner.scala
@@ -7,8 +7,8 @@ package com.datastax.bdp.spark
 
 import java.io.IOException
 
-import scala.collection.JavaConverters._
-import com.datastax.dse.driver.api.core.cql.continuous.{ContinuousResultSet, ContinuousSession}
+import com.datastax.dse.driver.api.core.config.DseDriverOption
+import com.datastax.dse.driver.api.core.cql.continuous.ContinuousResultSet
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.`type`.codec.TypeCodec
 import com.datastax.oss.driver.api.core.cql.{BoundStatement, Statement}
@@ -19,62 +19,52 @@ import com.datastax.spark.connector.rdd.ReadConf
 import com.datastax.spark.connector.util.DriverUtil.toName
 import com.datastax.spark.connector.util._
 
+import scala.collection.JavaConverters._
+
 case class ContinuousPagingScanner(
   readConf: ReadConf,
   connConf: CassandraConnectorConf,
-  columnNames: IndexedSeq[String]) extends Scanner with Logging {
+  columnNames: IndexedSeq[String],
+  cqlSession: CqlSession) extends Scanner with Logging {
 
   val TARGET_PAGE_SIZE_IN_BYTES: Int = 5000 * 50 // 5000 rows * 50 bytes per row
   val MIN_PAGES_PER_SECOND = 1000
 
-  //TODO This must be moved to session initilization? We can no longer pass options at execution time without deriving a new profile
-  // I think the right thing to do, to support old configurations as well as new is to create a new profile based on options as
-  // Set using derivied profiles, but this probably can't happen here
-  /**
-  private val cpOptions =  readConf.throughputMiBPS match {
+  private lazy val cpProfile = readConf.throughputMiBPS match {
     case Some(throughput) =>
-      val bytesPerSecond = (throughput * 1024 * 1024).toInt
+      val bytesPerSecond = (throughput * 1024 * 1024).toLong
       val fallBackPagesPerSecond = math.max(MIN_PAGES_PER_SECOND, bytesPerSecond / TARGET_PAGE_SIZE_IN_BYTES)
-      val pagesPerSecond: Int = readConf.readsPerSec.getOrElse(fallBackPagesPerSecond)
+      val pagesPerSecond = readConf.readsPerSec.map(_.toLong).getOrElse(fallBackPagesPerSecond)
       if (readConf.readsPerSec.isEmpty) {
         logInfo(s"Using a pages per second of $pagesPerSecond since " +
           s"${ReadConf.ReadsPerSecParam.name} is not set")
       }
-      val bytesPerPage = (bytesPerSecond / pagesPerSecond ).toInt
+      val bytesPerPage = bytesPerSecond / pagesPerSecond
 
-      if (bytesPerPage <= 0) {
+      if (bytesPerPage <= 0 || bytesPerPage > Int.MaxValue) {
         throw new IllegalArgumentException(
           s"""Read Throttling set to $throughput MBPS, but with the current
              | ${ReadConf.ReadsPerSecParam.name} value of $pagesPerSecond that equates to
-             | $bytesPerPage bytes per page. This number must be positive and non-zero.
+             | $bytesPerPage bytes per page.
+             | This number must be positive, non-zero and smaller than ${Int.MaxValue}.
            """.stripMargin)
       }
 
       logDebug(s"Read Throttling set to $throughput mbps. Pages of $bytesPerPage with ${readConf.readsPerSec} max" +
         s"pages per second. ${ReadConf.FetchSizeInRowsParam.name} will be ignored.")
-      ContinuousPagingOptions
-        .builder()
-        .withPageSize(bytesPerPage, ContinuousPagingOptions.PageUnit.BYTES)
-        .withMaxPagesPerSecond(pagesPerSecond)
-        .build()
+      cqlSession.getContext.getConfig.getDefaultProfile
+        .withBoolean(DseDriverOption.CONTINUOUS_PAGING_PAGE_SIZE_BYTES, true)
+        .withInt(DseDriverOption.CONTINUOUS_PAGING_PAGE_SIZE, bytesPerPage.toInt)
+        .withInt(DseDriverOption.CONTINUOUS_PAGING_MAX_PAGES_PER_SECOND, pagesPerSecond.toInt)
 
     case None =>
-      ContinuousPagingOptions
-        .builder()
-        .withPageSize(readConf.fetchSizeInRows, ContinuousPagingOptions.PageUnit.ROWS)
-        .withMaxPagesPerSecond(readConf.readsPerSec.getOrElse(Integer.MAX_VALUE))
-        .build()
+      cqlSession.getContext.getConfig.getDefaultProfile
+        .withBoolean(DseDriverOption.CONTINUOUS_PAGING_PAGE_SIZE_BYTES, false)
+        .withInt(DseDriverOption.CONTINUOUS_PAGING_PAGE_SIZE, readConf.fetchSizeInRows)
+        .withInt(DseDriverOption.CONTINUOUS_PAGING_MAX_PAGES_PER_SECOND, readConf.readsPerSec.getOrElse(0))
   }
-    **/
 
-  /**
-    * Attempts to get or create a session for this execution thread.
-    */
-  private val cpSession = new CassandraConnector(connConf)
-    .openSession()
-    .asInstanceOf[CqlSession with ContinuousSession]
-
-  private val codecRegistry = cpSession.getContext.getCodecRegistry
+  private val codecRegistry = cqlSession.getContext.getCodecRegistry
 
   private def asBoundStatement(statement: Statement[_]): Option[BoundStatement] = {
     statement match {
@@ -91,22 +81,22 @@ case class ContinuousPagingScanner(
     * Calls SessionProxy Close which issues a deferred close request on the session if no
     * references are requested to it in the next keep_alive ms
     */
-  override def close(): Unit = cpSession.close
+  override def close(): Unit = cqlSession.close()
 
-  override def getSession(): CqlSession = cpSession
+  override def getSession(): CqlSession = cqlSession
 
   override def scan[StatementT <: Statement[StatementT]](statement: StatementT): ScanResult = {
-     val authStatement = maybeExecutingAs(statement, readConf.executeAs)
+    val authStatement = maybeExecutingAs(statement, readConf.executeAs)
 
     if (isSolr(authStatement)) {
       logDebug("Continuous Paging doesn't work with Search, Falling back to default paging")
-      val regularResult = cpSession.execute(authStatement)
+      val regularResult = cqlSession.execute(authStatement)
       val regularIterator = regularResult.iterator().asScala
       ScanResult(regularIterator, CassandraRowMetadata.fromResultSet(columnNames, regularResult, codecRegistry))
 
     } else {
       try {
-        val cpResult = cpSession.executeContinuously(authStatement)
+        val cpResult = cqlSession.executeContinuously(authStatement.setExecutionProfile(cpProfile))
         val cpIterator = cpResult.iterator().asScala
         ScanResult(cpIterator, getMetaData(cpResult))
       } catch {
@@ -120,7 +110,7 @@ case class ContinuousPagingScanner(
     }
   }
 
-  private def getMetaData(result: ContinuousResultSet) = {
+  private def getMetaData(result: ContinuousResultSet): CassandraRowMetadata = {
     import scala.collection.JavaConverters._
     val columnDefs = result.getColumnDefinitions.asScala
     val rsColumnNames = columnDefs.map(c => toName(c.getName))
@@ -129,5 +119,18 @@ case class ContinuousPagingScanner(
       .asInstanceOf[Seq[TypeCodec[AnyRef]]]
 
     CassandraRowMetadata(columnNames, Some(rsColumnNames.toIndexedSeq), codecs.toIndexedSeq)
+  }
+}
+
+object ContinuousPagingScanner {
+  def apply(
+      readConf: ReadConf,
+      connConf: CassandraConnectorConf,
+      columnNames: IndexedSeq[String]): ContinuousPagingScanner = {
+    /**
+      * Attempts to get or create a session for this execution thread.
+      */
+    val cqlSession = new CassandraConnector(connConf).openSession()
+    new ContinuousPagingScanner(readConf, connConf, columnNames, cqlSession)
   }
 }

--- a/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
@@ -187,7 +187,7 @@ object DefaultConnectionFactory extends CassandraConnectionFactory {
 
     if (isContinuousPagingEnabled) {
       logger.debug("Using ContinousPagingScanner")
-      new ContinuousPagingScanner(readConf, connConf, columnNames)
+      ContinuousPagingScanner(readConf, connConf, columnNames)
     } else {
       logger.debug("Not Connected to DSE 5.1 or Greater Falling back to Non-Continuous Paging")
       new DefaultScanner(readConf, connConf, columnNames)

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraTableScanRDD.scala
@@ -331,14 +331,12 @@ class CassandraTableScanRDD[R] private[connector](
     range: CqlTokenRange[_, _],
     inputMetricsUpdater: InputMetricsUpdater): Iterator[R] = {
 
-    val session = scanner.getSession()
-
     val (cql, values) = tokenRangeToCqlQuery(range)
     logDebug(
       s"Fetching data for range ${range.cql(partitionKeyStr)} " +
         s"with $cql " +
         s"with params ${values.mkString("[", ",", "]")}")
-    val stmt = createStatement(session, cql, values: _*)
+    val stmt = createStatement(scanner.getSession(), cql, values: _*)
       .setRoutingToken(range.range.startNativeToken())
 
     try {


### PR DESCRIPTION
Reintroduce ContinuousPaging throttle configuration properties.
Before this change the properties were silently ignored, this was a side
effect introduced by the Huge Java Driver Refactoring.
