### PR TITLE
SPARKC-620 closed classloader workaround

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/util/ClassLoaderCheck.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/util/ClassLoaderCheck.scala
@@ -1,0 +1,10 @@
+package com.datastax.spark.connector.util
+
+
+/**
+  * Do not remove.
+  * This is a temporary marker class that is loaded by name during application shutdown.
+  * See SPARKC-620 for details.
+  */
+object ClassLoaderCheck {}
+


### PR DESCRIPTION
During shutdown hive-exec (used in spark-sql) closes context class
loader that was used to load all the SCC classes.
This happens before shutdown hooks invocation. It results in errors
when an additional SCC/Java Driver/Netty class needs to be loaded
during shutdown hook execution.

Unfortunately the class loading errors cause our hook to hang forever
(we use the hook to close all the remaining Driver sessions and
session.close() invocation simply doesn't ever return).

Since there is no way to avoid class loader closing, we need to fix
things on our end.

This PR introduces a workaround for this problem. An attempt to load
a marker class is made just before the shutdown hook invocation. In
case of an error the process exits without calling `close` on the
remaining sessions.

The proper solution would require removing the hook completely.