### PR TITLE
SPARKC-642 fix TwoNodeCluster integration test setup

### DIFF
--- a/connector/src/it/scala/com/datastax/spark/connector/rdd/ReplicaRepartitionedCassandraRDDSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/rdd/ReplicaRepartitionedCassandraRDDSpec.scala
@@ -64,7 +64,7 @@ class ReplicaRepartitionedCassandraRDDSpec extends SparkCassandraITFlatSpecBase 
     val someCass = repart.joinWithCassandraTable(ks, tableName)
     someCass.partitions.foreach {
       case e: EndpointPartition =>
-        conn.hostAddresses should contain(e.endpoints.head)
+        conn.hostAddresses.map(_.getHostAddress) should contain(e.endpoints.head)
       case _ =>
         fail("Unable to get endpoints on repartitioned RDD, This means preferred locations will be broken")
     }

--- a/test-support/src/main/scala/com/datastax/spark/connector/ccm/mode/StandardModeExecutor.scala
+++ b/test-support/src/main/scala/com/datastax/spark/connector/ccm/mode/StandardModeExecutor.scala
@@ -81,18 +81,20 @@ private[mode] trait DefaultExecutor extends ClusterModeExecutor {
       })
 
       config.nodes.foreach { i =>
+        val node = s"node$i"
         val addArgs = Seq ("add",
-          "-s",
+          "-s", // every node is a seed node
+          "-b", // autobootstrap is enabled
           "-j", config.jmxPort(i).toString,
           "-i", config.ipOfNode(i),
           "--remote-debug-port=0") ++
           dseFlag :+
-          s"node$i"
+          node
 
         execute(addArgs: _*)
 
         if (config.dseEnabled && config.getDseVersion.exists(_.compareTo(V6_8_5) >= 0)) {
-          execute("updateconf", s"metadata_directory:${dir.toFile.getAbsolutePath}/metadata$i")
+          execute(node, "updateconf", s"metadata_directory:${dir.toFile.getAbsolutePath}/metadata$i")
         }
       }
 


### PR DESCRIPTION
ReplicaRepartitionedCassandraRDDSpec based on TwoNodeCluster was not
working for DSE 6.8 as this db version relies on metadata dir.
Before this change the metadata dir was shared among
all the nodes in the cluster (which caused Gossip failures that
eventually lead to test failure).
After this change all the nodes in the cluster use separate
metadata dirs.

Additionally, autoboostrapping is now enabled as all the nodes in
TwoNodeCluster need to have data from relevant parts of the token
ring.