### PR TITLE
SPARKC-614 fix full table scan perf tests

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraScanPartitionReaderFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraScanPartitionReaderFactory.scala
@@ -111,7 +111,7 @@ abstract class CassandraPartitionReaderBase
     }
   }
 
-  protected def rowReader = new UnsafeRowReaderFactory(schema).rowReader(tableDef, queryParts.selectedColumnRefs)
+  protected val rowReader = new UnsafeRowReaderFactory(schema).rowReader(tableDef, queryParts.selectedColumnRefs)
 }
 
 /**

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -2,7 +2,7 @@ object Versions {
 
   val CommonsExec     = "1.3"
   val CommonsIO       = "2.6"
-  val CommonsLang3    = "3.5"
+  val CommonsLang3    = "3.9"
   val Paranamer       = "2.8"
 
   val DataStaxJavaDriver = "4.7.2"
@@ -21,7 +21,7 @@ object Versions {
   // and install in a local Maven repository. This is all done automatically, however it will work
   // only on Unix/OSX operating system. Windows users have to build and install Spark manually if the
   // desired version is not yet published into a public Maven repository.
-  val ApacheSpark     = "3.0.0"
+  val ApacheSpark     = "3.0.1"
   val SparkJetty      = "9.3.27.v20190418"
   val SolrJ           = "8.3.0"
 


### PR DESCRIPTION
rowReader is referenced for each row, having a `def` in it's definition
caused new object creation for each row.
Keeping rowReader as val fixes this issue. This changes fullTableScan
perf test time back to normal (from 13 hours(!) to 15 minutes).