### PR TITLE
SPARKC-629 fix invalid clustering key pushdown

### DIFF
--- a/connector/src/main/scala/org/apache/spark/sql/cassandra/BasicCassandraPredicatePushDown.scala
+++ b/connector/src/main/scala/org/apache/spark/sql/cassandra/BasicCassandraPredicatePushDown.scala
@@ -146,12 +146,17 @@ class BasicCassandraPredicatePushDown[Predicate : PredicateOps](
     eqOrInPredicates ++ optionalNonEqPredicate
   }
 
-  /** Selects clustering key predicates for pushdown based on protocol version */
+  /** Selects clustering key predicates for pushdown based on protocol version.
+    * Clustering key predicates are pushed down only if the partition key predicates are defined. */
   private val clusteringColumnPredicatesToPushDown: Set[Predicate] = {
-    if (pv < DefaultProtocolVersion.V4) {
-      clusteringColumnPredicatesToPushDownPriorV4()
+    if (partitionKeyPredicatesToPushDown.isEmpty) {
+      Set()
     } else {
-      clusteringColumnPredicatesToPushDownFromV4()
+      if (pv < DefaultProtocolVersion.V4) {
+        clusteringColumnPredicatesToPushDownPriorV4()
+      } else {
+        clusteringColumnPredicatesToPushDownFromV4()
+      }
     }
   }
 


### PR DESCRIPTION
Before this change clustering keys were pushed down without
considering partition key pushdowns. This enabled a scenario
where a clustering key was pushed down and the partition key
pushdown was missing. This kind of query ends with a timeout.
It was not rejected by C* only because we add ALLOW FILTERING
to our queries.

This PR introduces pk check to ck pushdowns. CK predicates
are pushed down only if pk pushdowns are defined.
