### PR TITLE
SPARKC-647 UDTValue performance fix - reuse CassandraRowMetadata instead of building it for each row

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/UDTValue.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/UDTValue.scala
@@ -9,7 +9,12 @@ import com.datastax.spark.connector.types.NullableTypeConverter
 final case class UDTValue(columnNames: IndexedSeq[String], columnValues: IndexedSeq[AnyRef])
   extends ScalaGettableData {
 
-  @volatile private var metaData_ : Option[CassandraRowMetadata] = None
+  private var metaData_ : Option[CassandraRowMetadata] = None
+
+  lazy val metaData : CassandraRowMetadata = metaData_ match {
+    case Some(x) => x
+    case None => CassandraRowMetadata.fromColumnNames(columnNames)
+  }
 
   def this(metaData: CassandraRowMetadata, columnValues: IndexedSeq[AnyRef]) = {
     this(metaData.columnNames, columnValues)
@@ -18,13 +23,6 @@ final case class UDTValue(columnNames: IndexedSeq[String], columnValues: Indexed
 
   override def productArity: Int = columnValues.size
   override def productElement(i: Int) = columnValues(i)
-
-  override def metaData: CassandraRowMetadata = {
-    metaData_ match {
-      case Some(x) => x
-      case None => val x = CassandraRowMetadata.fromColumnNames(columnNames); metaData_ = Some(x); x
-    }
-  }
 }
 
 object UDTValue {

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/UserDefinedType.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/UserDefinedType.scala
@@ -8,10 +8,9 @@ import scala.reflect.runtime.universe._
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 
 import com.datastax.driver.core.{UDTValue => DriverUDTValue, UserType, DataType}
-import com.datastax.spark.connector.{ColumnName, UDTValue}
+import com.datastax.spark.connector.{CassandraRowMetadata, ColumnName, UDTValue}
 import com.datastax.spark.connector.cql.{StructDef, FieldDef}
 import com.datastax.spark.connector.util.CodecRegistryUtil
-import com.datastax.spark.connector.CassandraRowMetadata
 
 /** A Cassandra user defined type field metadata. It consists of a name and an associated column type.
   * The word `column` instead of `field` is used in member names because we want to treat UDT field

--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/UserDefinedType.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/types/UserDefinedType.scala
@@ -32,7 +32,7 @@ case class UserDefinedType(name: String, columns: IndexedSeq[UDTFieldDef])
   def cqlTypeName = name
 
   val fieldConverters = columnTypes.map(_.converterToCassandra)
-  private val metadata = CassandraRowMetadata.fromColumnNames(columnNames)
+  private lazy val metadata = CassandraRowMetadata.fromColumnNames(columnNames)
 
   def converterToCassandra = new NullableTypeConverter[UDTValue] {
     override def targetTypeTag = UDTValue.TypeTag

--- a/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSQLRow.scala
+++ b/spark-cassandra-connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSQLRow.scala
@@ -83,7 +83,7 @@ object CassandraSQLRow {
       case set: Set[_] => set.map(toSparkSqlType).toSeq
       case list: List[_] => list.map(toSparkSqlType)
       case map: Map[_, _] => map map { case(k, v) => (toSparkSqlType(k), toSparkSqlType(v))}
-      case udt: UDTValue => UDTValue(udt.columnNames, udt.columnValues.map(toSparkSqlType))
+      case udt: UDTValue => UDTValue(udt.metaData, udt.columnValues.map(toSparkSqlType))
       case tupleValue: TupleValue => TupleValue(tupleValue.values.map(toSparkSqlType): _*)
       case _ => value.asInstanceOf[AnyRef]
     }


### PR DESCRIPTION
# Description

## How did the Spark Cassandra Connector Work or Not Work Before this Patch

Slow UDTValue related work on saving to Cassandra:
saveToCassandra for 100K rows (about 100Mb) with cores = 1 (1 Spark thread) took 45 seconds
the UDT has about 50 fields.
spark.cassandra.output.batch.size.bytes = 63000
spark.cassandra.output.concurrent.writes = 160
scala case classes were used for both row and a UDT field.
the same results for Java Beans.

## General Design of the patch
asyncprofiler showed that the recalculation of 'metadata' (CassandraRowMetadata) in com.datastax.spark.connector.UDTValue for each row is burning CPU, because metadata is not reused.

At the same time there is a (unused?) class com.datastax.spark.connector.japi.UDTValue that receives CassandraRowMetadata as a constructor parameter.

I decided to align the approaches in those UDTValue classes. 

# How Has This Been Tested?

Unit tests were not executed. The jar (unshaded) was built and profiled on the env. For the same test the timing improved significantly - 9-10 sec instead of 45 sec.

# Checklist:

- [x] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/browse/SPARKC-647) - SPARKC-647
- [x] I have performed a self-review of my own code
- [x] Locally all tests pass (make sure tests fail without your patch) 
