### PR TITLE
SPARKC-642 repartitionByCassandraReplica relocates data to the local node only

### DIFF
--- a/connector/src/it/scala/com/datastax/spark/connector/cluster/Fixtures.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/cluster/Fixtures.scala
@@ -187,6 +187,15 @@ trait TwoClustersWithOneNode extends Fixture {
   override def cluster(c: Int): Cluster = ClusterHolder.get(this)(c)
 }
 
+/** A fixture that bootstraps on single cluster with two nodes. */
+trait TwoNodeCluster extends SingleClusterFixture {
+
+  private[cluster] final override val configs: Seq[CcmConfig] = Seq(defaultConfig.copy(nodes = Seq(1, 2)))
+
+  private[cluster] override def connectionParameters(address: InetSocketAddress): Map[String, String] =
+    DefaultCluster.defaultConnectionParameters(address)
+}
+
 trait CETCluster extends DefaultCluster
 
 trait CSTCluster extends DefaultCluster

--- a/connector/src/it/scala/com/datastax/spark/connector/rdd/ReplicaRepartitionedCassandraRDDSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/rdd/ReplicaRepartitionedCassandraRDDSpec.scala
@@ -1,0 +1,85 @@
+package com.datastax.spark.connector.rdd
+
+import java.lang.{Long => JLong}
+
+import com.datastax.spark.connector._
+import com.datastax.spark.connector.cluster.TwoNodeCluster
+import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.rdd.partitioner.EndpointPartition
+
+import scala.concurrent.Future
+
+class ReplicaRepartitionedCassandraRDDSpec extends SparkCassandraITFlatSpecBase with TwoNodeCluster {
+
+  override lazy val conn = CassandraConnector(defaultConf)
+  val tableName = "key_value"
+  val keys = 0 to 200
+  val total = 0 to 10000
+
+  override def beforeClass {
+    conn.withSessionDo { session =>
+      createKeyspace(session)
+      val startTime = System.currentTimeMillis()
+
+      val executor = getExecutor(session)
+
+      awaitAll(
+        Future {
+          session.execute(
+            s"""
+               |CREATE TABLE $ks.$tableName (
+               |  key INT,
+               |  group BIGINT,
+               |  value TEXT,
+               |  PRIMARY KEY (key, group)
+               |)""".stripMargin)
+          val ps = session
+            .prepare(s"""INSERT INTO $ks.$tableName (key, group, value) VALUES (?, ?, ?)""")
+          awaitAll((for (value <- total) yield
+            executor.executeAsync(ps.bind(value: Integer, (value * 100).toLong: JLong, value.toString))): _*)
+        }
+      )
+      executor.waitForCurrentlyExecutingTasks()
+      println(s"Took ${(System.currentTimeMillis() - startTime) / 1000.0} Seconds to setup Suite Data")
+    }
+  }
+
+  def checkArrayCassandraRow[T](result: Array[(T, CassandraRow)]) = {
+    markup("Checking RightSide Join Results")
+    result.length should be(keys.length)
+    for (key <- keys) {
+      val sorted_result = result.map(_._2).sortBy(_.getInt(0))
+      sorted_result(key).getInt("key") should be(key)
+      sorted_result(key).getLong("group") should be(key * 100)
+      sorted_result(key).getString("value") should be(key.toString)
+    }
+  }
+
+  "A Tuple RDD specifying partition keys" should "be repartitionable" in {
+    val source = sc.parallelize(keys).map(Tuple1(_))
+    val repart = source.repartitionByCassandraReplica(ks, tableName, 10)
+    repart.partitions.length should be(conn.hosts.size * 10)
+    conn.hosts.size should be(2)
+    conn.hosts should be(cluster.addresses.toSet)
+    val someCass = repart.joinWithCassandraTable(ks, tableName)
+    someCass.partitions.foreach {
+      case e: EndpointPartition =>
+        conn.hostAddresses should contain(e.endpoints.head)
+      case _ =>
+        fail("Unable to get endpoints on repartitioned RDD, This means preferred locations will be broken")
+    }
+    val result = someCass.collect
+    checkArrayCassandraRow(result)
+  }
+
+  it should "be deterministically repartitionable" in {
+    val source = sc.parallelize(keys).map(Tuple1(_))
+    val repartRDDs = (1 to 10).map(_ =>
+      source
+        .repartitionByCassandraReplica(ks, tableName, 10)
+        .mapPartitionsWithIndex((index, it) => it.map((_, index))))
+    val first = repartRDDs(1).collect
+    repartRDDs.foreach(rdd => rdd.collect should be(first))
+  }
+
+}

--- a/connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/RDDFunctions.scala
@@ -237,31 +237,6 @@ class RDDFunctions[T](rdd: RDD[T]) extends WritableToCassandra[T] with Serializa
     currentType: ClassTag[T],
     rwf: RowWriterFactory[T]): CassandraPartitionedRDD[T] = {
 
-    val replicaLocator = ReplicaLocator[T](connector, keyspaceName, tableName, partitionKeyMapper)
-    rdd.repartitionByCassandraReplica(
-      replicaLocator,
-      keyspaceName,
-      tableName,
-      partitionsPerHost,
-      partitionKeyMapper)
-  }
-
-
-  /**
-   * A Serializable version of repartitionByCassandraReplica which removes
-   * the implicit RowWriterFactory Dependency
-   */
-  private[connector] def repartitionByCassandraReplica(
-    replicaLocator: ReplicaLocator[T],
-    keyspaceName: String,
-    tableName: String,
-    partitionsPerHost: Int,
-    partitionKeyMapper: ColumnSelector)(
-  implicit
-    connector: CassandraConnector,
-    currentType: ClassTag[T],
-    rwf: RowWriterFactory[T]): CassandraPartitionedRDD[T] = {
-
     val partitioner = new ReplicaPartitioner[T](
       tableName,
       keyspaceName,

--- a/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
@@ -65,7 +65,7 @@ class CassandraConnector(val conf: CassandraConnectorConf)
     // wrapped in a session, so we get full lists of hosts,
     // not only those explicitly passed in the conf
     withSessionDo { session =>
-      dataCenterNodes(_config, session)
+      dataCenterNodes(session)
     }
 
   private[connector] def hostAddresses: Set[InetAddress] = hosts.map(_.getAddress)
@@ -181,7 +181,7 @@ object CassandraConnector extends Logging {
   }
 
   // LocalNodeFirstLoadBalancingPolicy assigns LOCAL or REMOTE (i.e. non-IGNORED) distance to local DC nodes
-  private def dataCenterNodes(conf: CassandraConnectorConf, session: CqlSession): Set[InetSocketAddress] = {
+  private def dataCenterNodes(session: CqlSession): Set[InetSocketAddress] = {
     val allNodes = session.getMetadata.getNodes.asScala.values.toSet
     val nodes = allNodes
       .filter(_.getDistance != NodeDistance.IGNORED)
@@ -197,7 +197,7 @@ object CassandraConnector extends Logging {
   private def alternativeConnectionConfigs(conf: CassandraConnectorConf, session: CqlSession): Set[CassandraConnectorConf] = {
     conf.contactInfo match {
       case ipConf: IpBasedContactInfo =>
-        val nodes = dataCenterNodes(conf, session)
+        val nodes = dataCenterNodes(session)
         nodes.map(n => conf.copy(contactInfo = ipConf.copy(hosts = Set(n)))) + conf.copy(contactInfo = ipConf.copy(hosts = nodes))
       case _ => Set.empty
     }

--- a/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnector.scala
@@ -5,14 +5,13 @@ import java.net.{InetAddress, InetSocketAddress}
 
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance
-import com.datastax.spark.connector.cql.CassandraConnectorConf.CassandraSSLConf
 import com.datastax.spark.connector.types.TypeAdapters.{ValueByNameAdapter, ValuesSeqAdapter}
 import com.datastax.spark.connector.types.{NullableTypeConverter, TypeConverter}
 import com.datastax.spark.connector.util.ConfigCheck.ConnectorConfigurationException
 import com.datastax.spark.connector.util.DriverUtil.toAddress
-import com.datastax.spark.connector.util.{DriverUtil, Logging, SerialShutdownHooks}
+import com.datastax.spark.connector.util.{Logging, SerialShutdownHooks}
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
-import org.apache.spark.{SparkConf, SparkContext, SparkFiles}
+import org.apache.spark.{SparkConf, SparkContext}
 
 import scala.collection.JavaConverters._
 import scala.language.reflectiveCalls
@@ -65,14 +64,8 @@ class CassandraConnector(val conf: CassandraConnectorConf)
   def hosts: Set[InetSocketAddress] =
     // wrapped in a session, so we get full lists of hosts,
     // not only those explicitly passed in the conf
-    withSessionDo {
-      _.getMetadata
-        .getNodes
-        .values
-        .asScala
-        .filter(_.getDistance == NodeDistance.LOCAL)
-        .flatMap(DriverUtil.toAddress)
-        .toSet
+    withSessionDo { session =>
+      dataCenterNodes(_config, session)
     }
 
   private[connector] def hostAddresses: Set[InetAddress] = hosts.map(_.getAddress)
@@ -187,14 +180,14 @@ object CassandraConnector extends Logging {
     logInfo(s"Disconnected from Cassandra cluster.")
   }
 
-  private def dataCenterNodes(conf: CassandraConnectorConf, ipConf: IpBasedContactInfo, session: CqlSession): Set[InetSocketAddress] = {
+  // LocalNodeFirstLoadBalancingPolicy assigns LOCAL or REMOTE (i.e. non-IGNORED) distance to local DC nodes
+  private def dataCenterNodes(conf: CassandraConnectorConf, session: CqlSession): Set[InetSocketAddress] = {
     val allNodes = session.getMetadata.getNodes.asScala.values.toSet
-    val dcToUse = conf.localDC.getOrElse(LocalNodeFirstLoadBalancingPolicy.determineDataCenter(ipConf.hosts, allNodes))
     val nodes = allNodes
-      .collect { case n if n.getDatacenter == dcToUse => toAddress(n) }
-      .flatten
+      .filter(_.getDistance != NodeDistance.IGNORED)
+      .flatMap(toAddress)
     if (nodes.isEmpty) {
-      throw new ConnectorConfigurationException(s"Could not determine suitable nodes for DC: $dcToUse and known nodes: " +
+      throw new ConnectorConfigurationException(s"Could not determine suitable nodes in local DC for known nodes: " +
         s"${allNodes.map(n => (n.getHostId, toAddress(n))).mkString(", ")}")
     }
     nodes
@@ -204,7 +197,7 @@ object CassandraConnector extends Logging {
   private def alternativeConnectionConfigs(conf: CassandraConnectorConf, session: CqlSession): Set[CassandraConnectorConf] = {
     conf.contactInfo match {
       case ipConf: IpBasedContactInfo =>
-        val nodes = dataCenterNodes(conf, ipConf, session)
+        val nodes = dataCenterNodes(conf, session)
         nodes.map(n => conf.copy(contactInfo = ipConf.copy(hosts = Set(n)))) + conf.copy(contactInfo = ipConf.copy(hosts = nodes))
       case _ => Set.empty
     }


### PR DESCRIPTION
# Description

## How did the Spark Cassandra Connector Work or Not Work Before this Patch

`repartitionByCassandraReplica` relocates data to the local(-host) node only, whereas it should relocate data over all the nodes of the local DC instead.

When running `repartitionByCassandraReplica` on a machine where:
- a local node exists, then it relocates the entire data to this single node.
- no local node exist (e.g. with nodes being on remote machines, or with a containerized node with an isolated IP on the local machine), then it always returns an empty RDD without throwing any exception.

## General Design of the patch

The problem is caused by the [reconfiguration](https://github.com/datastax/spark-cassandra-connector/commit/3f891f8c25283eb5fb19eac4407d847d5c8d8d94) of `CassandraConnectorConf` that handles new non-IP-based `ContactInfo`, as part of the v2.5.0 pre-release.

In order to determine the local DC nodes, the nodes retrieved from the cassandra session are [filtered](https://github.com/datastax/spark-cassandra-connector/commit/3f891f8c25283eb5fb19eac4407d847d5c8d8d94#diff-ea855a77ea29f5a80329c44d5823660a3f600bd5b4abaf63f9dc3832e1db062fR73) to select only LOCAL-distance nodes. This is, in effect, selecting the localhost node only, not all the nodes of the local DC as would be expected.

The confusion may come from the fact that:
- according to the default load-balancing policy provided by the cassandra java driver, `LOCAL` nodes are nodes in the local DC, `REMOTE` nodes are nodes in other DCs ([BasicLoadBalancingPolicy](https://github.com/datastax/java-driver/blob/4.x/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicy.java#L401))
- whereas according to the load-balancing policy used by the spark cassandra connector, the `LOCAL` node is the localhost node, `REMOTE` nodes are other nodes in the local DC, all nodes in other DCs are `IGNORED` ([LocalNodeFirstLoadBalancingPolicy](https://github.com/datastax/spark-cassandra-connector/blob/master/driver/src/main/scala/com/datastax/spark/connector/cql/LocalNodeFirstLoadBalancingPolicy.scala#L49))

This difference may be confusing, but is acceptable considering that it is up to each policy implementation to determine how it handles the `NodeDistance` it assigns to nodes.

This PR fixes the issue by selecting non-`IGNORED` (i.e. `LOCAL` + `REMOTE`) nodes as expected, instead of `LOCAL` node only.

Moreover, it puts the determination of the local DC nodes back into the existing method `dataCenterNodes()` of class `CassandraConnector` (it is in fact how it was designed before the problematical commit). This refactoring has two benefits:
- it avoids the repeated calls to the method `LocalNodeFirstLoadBalancingPolicy.determineDataCenter()`, in order to determine the local DC, each time the method `dataCenterNodes()` is called
- it throws an `ConnectorConfigurationException` when no node in the local DC is found

Lastly, it cleans up an unused piece of code, which was instantiating an unused `ReplicaLocator` in the RDD function `repartitionByCassandraReplica` (it seems to be a legacy code copied from the RDD function `keyByCassandraReplica`). `repartitionByCassandraReplica` uses a `ReplicaPartitioner` instead, which is referencing the (currently wrong) set of local DC nodes as described previously.

Fixes: [SPARKC-642](https://datastax-oss.atlassian.net/browse/SPARKC-642)

# How Has This Been Tested?

I discovered this bug by running `repartitionByCassandraReplica` on my local machine with a containerized cassandra node, and noticing that an empty RDD is always returned as described above.

Note that integration tests that are testing method `repartitionByCassandraReplica` in `RDDSpec` currently only check the number of output partitions on the basis of the number of nodes determined by `CassandraConnector`, but they do not check that this number of nodes is actually the one expected, which is why the tests pass, but with a wrong number of nodes / partitions.

Designing suitable integration tests, in order to correctly check this, would probably require digging into some CCM setups, which is beyond my expertise.
Any contribution on this is welcome.

# Checklist:

- [x] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/projects/SPARKC)
- [x] I have performed a self-review of my own code
- [x] Locally all tests pass (make sure tests fail without your patch)
