### PR TITLE
SPARKC-619 restore PrefetchingResultSetIterator 

### DIFF
--- a/connector/src/it/scala/com/datastax/spark/connector/SparkCassandraITFlatSpecBase.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/SparkCassandraITFlatSpecBase.scala
@@ -161,6 +161,10 @@ trait SparkCassandraITSpecBase
 
   implicit val ec = SparkCassandraITSpecBase.ec
 
+  def await[T](unit: Future[T]): T = {
+    Await.result(unit, Duration.Inf)
+  }
+
   def awaitAll[T](units: Future[T]*): Seq[T] = {
     Await.result(Future.sequence(units), Duration.Inf)
   }

--- a/connector/src/it/scala/com/datastax/spark/connector/rdd/reader/PrefetchingResultSetIteratorSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/rdd/reader/PrefetchingResultSetIteratorSpec.scala
@@ -1,0 +1,67 @@
+package com.datastax.spark.connector.rdd.reader
+
+import com.codahale.metrics.Timer
+import com.datastax.oss.driver.api.core.cql.SimpleStatement.newInstance
+import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
+import com.datastax.spark.connector.cluster.DefaultCluster
+import com.datastax.spark.connector.cql.CassandraConnector
+import org.scalatest.concurrent.Eventually.{eventually, timeout}
+import org.scalatest.time.{Seconds, Span}
+
+class PrefetchingResultSetIteratorSpec extends SparkCassandraITFlatSpecBase with DefaultCluster {
+
+  private val table = "prefetching"
+  private val emptyTable = "empty_prefetching"
+  override lazy val conn = CassandraConnector(sparkConf)
+
+  override def beforeClass {
+    conn.withSessionDo { session =>
+      session.execute(
+        s"CREATE KEYSPACE IF NOT EXISTS $ks WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }")
+
+      session.execute(
+        s"CREATE TABLE IF NOT EXISTS $ks.$table (key INT, x INT, PRIMARY KEY (key))")
+
+      session.execute(
+        s"CREATE TABLE IF NOT EXISTS $ks.$emptyTable (key INT, x INT, PRIMARY KEY (key))")
+
+      awaitAll(
+        for (i <- 1 to 999) yield {
+          executor.executeAsync(newInstance(s"INSERT INTO $ks.$table (key, x) values ($i, $i)"))
+        }
+      )
+    }
+  }
+
+  "PrefetchingResultSetIterator" should "return all rows regardless of the  page sizes" in {
+    val pageSizes = Seq(1, 2, 5, 111, 998, 999, 1000, 1001)
+    for (pageSize <- pageSizes) {
+      withClue(s"Prefetching iterator failed for the page size: $pageSize") {
+        val statement = newInstance(s"select * from $ks.$table").setPageSize(pageSize)
+        val result = executor.executeAsync(statement).map(new PrefetchingResultSetIterator(_))
+        await(result).toList should have size 999
+      }
+    }
+  }
+
+  it should "be empty for an empty table" in {
+    val statement = newInstance(s"select * from $ks.$emptyTable")
+    val result = executor.executeAsync(statement).map(new PrefetchingResultSetIterator(_))
+
+    await(result).hasNext should be(false)
+    intercept[NoSuchElementException] {
+      await(result).next()
+    }
+  }
+
+  it should "update the provided timer" in {
+    val statement = newInstance(s"select * from $ks.$table").setPageSize(200)
+    val timer = new Timer()
+    val result = executor.executeAsync(statement).map(rs => new PrefetchingResultSetIterator(rs, Option(timer)))
+    await(result).toList
+
+    eventually(timeout(Span(2, Seconds))) {
+      timer.getCount should be(4)
+    }
+  }
+}

--- a/connector/src/main/scala/com/datastax/bdp/util/ScalaJavaUtil.scala
+++ b/connector/src/main/scala/com/datastax/bdp/util/ScalaJavaUtil.scala
@@ -7,10 +7,11 @@
 package com.datastax.bdp.util
 
 import java.time.{Duration => JavaDuration}
-import java.util.concurrent.Callable
+import java.util.concurrent.{Callable, CompletionStage}
 import java.util.function
-import java.util.function.{Consumer, Predicate, Supplier}
+import java.util.function.{BiConsumer, Consumer, Predicate, Supplier}
 
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future, Promise}
 import scala.concurrent.duration.{Duration => ScalaDuration}
 import scala.language.implicitConversions
 
@@ -45,4 +46,19 @@ object ScalaJavaUtil {
   }
 
   def asScalaFunction[T, R](f: java.util.function.Function[T, R]): T => R = x => f(x)
+
+  def asScalaFuture[T](completionStage: CompletionStage[T])
+                      (implicit context: ExecutionContextExecutor): Future[T] = {
+    val promise = Promise[T]()
+    completionStage.whenCompleteAsync(new BiConsumer[T, java.lang.Throwable] {
+      override def accept(t: T, throwable: Throwable): Unit = {
+        if (throwable == null)
+          promise.success(t)
+        else
+          promise.failure(throwable)
+
+      }
+    }, context)
+    promise.future
+  }
 }

--- a/connector/src/main/scala/com/datastax/spark/connector/cql/Scanner.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/cql/Scanner.scala
@@ -1,5 +1,6 @@
 package com.datastax.spark.connector.cql
 
+import com.datastax.bdp.util.ScalaJavaUtil.asScalaFuture
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.cql.{Row, Statement}
 import com.datastax.spark.connector.CassandraRowMetadata
@@ -7,6 +8,9 @@ import com.datastax.spark.connector.rdd.ReadConf
 import com.datastax.spark.connector.rdd.reader.PrefetchingResultSetIterator
 import com.datastax.spark.connector.util.maybeExecutingAs
 import com.datastax.spark.connector.writer.RateLimiter
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await}
 
 /**
   * Object which will be used in Table Scanning Operations.
@@ -35,21 +39,25 @@ class DefaultScanner (
   }
 
   override def scan[StatementT <: Statement[StatementT]](statement: StatementT): ScanResult = {
-    val rs = session.execute(maybeExecutingAs(statement, readConf.executeAs))
-    val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames, rs, codecRegistry)
-    val prefetchingIterator = new PrefetchingResultSetIterator(rs, readConf.fetchSizeInRows)
-    val rateLimitingIterator = readConf.throughputMiBPS match {
-      case Some(throughput) =>
-        val rateLimiter = new RateLimiter((throughput * 1024 * 1024).toLong, 1024 * 1024)
-        prefetchingIterator.map { row =>
-          rateLimiter.maybeSleep(getRowBinarySize(row))
-          row
-        }
-      case None =>
-        prefetchingIterator
-    }
+    import com.datastax.spark.connector.util.Threads.BlockingIOExecutionContext
 
-    ScanResult(rateLimitingIterator, columnMetaData)
+    val rs = session.executeAsync(maybeExecutingAs(statement, readConf.executeAs))
+    val scanResult = asScalaFuture(rs).map { rs =>
+      val columnMetaData = CassandraRowMetadata.fromResultSet(columnNames, rs, codecRegistry)
+      val prefetchingIterator = new PrefetchingResultSetIterator(rs)
+      val rateLimitingIterator = readConf.throughputMiBPS match {
+        case Some(throughput) =>
+          val rateLimiter = new RateLimiter((throughput * 1024 * 1024).toLong, 1024 * 1024)
+          prefetchingIterator.map { row =>
+            rateLimiter.maybeSleep(getRowBinarySize(row))
+            row
+          }
+        case None =>
+          prefetchingIterator
+      }
+      ScanResult(rateLimitingIterator, columnMetaData)
+    }
+    Await.result(scanResult, Duration.Inf)
   }
 
   override def getSession(): CqlSession = session

--- a/connector/src/main/scala/com/datastax/spark/connector/rdd/reader/PrefetchingResultSetIterator.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/rdd/reader/PrefetchingResultSetIterator.scala
@@ -3,46 +3,53 @@ package com.datastax.spark.connector.rdd.reader
 import java.util.concurrent.TimeUnit
 
 import com.codahale.metrics.Timer
-import com.datastax.oss.driver.api.core.cql.{AsyncResultSet, ResultSet, Row}
-import com.datastax.oss.driver.internal.core.cql.MultiPageResultSet
-import com.google.common.util.concurrent.{FutureCallback, Futures, ListenableFuture}
+import com.datastax.bdp.util.ScalaJavaUtil
+import com.datastax.oss.driver.api.core.cql.{AsyncResultSet, Row}
+import com.datastax.spark.connector.util.Threads.BlockingIOExecutionContext
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
 
 /** Allows to efficiently iterate over a large, paged ResultSet,
   * asynchronously prefetching the next page.
-  * 
+  *
+  * This iterator is NOT thread safe. Attempting to retrieve elements from many threads without synchronization
+  * may yield unspecified results.
+  *
   * @param resultSet result set obtained from the Java driver
-  * @param prefetchWindowSize if there are less than this rows available without blocking,
-  *                           initiates fetching the next page
-  * @param timer a Codahale timer to optionally gather the metrics of fetching time
+  * @param timer     a Codahale timer to optionally gather the metrics of fetching time
   */
-class PrefetchingResultSetIterator(resultSet: ResultSet, prefetchWindowSize: Int, timer: Option[Timer] = None)
-  extends Iterator[Row] {
+class PrefetchingResultSetIterator(resultSet: AsyncResultSet, timer: Option[Timer] = None) extends Iterator[Row] {
+  private var currentIterator = resultSet.currentPage().iterator()
+  private var currentResultSet = resultSet
+  private var nextResultSet = fetchNextPage()
 
-  private[this] val iterator = resultSet.iterator()
+  private def fetchNextPage(): Option[Future[AsyncResultSet]] = {
+    if (currentResultSet.hasMorePages) {
+      val t0 = System.nanoTime();
+      val next = ScalaJavaUtil.asScalaFuture(currentResultSet.fetchNextPage())
+      timer.foreach { t =>
+        next.foreach(_ => t.update(System.nanoTime() - t0, TimeUnit.NANOSECONDS))
+      }
+      Option(next)
+    } else
+      None
+  }
 
-  override def hasNext = iterator.hasNext
+  private def maybePrefetch(): Unit = {
+    if (!currentIterator.hasNext && currentResultSet.hasMorePages) {
+      currentResultSet = Await.result(nextResultSet.get, Duration.Inf)
+      currentIterator = currentResultSet.currentPage().iterator()
+      nextResultSet = fetchNextPage()
+    }
+  }
 
-// TODO: implement async page fetching. Following implementation might call fetchMoreResults up to prefetchWindowSize
-//       times to fetch the same page. Is this behaviour still valid in the new driver?
-//       This class should take AsyncResultSet as constructor param (not ResultSet)
+  override def hasNext: Boolean =
+    currentIterator.hasNext || currentResultSet.hasMorePages
 
-//  private[this] def maybePrefetch(): Unit = {
-//    if (!resultSet.isFullyFetched && resultSet.getAvailableWithoutFetching < prefetchWindowSize) {
-//      val t0 = System.nanoTime()
-//      val future: ListenableFuture[ResultSet] = resultSet.fetchMoreResults()
-//      if (timer.isDefined)
-//        Futures.addCallback(future, new FutureCallback[ResultSet] {
-//          override def onSuccess(ignored: ResultSet): Unit = {
-//            timer.get.update(System.nanoTime() - t0, TimeUnit.NANOSECONDS)
-//          }
-//
-//          override def onFailure(ignored: Throwable): Unit = { }
-//        })
-//    }
-//  }
-
-  override def next() = {
-//    maybePrefetch()
-    iterator.next()
+  override def next(): Row = {
+    val row = currentIterator.next() // let's try to exhaust the current iterator first
+    maybePrefetch()
+    row
   }
 }

--- a/connector/src/main/scala/com/datastax/spark/connector/util/Threads.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/util/Threads.scala
@@ -1,0 +1,24 @@
+package com.datastax.spark.connector.util
+
+import java.util.concurrent.{Executors, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder
+
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
+
+object Threads extends Logging {
+
+  implicit val BlockingIOExecutionContext: ExecutionContextExecutorService = {
+    val threadFactory = new ThreadFactoryBuilder()
+      .setDaemon(true)
+      .setNameFormat("spark-cassandra-connector-io" + "%d")
+      .setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler {
+        override def uncaughtException(t: Thread, e: Throwable): Unit = {
+          logWarning(s"Unhandled exception in thread ${t.getName}.", e)
+        }
+      })
+      .build
+    ExecutionContext.fromExecutorService(Executors.newCachedThreadPool(threadFactory))
+  }
+}
+

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/RichStatement.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/RichStatement.scala
@@ -21,8 +21,9 @@ object RichStatement {
 private[connector] class RichBoundStatementWrapper(initStatement: BoundStatement)
   extends RichStatement {
 
-  def update(updateFunction: BoundStatement => BoundStatement): Unit = {
+  def update(updateFunction: BoundStatement => BoundStatement): RichBoundStatementWrapper = {
     _stmt = updateFunction(_stmt)
+    this
   }
 
   private var _stmt = initStatement


### PR DESCRIPTION
The iterator tries to prefetch the next result page. Once the
current page is exhausted, the next page (hopefully
materialized at this point) becomes the current page and a
fetch request is sent.

fetchSize argument was removed, the supplied statement should
have pageSize parameter set by the caller.