### PR TITLE
SPARKC-647 UDTValue performance fix - reuse CassandraRowMetadata instead of building it for each row (b2.5)

### DIFF
--- a/connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSQLRow.scala
+++ b/connector/src/main/scala/org/apache/spark/sql/cassandra/CassandraSQLRow.scala
@@ -85,7 +85,7 @@ object CassandraSQLRow {
       case set: Set[_] => set.map(toSparkSqlType).toSeq
       case list: List[_] => list.map(toSparkSqlType)
       case map: Map[_, _] => map map { case(k, v) => (toSparkSqlType(k), toSparkSqlType(v))}
-      case udt: UDTValue => UDTValue(udt.columnNames, udt.columnValues.map(toSparkSqlType))
+      case udt: UDTValue => UDTValue(udt.metaData, udt.columnValues.map(toSparkSqlType))
       case tupleValue: TupleValue => TupleValue(tupleValue.values.map(toSparkSqlType): _*)
       case dateRange: DateRange => dateRange.toString
       case _ => value.asInstanceOf[AnyRef]
@@ -106,7 +106,7 @@ object CassandraSQLRow {
       case set: Set[_] => set.map(toUnsafeSqlType).toSeq
       case list: List[_] => list.map(toUnsafeSqlType)
       case map: Map[_, _] => map map { case(k, v) => (toUnsafeSqlType(k), toUnsafeSqlType(v))}
-      case udt: UDTValue => UDTValue(udt.columnNames, udt.columnValues.map(toUnsafeSqlType))
+      case udt: UDTValue => UDTValue(udt.metaData, udt.columnValues.map(toUnsafeSqlType))
       case tupleValue: TupleValue => TupleValue(tupleValue.values.map(toUnsafeSqlType): _*)
       case dateRange: DateRange => UTF8String.fromString(dateRange.toString)
       case instant: Instant => java.sql.Timestamp.from(instant)

--- a/driver/src/main/scala/com/datastax/spark/connector/UDTValue.scala
+++ b/driver/src/main/scala/com/datastax/spark/connector/UDTValue.scala
@@ -7,10 +7,25 @@ import com.datastax.spark.connector.util.DriverUtil.toName
 import scala.collection.JavaConversions._
 import scala.reflect.runtime.universe._
 
-final case class UDTValue(metaData: CassandraRowMetadata, columnValues: IndexedSeq[AnyRef])
+final case class UDTValue(columnNames: IndexedSeq[String], columnValues: IndexedSeq[AnyRef])
   extends ScalaGettableData {
+
+  @volatile private var metaData_ : Option[CassandraRowMetadata] = None
+
+  def this(metaData: CassandraRowMetadata, columnValues: IndexedSeq[AnyRef]) = {
+    this(metaData.columnNames, columnValues)
+    this.metaData_ = Some(metaData)
+  }
+
   override def productArity: Int = columnValues.size
   override def productElement(i: Int) = columnValues(i)
+
+  override def metaData: CassandraRowMetadata = {
+    metaData_ match {
+      case Some(x) => x
+      case None => val x = CassandraRowMetadata.fromColumnNames(columnNames); metaData_ = Some(x); x
+    }
+  }
 }
 
 object UDTValue {
@@ -18,11 +33,11 @@ object UDTValue {
   def fromJavaDriverUDTValue(value: DriverUDTValue): UDTValue = {
     val fields = value.getType.getFieldNames.map(f => toName(f)).toIndexedSeq
     val values = fields.map(GettableData.get(value, _))
-    UDTValue(CassandraRowMetadata.fromColumnNames(fields), values)
+    UDTValue(fields, values)
   }
 
   def fromMap(map: Map[String, Any]): UDTValue =
-    new UDTValue(CassandraRowMetadata.fromColumnNames(map.keys.toIndexedSeq), map.values.map(_.asInstanceOf[AnyRef]).toIndexedSeq)
+    new UDTValue(map.keys.toIndexedSeq, map.values.map(_.asInstanceOf[AnyRef]).toIndexedSeq)
 
   val TypeTag = implicitly[TypeTag[UDTValue]]
   val Symbol = typeOf[UDTValue].asInstanceOf[TypeRef].sym
@@ -33,4 +48,7 @@ object UDTValue {
       case x: UDTValue => x
     }
   }
+
+  def apply(metaData: CassandraRowMetadata, columnValues: IndexedSeq[AnyRef]): UDTValue =
+    new UDTValue(metaData, columnValues)
 }

--- a/driver/src/main/scala/com/datastax/spark/connector/UDTValue.scala
+++ b/driver/src/main/scala/com/datastax/spark/connector/UDTValue.scala
@@ -7,12 +7,10 @@ import com.datastax.spark.connector.util.DriverUtil.toName
 import scala.collection.JavaConversions._
 import scala.reflect.runtime.universe._
 
-final case class UDTValue(columnNames: IndexedSeq[String], columnValues: IndexedSeq[AnyRef])
+final case class UDTValue(metaData: CassandraRowMetadata, columnValues: IndexedSeq[AnyRef])
   extends ScalaGettableData {
   override def productArity: Int = columnValues.size
   override def productElement(i: Int) = columnValues(i)
-
-  override def metaData = CassandraRowMetadata.fromColumnNames(columnNames)
 }
 
 object UDTValue {
@@ -20,11 +18,11 @@ object UDTValue {
   def fromJavaDriverUDTValue(value: DriverUDTValue): UDTValue = {
     val fields = value.getType.getFieldNames.map(f => toName(f)).toIndexedSeq
     val values = fields.map(GettableData.get(value, _))
-    UDTValue(fields, values)
+    UDTValue(CassandraRowMetadata.fromColumnNames(fields), values)
   }
 
   def fromMap(map: Map[String, Any]): UDTValue =
-    new UDTValue(map.keys.toIndexedSeq, map.values.map(_.asInstanceOf[AnyRef]).toIndexedSeq)
+    new UDTValue(CassandraRowMetadata.fromColumnNames(map.keys.toIndexedSeq), map.values.map(_.asInstanceOf[AnyRef]).toIndexedSeq)
 
   val TypeTag = implicitly[TypeTag[UDTValue]]
   val Symbol = typeOf[UDTValue].asInstanceOf[TypeRef].sym

--- a/driver/src/main/scala/com/datastax/spark/connector/UDTValue.scala
+++ b/driver/src/main/scala/com/datastax/spark/connector/UDTValue.scala
@@ -10,7 +10,12 @@ import scala.reflect.runtime.universe._
 final case class UDTValue(columnNames: IndexedSeq[String], columnValues: IndexedSeq[AnyRef])
   extends ScalaGettableData {
 
-  @volatile private var metaData_ : Option[CassandraRowMetadata] = None
+  private var metaData_ : Option[CassandraRowMetadata] = None
+
+  lazy val metaData : CassandraRowMetadata = metaData_ match {
+    case Some(x) => x
+    case None => CassandraRowMetadata.fromColumnNames(columnNames)
+  }
 
   def this(metaData: CassandraRowMetadata, columnValues: IndexedSeq[AnyRef]) = {
     this(metaData.columnNames, columnValues)
@@ -19,13 +24,6 @@ final case class UDTValue(columnNames: IndexedSeq[String], columnValues: Indexed
 
   override def productArity: Int = columnValues.size
   override def productElement(i: Int) = columnValues(i)
-
-  override def metaData: CassandraRowMetadata = {
-    metaData_ match {
-      case Some(x) => x
-      case None => val x = CassandraRowMetadata.fromColumnNames(columnNames); metaData_ = Some(x); x
-    }
-  }
 }
 
 object UDTValue {

--- a/driver/src/main/scala/com/datastax/spark/connector/types/UserDefinedType.scala
+++ b/driver/src/main/scala/com/datastax/spark/connector/types/UserDefinedType.scala
@@ -37,7 +37,7 @@ case class UserDefinedType(
   def cqlTypeName = name
 
   val fieldConvereters = columnTypes.map(_.converterToCassandra)
-  private val metadata = CassandraRowMetadata.fromColumnNames(columnNames)
+  private lazy val metadata = CassandraRowMetadata.fromColumnNames(columnNames)
 
   private lazy val valueByNameConverter = scala.util.Try(TypeConverter.forType[ValueByNameAdapter]).toOption
 

--- a/driver/src/main/scala/com/datastax/spark/connector/types/UserDefinedType.scala
+++ b/driver/src/main/scala/com/datastax/spark/connector/types/UserDefinedType.scala
@@ -7,7 +7,7 @@ import com.datastax.oss.driver.api.core.data.{UdtValue => DriverUDTValue}
 import com.datastax.spark.connector.cql.{FieldDef, StructDef}
 import com.datastax.spark.connector.types.ColumnType.fromDriverType
 import com.datastax.spark.connector.types.TypeAdapters.ValueByNameAdapter
-import com.datastax.spark.connector.{ColumnName, UDTValue}
+import com.datastax.spark.connector.{CassandraRowMetadata, ColumnName, UDTValue}
 
 import scala.collection.JavaConversions._
 import scala.reflect.runtime.universe._
@@ -37,6 +37,7 @@ case class UserDefinedType(
   def cqlTypeName = name
 
   val fieldConvereters = columnTypes.map(_.converterToCassandra)
+  private val metadata = CassandraRowMetadata.fromColumnNames(columnNames)
 
   private lazy val valueByNameConverter = scala.util.Try(TypeConverter.forType[ValueByNameAdapter]).toOption
 
@@ -51,7 +52,7 @@ case class UserDefinedType(
             val columnValue = columnConverter.convert(udtValue.getRaw(columnName))
             columnValue
           }
-        new UDTValue(columnNames, columnValues)
+        new UDTValue(metadata, columnValues)
       case value if valueByNameConverter.exists(_.convertPF.isDefinedAt(value)) =>
         val valuesByName = valueByNameConverter.get.convert(value)
         val columnValues =
@@ -61,14 +62,14 @@ case class UserDefinedType(
             val columnValue = columnConverter.convert(valuesByName.getByName(columnName))
             columnValue
           }
-        new UDTValue(columnNames, columnValues)
+        new UDTValue(metadata, columnValues)
     }
   }
 
   override type ValueRepr = UDTValue
 
   override def newInstance(columnValues: Any*): UDTValue = {
-    UDTValue(columnNames, columnValues.map(_.asInstanceOf[AnyRef]).toIndexedSeq)
+    UDTValue(metadata, columnValues.map(_.asInstanceOf[AnyRef]).toIndexedSeq)
   }
 }
 


### PR DESCRIPTION
# Description

## How did the Spark Cassandra Connector Work or Not Work Before this Patch

Slow UDTValue related work on saving to Cassandra:
saveToCassandra for 100K rows (about 100Mb) with cores = 1 (1 Spark thread) took 45 seconds
the UDT has about 50 fields.
spark.cassandra.output.batch.size.bytes = 63000
spark.cassandra.output.concurrent.writes = 160
scala case classes were used for both row and a UDT field.
the same results for Java Beans.

## General Design of the patch
asyncprofiler showed that the recalculation of 'metadata' (CassandraRowMetadata) in com.datastax.spark.connector.UDTValue for each row is burning CPU, because metadata is not reused.

At the same time there is a (unused?) class com.datastax.spark.connector.japi.UDTValue that receives CassandraRowMetadata as a constructor parameter.

I decided to align the approaches in those UDTValue classes. 

# How Has This Been Tested?

Unit tests were not executed. The jar (unshaded) was built and profiled on the env. For the same test the timing improved significantly - 9-10 sec instead of 45 sec.

# Checklist:

- [x] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/browse/SPARKC-647) - SPARKC-647
- [x] I have performed a self-review of my own code
- [x] Locally all tests pass (make sure tests fail without your patch) - sbt test and it:test were fine
