### PR TITLE
SPARKC-619 restore PrefetchingResultSetIterator

### DIFF
--- a/connector/src/it/scala/com/datastax/spark/connector/SparkCassandraITFlatSpecBase.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/SparkCassandraITFlatSpecBase.scala
@@ -183,6 +183,10 @@ trait SparkCassandraITSpecBase
 
   implicit val ec = SparkCassandraITSpecBase.ec
 
+  def await[T](unit: Future[T]): T = {
+    Await.result(unit, Duration.Inf)
+  }
+
   def awaitAll[T](units: Future[T]*): Seq[T] = {
     Await.result(Future.sequence(units), Duration.Inf)
   }

--- a/connector/src/it/scala/com/datastax/spark/connector/rdd/reader/PrefetchingResultSetIteratorSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/rdd/reader/PrefetchingResultSetIteratorSpec.scala
@@ -1,0 +1,67 @@
+package com.datastax.spark.connector.rdd.reader
+
+import com.codahale.metrics.Timer
+import com.datastax.oss.driver.api.core.cql.SimpleStatement.newInstance
+import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
+import com.datastax.spark.connector.cluster.DefaultCluster
+import com.datastax.spark.connector.cql.CassandraConnector
+import org.scalatest.concurrent.Eventually.{eventually, timeout}
+import org.scalatest.time.{Seconds, Span}
+
+class PrefetchingResultSetIteratorSpec extends SparkCassandraITFlatSpecBase with DefaultCluster {
+
+  private val table = "prefetching"
+  private val emptyTable = "empty_prefetching"
+  override lazy val conn = CassandraConnector(sparkConf)
+
+  override def beforeClass {
+    conn.withSessionDo { session =>
+      session.execute(
+        s"CREATE KEYSPACE IF NOT EXISTS $ks WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }")
+
+      session.execute(
+        s"CREATE TABLE IF NOT EXISTS $ks.$table (key INT, x INT, PRIMARY KEY (key))")
+
+      session.execute(
+        s"CREATE TABLE IF NOT EXISTS $ks.$emptyTable (key INT, x INT, PRIMARY KEY (key))")
+
+      awaitAll(
+        for (i <- 1 to 999) yield {
+          executor.executeAsync(newInstance(s"INSERT INTO $ks.$table (key, x) values ($i, $i)"))
+        }
+      )
+    }
+  }
+
+  "PrefetchingResultSetIterator" should "return all rows regardless of the  page sizes" in {
+    val pageSizes = Seq(1, 2, 5, 111, 998, 999, 1000, 1001)
+    for (pageSize <- pageSizes) {
+      withClue(s"Prefetching iterator failed for the page size: $pageSize") {
+        val statement = newInstance(s"select * from $ks.$table").setPageSize(pageSize)
+        val result = executor.executeAsync(statement).map(new PrefetchingResultSetIterator(_))
+        await(result).toList should have size 999
+      }
+    }
+  }
+
+  it should "be empty for an empty table" in {
+    val statement = newInstance(s"select * from $ks.$emptyTable")
+    val result = executor.executeAsync(statement).map(new PrefetchingResultSetIterator(_))
+
+    await(result).hasNext should be(false)
+    intercept[NoSuchElementException] {
+      await(result).next()
+    }
+  }
+
+  it should "update the provided timer" in {
+    val statement = newInstance(s"select * from $ks.$table").setPageSize(200)
+    val timer = new Timer()
+    val result = executor.executeAsync(statement).map(rs => new PrefetchingResultSetIterator(rs, Option(timer)))
+    await(result).toList
+
+    eventually(timeout(Span(2, Seconds))) {
+      timer.getCount should be(4)
+    }
+  }
+}

--- a/connector/src/main/scala/com/datastax/bdp/util/ScalaJavaUtil.scala
+++ b/connector/src/main/scala/com/datastax/bdp/util/ScalaJavaUtil.scala
@@ -11,7 +11,7 @@ import java.util.concurrent.{Callable, CompletionStage}
 import java.util.function
 import java.util.function.{BiConsumer, Consumer, Predicate, Supplier}
 
-import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future, Promise}
 import scala.concurrent.duration.{Duration => ScalaDuration}
 import scala.language.implicitConversions
 
@@ -48,7 +48,7 @@ object ScalaJavaUtil {
   def asScalaFunction[T, R](f: java.util.function.Function[T, R]): T => R = x => f(x)
 
   def asScalaFuture[T](completionStage: CompletionStage[T])
-                      (implicit context: ExecutionContext): Future[T] = {
+                      (implicit context: ExecutionContextExecutor): Future[T] = {
     val promise = Promise[T]()
     completionStage.whenCompleteAsync(new BiConsumer[T, java.lang.Throwable] {
       override def accept(t: T, throwable: Throwable): Unit = {
@@ -58,7 +58,7 @@ object ScalaJavaUtil {
           promise.failure(throwable)
 
       }
-    })
+    }, context)
     promise.future
   }
 }

--- a/connector/src/main/scala/com/datastax/spark/connector/cql/Scanner.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/cql/Scanner.scala
@@ -1,5 +1,6 @@
 package com.datastax.spark.connector.cql
 
+import com.datastax.bdp.util.ScalaJavaUtil.asScalaFuture
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.cql.{Row, Statement}
 import com.datastax.spark.connector.CassandraRowMetadata
@@ -7,6 +8,9 @@ import com.datastax.spark.connector.rdd.ReadConf
 import com.datastax.spark.connector.rdd.reader.PrefetchingResultSetIterator
 import com.datastax.spark.connector.util.maybeExecutingAs
 import com.datastax.spark.connector.writer.RateLimiter
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await}
 
 /**
   * Object which will be used in Table Scanning Operations.
@@ -35,21 +39,25 @@ class DefaultScanner (
   }
 
   override def scan[StatementT <: Statement[StatementT]](statement: StatementT): ScanResult = {
-    val rs = session.execute(maybeExecutingAs(statement, readConf.executeAs))
-    val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames, rs, codecRegistry)
-    val prefetchingIterator = new PrefetchingResultSetIterator(rs, readConf.fetchSizeInRows)
-    val rateLimitingIterator = readConf.throughputMiBPS match {
-      case Some(throughput) =>
-        val rateLimiter = new RateLimiter((throughput * 1024 * 1024).toLong, 1024 * 1024)
-        prefetchingIterator.map { row =>
-          rateLimiter.maybeSleep(getRowBinarySize(row))
-          row
-        }
-      case None =>
-        prefetchingIterator
-    }
+    import com.datastax.spark.connector.util.Threads.BlockingIOExecutionContext
 
-    ScanResult(rateLimitingIterator, columnMetaData)
+    val rs = session.executeAsync(maybeExecutingAs(statement, readConf.executeAs))
+    val scanResult = asScalaFuture(rs).map { rs =>
+      val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames, rs, codecRegistry)
+      val prefetchingIterator = new PrefetchingResultSetIterator(rs, readConf.fetchSizeInRows)
+      val rateLimitingIterator = readConf.throughputMiBPS match {
+        case Some(throughput) =>
+          val rateLimiter = new RateLimiter((throughput * 1024 * 1024).toLong, 1024 * 1024)
+          prefetchingIterator.map { row =>
+            rateLimiter.maybeSleep(getRowBinarySize(row))
+            row
+          }
+        case None =>
+          prefetchingIterator
+      }
+      ScanResult(rateLimitingIterator, columnMetaData)
+    }
+    Await.result(scanResult, Duration.Inf)
   }
 
   override def getSession(): CqlSession = session

--- a/connector/src/main/scala/com/datastax/spark/connector/cql/Scanner.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/cql/Scanner.scala
@@ -44,7 +44,7 @@ class DefaultScanner (
     val rs = session.executeAsync(maybeExecutingAs(statement, readConf.executeAs))
     val scanResult = asScalaFuture(rs).map { rs =>
       val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames, rs, codecRegistry)
-      val prefetchingIterator = new PrefetchingResultSetIterator(rs, readConf.fetchSizeInRows)
+      val prefetchingIterator = new PrefetchingResultSetIterator(rs)
       val rateLimitingIterator = readConf.throughputMiBPS match {
         case Some(throughput) =>
           val rateLimiter = new RateLimiter((throughput * 1024 * 1024).toLong, 1024 * 1024)

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraCoGroupedRDD.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraCoGroupedRDD.scala
@@ -168,7 +168,7 @@ class CassandraCoGroupedRDD[T](
     val fetchResult = asScalaFuture(session.executeAsync(stmt)).map { rs =>
       val columnNames = fromRDD.selectedColumnRefs.map(_.selectedAs).toIndexedSeq ++ Seq(TokenColumn)
       val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames, rs, session.getContext.getCodecRegistry)
-      val iterator = new PrefetchingResultSetIterator(rs, fromRDD.readConf.fetchSizeInRows)
+      val iterator = new PrefetchingResultSetIterator(rs)
       val iteratorWithMetrics = iterator.map(inputMetricsUpdater.updateMetrics)
       logDebug(s"Row iterator for range $range obtained successfully.")
       (columnMetaData, iteratorWithMetrics)

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraCoGroupedRDD.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraCoGroupedRDD.scala
@@ -7,9 +7,11 @@ package com.datastax.spark.connector.rdd
 
 import java.io.IOException
 
+import com.datastax.bdp.util.ScalaJavaUtil._
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.cql.{BoundStatement, Row}
 import com.datastax.spark.connector.util._
+
 import scala.collection.JavaConversions._
 import scala.language.existentials
 import scala.reflect.ClassTag
@@ -27,6 +29,9 @@ import com.datastax.spark.connector.rdd.reader.{PrefetchingResultSetIterator, Ro
 import com.datastax.spark.connector.types.ColumnType
 import com.datastax.spark.connector.util.Quote._
 import com.datastax.spark.connector.util.{CountingIterator, MultiMergeJoinIterator, NameTools}
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 /**
   * A RDD which pulls from provided separate CassandraTableScanRDDs which share partition keys type and
@@ -158,20 +163,20 @@ class CassandraCoGroupedRDD[T](
         s"with params ${values.mkString("[", ",", "]")}")
     val stmt = createStatement(session, fromRDD.readConf, cql, values: _*)
 
-    try {
-      val rs = session.execute(stmt)
+    import com.datastax.spark.connector.util.Threads.BlockingIOExecutionContext
+
+    val fetchResult = asScalaFuture(session.executeAsync(stmt)).map { rs =>
       val columnNames = fromRDD.selectedColumnRefs.map(_.selectedAs).toIndexedSeq ++ Seq(TokenColumn)
-      val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames,rs, session)
+      val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames, rs, session.getContext.getCodecRegistry)
       val iterator = new PrefetchingResultSetIterator(rs, fromRDD.readConf.fetchSizeInRows)
       val iteratorWithMetrics = iterator.map(inputMetricsUpdater.updateMetrics)
       logDebug(s"Row iterator for range $range obtained successfully.")
       (columnMetaData, iteratorWithMetrics)
-    } catch {
-      case t: Throwable =>
-        throw new IOException(s"Exception during execution of $cql: ${t.getMessage}", t)
+    }.recover {
+      case t: Throwable => throw new IOException(s"Exception during execution of $cql: ${t.getMessage}", t)
     }
+    Await.result(fetchResult, Duration.Inf)
   }
-
 
   @DeveloperApi
   override def compute(split: Partition, context: TaskContext): Iterator[Seq[Seq[T]]] = {

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraLeftJoinRDD.scala
@@ -149,6 +149,7 @@ class CassandraLeftJoinRDD[L, R] (
     leftIterator: Iterator[L],
     metricsUpdater: InputMetricsUpdater
   ): Iterator[(L, Option[R])] = {
+    import com.datastax.spark.connector.util.Threads.BlockingIOExecutionContext
 
     val queryExecutor = QueryExecutor(session, readConf.parallelismLevel, None, None)
 
@@ -158,7 +159,7 @@ class CassandraLeftJoinRDD[L, R] (
 
       queryExecutor.executeAsync(bsb.bind(left).executeAs(readConf.executeAs)).onComplete {
         case Success(rs) =>
-          val resultSet = new PrefetchingResultSetIterator(ResultSets.newInstance(rs), fetchSize)
+          val resultSet = new PrefetchingResultSetIterator(rs, fetchSize)
           val iteratorWithMetrics = resultSet.map(metricsUpdater.updateMetrics)
           /* This is a much less than ideal place to actually rate limit, we are buffering
           these futures this means we will most likely exceed our threshold*/
@@ -170,10 +171,11 @@ class CassandraLeftJoinRDD[L, R] (
           resultFuture.set(leftSide.zip(rightSide))
         case Failure(throwable) =>
           resultFuture.setException(throwable)
-      }(ExecutionContext.Implicits.global) // TODO: use dedicated context, use Future instead of SettableFuture
+      }
 
       resultFuture
     }
+
     val queryFutures = leftIterator.map(left => {
       requestsPerSecondRateLimiter.maybeSleep(1)
       pairWithRight(left)

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraMergeJoinRDD.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraMergeJoinRDD.scala
@@ -160,7 +160,7 @@ class CassandraMergeJoinRDD[L,R](
     val fetchResult = asScalaFuture(session.executeAsync(stmt)).map { rs =>
       val columnNames = fromRDD.selectedColumnRefs.map(_.selectedAs).toIndexedSeq ++ Seq(TokenColumn)
       val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames, rs, session)
-      val iterator = new PrefetchingResultSetIterator(rs, fromRDD.readConf.fetchSizeInRows)
+      val iterator = new PrefetchingResultSetIterator(rs)
       val iteratorWithMetrics = iterator.map(inputMetricsUpdater.updateMetrics)
       logDebug(s"Row iterator for range $range obtained successfully.")
       (columnMetaData, iteratorWithMetrics)

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraMergeJoinRDD.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/CassandraMergeJoinRDD.scala
@@ -7,6 +7,8 @@ package com.datastax.spark.connector.rdd
 
 import java.io.IOException
 
+import com.datastax.bdp.util.ScalaJavaUtil.asScalaFuture
+
 import scala.collection.JavaConversions._
 import scala.language.existentials
 import scala.reflect.ClassTag
@@ -14,18 +16,20 @@ import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.metrics.InputMetricsUpdater
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{Partition, SparkContext, TaskContext}
-import com.datastax.driver.core._
 import com.datastax.oss.driver.api.core.CqlSession
-import com.datastax.oss.driver.api.core.cql.{BoundStatement, Row, Statement}
+import com.datastax.oss.driver.api.core.cql.{BoundStatement, Row}
 import com.datastax.oss.driver.api.core.metadata.Metadata
 import com.datastax.oss.driver.api.core.metadata.token.Token
 import com.datastax.spark.connector.CassandraRowMetadata
-import com.datastax.spark.connector.cql.{CassandraConnector, ColumnDef, Schema}
+import com.datastax.spark.connector.cql.{CassandraConnector, ColumnDef}
 import com.datastax.spark.connector.rdd.partitioner.{CassandraPartition, CqlTokenRange, NodeAddresses}
 import com.datastax.spark.connector.rdd.reader.{PrefetchingResultSetIterator, RowReader}
 import com.datastax.spark.connector.types.ColumnType
 import com.datastax.spark.connector.util.Quote._
 import com.datastax.spark.connector.util.{CountingIterator, MergeJoinIterator, NameTools, schemaFromCassandra}
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 /**
   * A RDD which pulls from two separate CassandraTableScanRDDs which share partition keys and
@@ -151,20 +155,20 @@ class CassandraMergeJoinRDD[L,R](
         s"with params ${values.mkString("[", ",", "]")}")
     val stmt = createStatement(session, fromRDD.readConf, cql, values: _*)
 
-    try {
-      val rs = session.execute(stmt)
+    import com.datastax.spark.connector.util.Threads.BlockingIOExecutionContext
+
+    val fetchResult = asScalaFuture(session.executeAsync(stmt)).map { rs =>
       val columnNames = fromRDD.selectedColumnRefs.map(_.selectedAs).toIndexedSeq ++ Seq(TokenColumn)
       val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames, rs, session)
       val iterator = new PrefetchingResultSetIterator(rs, fromRDD.readConf.fetchSizeInRows)
       val iteratorWithMetrics = iterator.map(inputMetricsUpdater.updateMetrics)
       logDebug(s"Row iterator for range $range obtained successfully.")
       (columnMetaData, iteratorWithMetrics)
-    } catch {
-      case t: Throwable =>
-        throw new IOException(s"Exception during execution of $cql: ${t.getMessage}", t)
+    }.recover {
+      case t: Throwable => throw new IOException(s"Exception during execution of $cql: ${t.getMessage}", t)
     }
+    Await.result(fetchResult, Duration.Inf)
   }
-
 
   @DeveloperApi
   override def compute(split: Partition, context: TaskContext): Iterator[(Seq[L], Seq[R])] = {

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/reader/PrefetchingResultSetIterator.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/reader/PrefetchingResultSetIterator.scala
@@ -1,11 +1,8 @@
 package com.datastax.spark.connector.rdd.reader
 
-import java.util.concurrent.TimeUnit
-
 import com.codahale.metrics.Timer
-import com.datastax.oss.driver.api.core.cql.{AsyncResultSet, ResultSet, Row}
-import com.datastax.oss.driver.internal.core.cql.MultiPageResultSet
-import com.google.common.util.concurrent.{FutureCallback, Futures, ListenableFuture}
+import com.datastax.oss.driver.api.core.cql.{AsyncResultSet, Row}
+import com.datastax.oss.driver.internal.core.cql.ResultSets
 
 /** Allows to efficiently iterate over a large, paged ResultSet,
   * asynchronously prefetching the next page.
@@ -15,10 +12,10 @@ import com.google.common.util.concurrent.{FutureCallback, Futures, ListenableFut
   *                           initiates fetching the next page
   * @param timer a Codahale timer to optionally gather the metrics of fetching time
   */
-class PrefetchingResultSetIterator(resultSet: ResultSet, prefetchWindowSize: Int, timer: Option[Timer] = None)
+class PrefetchingResultSetIterator(resultSet: AsyncResultSet, prefetchWindowSize: Int, timer: Option[Timer] = None)
   extends Iterator[Row] {
 
-  private[this] val iterator = resultSet.iterator()
+  private val iterator = ResultSets.newInstance(resultSet).iterator() //TODO
 
   override def hasNext = iterator.hasNext
 

--- a/connector/src/main/scala/com/datastax/spark/connector/util/Threads.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/util/Threads.scala
@@ -4,14 +4,19 @@ import java.util.concurrent.{Executors, LinkedBlockingQueue, ThreadPoolExecutor,
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
 
-object Threads {
+object Threads extends Logging {
 
-  implicit val BlockingIOExecutionContext = {
+  implicit val BlockingIOExecutionContext: ExecutionContextExecutorService = {
     val threadFactory = new ThreadFactoryBuilder()
       .setDaemon(true)
       .setNameFormat("spark-cassandra-connector-io" + "%d")
+      .setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler {
+        override def uncaughtException(t: Thread, e: Throwable): Unit = {
+          logWarning(s"Unhandled exception in thread ${t.getName}.", e)
+        }
+      })
       .build
     ExecutionContext.fromExecutorService(Executors.newCachedThreadPool(threadFactory))
   }

--- a/connector/src/main/scala/com/datastax/spark/connector/util/Threads.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/util/Threads.scala
@@ -1,0 +1,19 @@
+package com.datastax.spark.connector.util
+
+import java.util.concurrent.{Executors, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder
+
+import scala.concurrent.ExecutionContext
+
+object Threads {
+
+  implicit val BlockingIOExecutionContext = {
+    val threadFactory = new ThreadFactoryBuilder()
+      .setDaemon(true)
+      .setNameFormat("spark-cassandra-connector-io" + "%d")
+      .build
+    ExecutionContext.fromExecutorService(Executors.newCachedThreadPool(threadFactory))
+  }
+}
+

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/RichStatement.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/RichStatement.scala
@@ -21,8 +21,9 @@ object RichStatement {
 private[connector] class RichBoundStatementWrapper(initStatement: BoundStatement)
   extends RichStatement {
 
-  def update(updateFunction: BoundStatement => BoundStatement): Unit = {
+  def update(updateFunction: BoundStatement => BoundStatement): RichBoundStatementWrapper = {
     _stmt = updateFunction(_stmt)
+    this
   }
 
   private var _stmt = initStatement


### PR DESCRIPTION
The iterator tries to prefetch the next result page. Once the
current page is exhausted, the next page (hopefully
materialized at this point) becomes the current page and a
fetch request is sent.

fetchSize argument was removed, the supplied statement should
have pageSize parameter set by the caller.