### PR TITLE
SPARKC-635 fix per cluster settings with custom props

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
@@ -224,11 +224,12 @@ object CassandraConnectionFactory {
     deprecatedSince = "DSE 6.0.0"
   )
 
-
   def fromSparkConf(conf: SparkConf): CassandraConnectionFactory = {
-    conf.getOption(FactoryParam.name)
-      .map(ReflectionUtil.findGlobalObject[CassandraConnectionFactory])
-      .getOrElse(FactoryParam.default)
+    fromNameOrDefault(conf.getOption(FactoryParam.name))
   }
 
+  def fromNameOrDefault(factoryName: Option[String]): CassandraConnectionFactory = {
+    factoryName.map(ReflectionUtil.findGlobalObject[CassandraConnectionFactory])
+      .getOrElse(FactoryParam.default)
+  }
 }

--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraScanPartitionReaderFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraScanPartitionReaderFactory.scala
@@ -76,7 +76,7 @@ abstract class CassandraPartitionReaderBase
     scanner.close()
   }
 
-  protected def scanner = connector.connectionFactory.getScanner(readConf, connector.conf, columnNames)
+  protected val scanner = connector.connectionFactory.getScanner(readConf, connector.conf, columnNames)
 
   protected def columnNames = queryParts.selectedColumnRefs.map(_.selectedAs).toIndexedSeq
 


### PR DESCRIPTION
Custom connection factories are allowed to provide a set of custom
supported properties. These properties were omitted when provided
as a custom cluster setting (myCluster/my.custom.setting=cp2077).
This commit introduces custom connection properties support for
per-cluster settings.

Test factories are top level objects (not mocks, not inner classes)
because they have to be findable by SCC reflection mechanism.