### PR TITLE
SPARKC-609 extend await time for auth clusters

### DIFF
--- a/connector/src/it/scala/com/datastax/spark/connector/SparkCassandraITFlatSpecBase.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/SparkCassandraITFlatSpecBase.scala
@@ -129,7 +129,7 @@ trait SparkCassandraITSpecBase
       */
     //For Auth Clusters we have to wait for the default User before a connection will work
     if (sparkConf.contains(DefaultAuthConfFactory.PasswordParam.name)) {
-      eventually(timeout(Span(60, Seconds))) {
+      eventually(timeout(Span(120, Seconds))) {
         CassandraConnector(sparkConf).withSessionDo(session => assert(session != null))
       }
     }


### PR DESCRIPTION
Apparently we already have a mechanism to wait for the auth
clusters to be ready. As the Auth tests still fail occasionally
this commit extends the await period.