### PR TITLE
SPARKC-633 minimize C* metadata refresh count

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraTable.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraTable.scala
@@ -1,9 +1,8 @@
 package com.datastax.spark.connector.datasource
 
 import java.util
-
 import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata
-import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.cql.{CassandraConnector, TableDef}
 import com.datastax.spark.connector.util._
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, Table, TableCapability}
@@ -27,7 +26,8 @@ case class CassandraTable(
     with SupportsRead
     with SupportsWrite {
 
-  val tableDef = tableFromCassandra(connector, metadata.getKeyspace.asInternal(), name())
+  /* Retrieving table def from cassandra may be slow (it implies C* metadata refresh) */
+  lazy val tableDef: TableDef = tableFromCassandra(connector, metadata.getKeyspace.asInternal(), name())
 
   override def schema(): StructType = optionalSchema
     .getOrElse(CassandraSourceUtil.toStructType(metadata))

--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/CasssandraDriverDataWriterFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/CasssandraDriverDataWriterFactory.scala
@@ -37,7 +37,7 @@ case class CassandraDriverDataWriter(
   private val columns = SomeColumns(inputSchema.fieldNames.map(name => ColumnName(name)): _*)
 
   private val writer =
-    TableWriter(connector, tableDef.keyspaceName, tableDef.tableName, columns, writeConf)(unsafeRowWriterFactory)
+    TableWriter(connector, tableDef, columns, writeConf, false)(unsafeRowWriterFactory)
       .getAsyncWriter()
 
   override def write(record: InternalRow): Unit = writer.write(record)

--- a/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/writer/TableWriter.scala
@@ -414,7 +414,17 @@ object TableWriter {
       checkPartitionKey: Boolean = false): TableWriter[T] = {
 
     val tableDef = tableFromCassandra(connector, keyspaceName, tableName)
-    val optionColumns = writeConf.optionsAsColumns(keyspaceName, tableName)
+    TableWriter(connector, tableDef, columnNames, writeConf, checkPartitionKey)
+  }
+
+  def apply[T : RowWriterFactory](
+       connector: CassandraConnector,
+       tableDef: TableDef,
+       columnNames: ColumnSelector,
+       writeConf: WriteConf,
+       checkPartitionKey: Boolean): TableWriter[T] = {
+
+    val optionColumns = writeConf.optionsAsColumns(tableDef.keyspaceName, tableDef.tableName)
     val tablDefWithMeta = tableDef.copy(regularColumns = tableDef.regularColumns ++ optionColumns)
 
     val selectedColumns = columnNames


### PR DESCRIPTION
Each tableFromCassandra invocation results in a metadata
refresh. The operation may be costly.
This PR reduces the number of metadata refresh operations
by making tableDef lazy and reusing available TableDef in
TableWriter.
