### PR TITLE
Upgrade Datastax Java driver to the latest version: 4.11.1

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -5,7 +5,7 @@ object Versions {
   val CommonsLang3    = "3.5"
   val Paranamer       = "2.8"
 
-  val DataStaxJavaDriver = "4.10.0"
+  val DataStaxJavaDriver = "4.11.1"
 
   val ScalaCheck      = "1.14.0"
   val ScalaTest       = "3.0.8"


### PR DESCRIPTION
# Description

Upgrade the Java driver to the latest version. 

This is needed to take care of [JAVA-2936](https://datastax-oss.atlassian.net/browse/JAVA-2936) 

## How did the Spark Cassandra Connector Work or Not Work Before this Patch

## General Design of the patch

# How Has This Been Tested?

Standard Test cases

# Checklist:

Note: This is a cherry-pick of the pull request to the master branch: https://github.com/datastax/spark-cassandra-connector/pull/1310