### PR TITLE
SPARKC-641 Config deprecations are not checked when instantiating CassandraConnector

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
@@ -220,7 +220,7 @@ object CassandraConnector extends Logging {
 
   /** Returns a CassandraConnector created from properties found in the [[org.apache.spark.SparkConf SparkConf]] object */
   def apply(conf: SparkConf): CassandraConnector = {
-    CassandraConnector(CassandraConnectorConf.fromSparkConf(conf))
+    CassandraConnector(CassandraConnectorConf(conf))
   }
 
   /** Returns a CassandraConnector with runtime Cluster Environment information. This can set remoteConnectionsPerExecutor

--- a/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectorConf.scala
@@ -355,7 +355,6 @@ object CassandraConnectorConf extends Logging {
   }
 
   def apply(conf: SparkConf): CassandraConnectorConf = {
-    ConfigCheck.checkConfig(conf)
     fromSparkConf(conf)
   }
 
@@ -410,6 +409,9 @@ object CassandraConnectorConf extends Logging {
   }
 
   def fromSparkConf(conf: SparkConf) = {
+
+    ConfigCheck.checkConfig(conf)
+
     val localDC = conf.getOption(LocalDCParam.name)
     val keepAlive = conf.getInt(KeepAliveMillisParam.name, KeepAliveMillisParam.default)
     val minReconnectionDelay = conf.getInt(MinReconnectionDelayParam.name, MinReconnectionDelayParam.default)


### PR DESCRIPTION
# Description

## How did the Spark Cassandra Connector Work or Not Work Before this Patch

When CassandraConnector is instantiated with `CassandraConnector(SparkContext)`, config deprecations are not checked (nor automatically replaced).

This is an issue when using any Cassandra RDD function because every default implicit `CassandraConnector` in class `RDDFunctions` is instantiated this way.

For example, when first executing `rdd.saveToCassandra(keyspaceName, tableName, columns, WriteConf())` with no implicit `CassandraConnector` already initialized, then config deprecations are not checked, nor replaced, and deprecated configs are not taken into account.

Note that config deprecations are however checked from methods `ReadConf.fromSparkConf()` and `WriteConf.fromSparkConf()`, so the issue only occurs if these methods are not called previously.

## General Design of the patch

`CassandraConnectorConf` can be instantiated from a `SparkConf` by two methods:
- `apply(SparkConf)`, which seems to be the preferred way since it allows the concise scala syntax `CassandraConnectorConf(SparkConf)`
- `fromSparkConf(SparkConf)`, which is used as part of the `CassandraConnector(SparkContext)` instantiation

The only difference between the two methods is that `apply(SparkConf)` checks config deprecations before calling `fromSparkConf(SparkConf)`, the latter of which does not check config deprecations.

This PR fixes the issue by moving the deprecation checks from the method `apply(SparkConf)` to the method `fromSparkConf(SparkConf)`, so that:
- every method named `fromSparkConf(SparkConf)` (from classes `CassandraConnectorConf`, `ReadConf` and `WriteConf`) homogeneously checks config deprecations
- `apply(SparkConf)` is in effect a synonym of `fromSparkConf(SparkConf)` and so can be used interchangeably

Fixes: [SPARKC-641](https://datastax-oss.atlassian.net/browse/SPARKC-641)

# How Has This Been Tested?

This can be simply tested manually by executing any cassandra RDD function and noticing that deprecated configs have not been taken into account.
I am not sure where new automated tests should be added, there is a test suite named `DeprecationSpec`, but note that config deprecation warnings and replacements occur in fact only once in this test suite.
Feel free to contribute if needed.

# Checklist:

- [x] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/projects/SPARKC)
- [x] I have performed a self-review of my own code
- [x] Locally all tests pass (make sure tests fail without your patch)
