### PR TITLE
SPARKC-626 CassandraSparkExtensions crash with Spark 3.1.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+3.1.0
+ * Updated Spark to 3.1.1 and commons-lang to 3.10
+ * Fixed crash in the DirectJoin caused by internal changes in Spark 3.1 (SPARKC-626)
+
 3.0.1
  * Fix: repeated metadata refresh with the Spark connector (SPARKC-633)
 

--- a/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinExec.scala
+++ b/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinExec.scala
@@ -9,7 +9,7 @@ import org.apache.spark.sql.catalyst.expressions.{And, Attribute, BindReferences
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.{DataSourceScanExec, SparkPlan, UnaryExecNode}
-import org.apache.spark.sql.execution.joins.{BuildLeft, BuildSide}
+import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildSide}
 import org.apache.spark.sql.execution.metric.SQLMetrics
 
 /**

--- a/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinStrategy.scala
+++ b/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinStrategy.scala
@@ -10,7 +10,7 @@ import org.apache.spark.sql.catalyst.planning.{ExtractEquiJoinKeys, PhysicalOper
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2ScanRelation, DataSourceV2Strategy}
-import org.apache.spark.sql.execution.joins.{BuildLeft, BuildRight, BuildSide}
+import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
 import org.apache.spark.sql.execution.{ProjectExec, SparkPlan}
 
 
@@ -259,7 +259,8 @@ object CassandraDirectJoinStrategy extends Logging {
          val aliasedOutput = directJoin.output.map{
            case attr if aliases.contains(attr.exprId) =>
              val oldAlias = aliases(attr.exprId)
-             oldAlias.copy(child = attr)(oldAlias.exprId, oldAlias.qualifier, oldAlias.explicitMetadata)
+             oldAlias.copy(child = attr)(oldAlias.exprId, oldAlias.qualifier,
+               oldAlias.explicitMetadata, oldAlias.nonInheritableMetadataKeys)
            case other => other
          }
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -2,7 +2,7 @@ object Versions {
 
   val CommonsExec     = "1.3"
   val CommonsIO       = "2.6"
-  val CommonsLang3    = "3.9"
+  val CommonsLang3    = "3.10"
   val Paranamer       = "2.8"
 
   val DataStaxJavaDriver = "4.10.0"
@@ -21,7 +21,7 @@ object Versions {
   // and install in a local Maven repository. This is all done automatically, however it will work
   // only on Unix/OSX operating system. Windows users have to build and install Spark manually if the
   // desired version is not yet published into a public Maven repository.
-  val ApacheSpark     = "3.0.1"
+  val ApacheSpark     = "3.1.1"
   val SparkJetty      = "9.3.27.v20190418"
   val SolrJ           = "8.3.0"
 


### PR DESCRIPTION
# Description

## How did the Spark Cassandra Connector Work or Not Work Before this Patch

See detailed description in Jira: https://datastax-oss.atlassian.net/browse/SPARKC-626

## General Design of the patch

Point imports to a new package

# How Has This Been Tested?

Almost all changes and especially bug fixes will require a test to be added to either the integration or Unit Tests. Any tests added will be automatically run on travis when the pull request is pushed to github. Be sure to run suites locally as well.

# Checklist:

- [X] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/browse/SPARKC-626)
- [X] I have performed a self-review of my own code
- [X] Locally all tests pass (make sure tests fail without your patch)
