### PR TITLE
 DSP-21510 fix per cluster settings with factory custom props

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.18

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
@@ -151,8 +151,11 @@ object CassandraConnectionFactory {
   val Properties = Set(FactoryParam)
 
   def fromSparkConf(conf: SparkConf): CassandraConnectionFactory = {
-    conf.getOption(FactoryParam.name)
-      .map(ReflectionUtil.findGlobalObject[CassandraConnectionFactory])
+    fromNameOrDefault(conf.getOption(FactoryParam.name))
+  }
+
+  def fromNameOrDefault(factoryName: Option[String]): CassandraConnectionFactory = {
+    factoryName.map(ReflectionUtil.findGlobalObject[CassandraConnectionFactory])
       .getOrElse(FactoryParam.default)
   }
 }

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
@@ -154,8 +154,7 @@ object CassandraConnector extends Logging {
     createSession, destroySession, alternativeConnectionConfigs)
 
   private def createSession(conf: CassandraConnectorConf): Session = {
-    lazy val endpointsStr = conf.hosts.map(_.getHostAddress).mkString("{", ", ", "}") + ":" + conf.port
-    logDebug(s"Attempting to open native connection to Cassandra at $endpointsStr")
+    logDebug(s"Attempting to open native connection to Cassandra")
     val cluster = conf.connectionFactory.createCluster(conf)
     try {
       val clusterName = cluster.getMetadata.getClusterName
@@ -165,7 +164,7 @@ object CassandraConnector extends Logging {
     catch {
       case e: Throwable =>
         cluster.close()
-        throw new IOException(s"Failed to open native connection to Cassandra at $endpointsStr", e)
+        throw new IOException(s"Failed to open native connection to Cassandra", e)
     }
   }
 

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/ConfigCheck.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/util/ConfigCheck.scala
@@ -32,7 +32,6 @@ object ConfigCheck {
 
   val validStaticPropertyNames = validStaticProperties.map(_.name)
 
-
   /**
    * Checks the SparkConf Object for any unknown spark.cassandra.* properties and throws an exception
    * with suggestions if an unknown property is found.

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/DefaultSource.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/DefaultSource.scala
@@ -1,15 +1,11 @@
 package org.apache.spark.sql.cassandra
 
-import java.util.Locale
-
-import scala.collection.mutable
 import org.apache.spark.sql.SaveMode._
 import org.apache.spark.sql.cassandra.DefaultSource._
 import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, RelationProvider, SchemaRelationProvider}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
-import com.datastax.spark.connector.util.Logging
-import com.datastax.spark.connector.cql.{AuthConfFactory, CassandraConnectorConf, DefaultAuthConfFactory}
+import com.datastax.spark.connector.cql.{AuthConfFactory, CassandraConnectionFactory, CassandraConnectorConf, DefaultAuthConfFactory}
 import com.datastax.spark.connector.rdd.ReadConf
 import com.datastax.spark.connector.util.Logging
 import com.datastax.spark.connector.writer.WriteConf
@@ -136,7 +132,8 @@ object DefaultSource {
     CassandraConnectorConf.Properties.map(_.name) ++
     CassandraSourceRelation.Properties.map(_.name) ++
     AuthConfFactory.Properties.map(_.name) ++
-    DefaultAuthConfFactory.properties
+    DefaultAuthConfFactory.properties ++
+    CassandraConnectionFactory.Properties.map(_.name)
 
   /** Check whether the provider is Cassandra datasource or not */
   def cassandraSource(provider: String) : Boolean = {


### PR DESCRIPTION
Custom connection factories are allowed to provide a set of custom
supported properties. These properties were omitted when provided
as a custom cluster setting (myCluster/my.custom.setting=cp2077).

This commit introduces custom connection properties support for
per-cluster settings.