### PR TITLE
SPARKC-656 update java driver to 4.12.0

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -5,7 +5,7 @@ object Versions {
   val CommonsLang3    = "3.5"
   val Paranamer       = "2.8"
 
-  val DataStaxJavaDriver = "4.10.0"
+  val DataStaxJavaDriver = "4.12.0"
 
   val ScalaCheck      = "1.14.0"
   val ScalaTest       = "3.0.8"


### PR DESCRIPTION
This should fix JAVA-2936 that we observe in our
performance tests.