### PR TITLE
SPARKC-657 Bump DSE & OSS C* versions to current patch/RC releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         scala:  [2.12.10]
-        db-version: [6.8.9, 3.11.9, 4.0-beta4]
+        db-version: [6.8.13, 5.1.24, 3.11.10, 4.0-RC1]
 
     steps:
       - uses: actions/checkout@v2

--- a/doc/developers.md
+++ b/doc/developers.md
@@ -39,7 +39,7 @@ b2.5 feature branch to b3.0 feature branch. Repeat for master.
 
 Example for imaginary SPARKC-9999.
 
-Let's assume that `datastax` is git@github.com:datastax/spark-cassandra-connector.git remote 
+Let's assume that `datastax` is `git@github.com:datastax/spark-cassandra-connector.git` remote
 and origin is your personal clone.
 ```shell
 $ git remote -v


### PR DESCRIPTION
# Description

## How did the Spark Cassandra Connector Work or Not Work Before this Patch
N/A as it worked correctly on older patch/RC versions of DSE & OSS C*

Describe the problem, or state of the project that this patch fixes. Explain
why this is a problem if this isn't obvious.
Testing the latest patch release versions for compatibility

## General Design of the patch
N/A

How the fix is accomplished, were new parameters or classes added? Why did you
pursue this particular fix?
Updated the GHA to test with latest versions

Fixes: [SPARKC-657](https://datastax-oss.atlassian.net/browse/SPARKC-657)

# How Has This Been Tested?

Almost all changes and especially bug fixes will require a test to be added to either the integration or Unit Tests. Any tests added will be automatically run on travis when the pull request is pushed to github. Be sure to run suites locally as well.

<details>
    <summary>Click here to expand/collapse the local testing console output</summary>

    ```
    % ./sbt/sbt test
    Attempting to fetch sbt
    ############################################################################################################################################################################################################ 100.0%
    Launching sbt from sbt/sbt-launch-1.3.3.jar
    Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=350m; support was removed in 8.0
    [info] Loading settings for project spark-cassandra-connector-build from updates.sbt,plugins.sbt ...
    [info] Loading project definition from /Users/madhavansridharan/Data/Tools/sperf_and_nibbler/spark-cassandra-connector/project
    [info] Updating ProjectRef(uri("file:/Users/madhavansridharan/Data/Tools/sperf_and_nibbler/spark-cassandra-connector/project/"), "spark-cassandra-connector-build")...
    [info] Done updating.
    [warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
    [info] Compiling 4 Scala sources to /Users/madhavansridharan/Data/Tools/sperf_and_nibbler/spark-cassandra-connector/project/target/scala-2.12/sbt-1.0/classes ...
    [warn] there was one feature warning; re-run with -feature for details
    [warn] one warning found
    [info] Done compiling.
    [info] Loading settings for project root from build.sbt ...
    Using Some(releases: https://oss.sonatype.org/service/local/staging/deploy/maven2) for publishing
    Reading credentials from None
    Running 10 Parallel Tasks
    [info] Set current project to root (in build file:/Users/madhavansridharan/Data/Tools/sperf_and_nibbler/spark-cassandra-connector/)
    [warn] Credentials file /Users/madhavansridharan/.ivy2/.credentials does not exist
    [warn] Credentials file /Users/madhavansridharan/.ivy2/.credentials does not exist
    [warn] Credentials file /Users/madhavansridharan/.ivy2/.credentials does not exist
    [warn] Credentials file /Users/madhavansridharan/.sbt/credentials does not exist
    [warn] Credentials file /Users/madhavansridharan/.sbt/credentials does not exist
    [warn] Credentials file /Users/madhavansridharan/.sbt/credentials.deploy does not exist
    [warn] Credentials file /Users/madhavansridharan/.sbt/credentials.deploy does not exist
    [warn] Credentials file /Users/madhavansridharan/.sbt/credentials does not exist
    [warn] Credentials file /Users/madhavansridharan/.sbt/credentials.deploy does not exist
    [warn] Credentials file /Users/madhavansridharan/.ivy2/.credentials does not exist
    [warn] Credentials file /Users/madhavansridharan/.sbt/credentials does not exist
    [warn] Credentials file /Users/madhavansridharan/.sbt/credentials.deploy does not exist
    [info] Updating driver...
    [info] Updating testSupport...
    [info] Updating publishableAssembly...
    [info] Updating ...
    [info] Done updating.
    [info] downloading https://repo1.maven.org/maven2/com/datastax/oss/java-driver-core-shaded/4.12.0/java-driver-core-shaded-4.12.0.jar ...
    [info] downloading https://repo1.maven.org/maven2/com/datastax/oss/java-driver-mapper-runtime/4.12.0/java-driver-mapper-runtime-4.12.0.jar ...
    [info] downloading https://repo1.maven.org/maven2/com/datastax/oss/java-driver-query-builder/4.12.0/java-driver-query-builder-4.12.0.jar ...
    [info] downloading https://repo1.maven.org/maven2/com/datastax/oss/java-driver-mapper-processor/4.12.0/java-driver-mapper-processor-4.12.0.jar ...
    [info] 	[SUCCESSFUL ] com.datastax.oss#java-driver-mapper-runtime;4.12.0!java-driver-mapper-runtime.jar(bundle) (508ms)
    [info] 	[SUCCESSFUL ] com.datastax.oss#java-driver-mapper-processor;4.12.0!java-driver-mapper-processor.jar (565ms)
    [info] 	[SUCCESSFUL ] com.datastax.oss#java-driver-query-builder;4.12.0!java-driver-query-builder.jar(bundle) (566ms)
    [info] 	[SUCCESSFUL ] com.datastax.oss#java-driver-core-shaded;4.12.0!java-driver-core-shaded.jar (782ms)
    [info] Done updating.
    [warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
    [info] Compiling 50 Scala sources to /Users/madhavansridharan/Data/Tools/sperf_and_nibbler/spark-cassandra-connector/driver/target/scala-2.12/classes ...
    [info] Done updating.
    [warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
    [info] Compiling 7 Scala sources to /Users/madhavansridharan/Data/Tools/sperf_and_nibbler/spark-cassandra-connector/test-support/target/scala-2.12/classes ...
    [info] Done updating.
    [warn] Credentials file /Users/madhavansridharan/.ivy2/.credentials does not exist
    [warn] Credentials file /Users/madhavansridharan/.sbt/credentials does not exist
    [warn] Credentials file /Users/madhavansridharan/.sbt/credentials.deploy does not exist
    [info] Updating connector...
    [info] Done updating.
    [warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
    [warn] there was one feature warning; re-run with -feature for details
    [warn] one warning found
    [info] Done compiling.
    [warn] there were 8 deprecation warnings
    [warn] there were 17 deprecation warnings (since 2.12.0)
    [warn] there were 25 deprecation warnings in total; re-run with -deprecation for details
    [warn] there were two feature warnings; re-run with -feature for details
    [warn] four warnings found
    [info] Done compiling.
    [info] Compiling 19 Scala sources and 1 Java source to /Users/madhavansridharan/Data/Tools/sperf_and_nibbler/spark-cassandra-connector/driver/target/scala-2.12/test-classes ...
    [info] Compiling 147 Scala sources and 15 Java sources to /Users/madhavansridharan/Data/Tools/sperf_and_nibbler/spark-cassandra-connector/connector/target/scala-2.12/classes ...
    [warn] /Users/madhavansridharan/Data/Tools/sperf_and_nibbler/spark-cassandra-connector/connector/src/main/scala/com/datastax/spark/connector/datasource/CassandraSourceUtil.scala:237:32: non-variable type argument String in type pattern scala.collection.immutable.Map[String,String] (the underlying of Map[String,String]) is unchecked since it is eliminated by erasure
    [warn]       case (k: String, innerM: Map[String, String]) => s"$k='${mapToString(innerM)}'"
    [warn]                                ^
    [warn] /Users/madhavansridharan/Data/Tools/sperf_and_nibbler/spark-cassandra-connector/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinExec.scala:68:60: match may not be exhaustive.
    [warn] It would fail on the following input: (_, _)
    [warn]   val (joinColumns, joinExpressions) = pkJoinCoulplets.map { case (cAttr: Attribute, otherCol: Expression) =>
    [warn]                                                            ^
    [warn] /Users/madhavansridharan/Data/Tools/sperf_and_nibbler/spark-cassandra-connector/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinExec.scala:217:11: match may not be exhaustive.
    [warn] It would fail on the following input: (_, _)
    [warn]       .map{ case (colref: Attribute, exp) => s"${exprIdToCassandra(colref.exprId)} = ${exp}"}
    [warn]           ^
    [warn] there were two deprecation warnings; re-run with -deprecation for details
    [warn] one warning found
    [info] Done compiling.
    [info] CassandraRowTest:
    [info] - basicAccessTest
    [info] - nullAccessTest
    [info] - NoneAccessTest
    [info] - nullToStringTest
    [info] - nonExistentColumnAccessTest
    [info] - primitiveConversionTest
    [info] - collectionConversionTest
    [info] - serializationTest
    SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
    SLF4J: Defaulting to no-operation (NOP) logger implementation
    SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
    [info] MultiplexingSchemaListenerTest:
    [info] MutableSchemaListener
    [info] - should allow adding or removing listeners
    [info] - should work with 0 listeners
    [info] - should work with 1 listeners
    [info] - should work with 2 listeners
    [info] - should work with 3 listeners
    [info] - should work with 4 listeners
    [info] - should work with 5 listeners
    [info] - should work with 6 listeners
    [info] - should work with 7 listeners
    [info] - should work with 8 listeners
    [info] - should work with 9 listeners
    [info] - should work with 10 listeners
    [info] - should allow listeners to be added while triggering events
    [info] LocalNodeFirstLoadBalancingPolicySpec:
    [info] - should set distance to LOCAL for local node in local dc
    [info] - should set distance to IGNORED for local node in different dc
    [info] - should set distance to REMOTE for remote nodes
    [info] - should apply configured node filter
    [info] TimestampParserSpec:
    [info] - should parse fast all supported date[time[zone]] formats
    [info] GettableDataToMappedTypeConverterSpec:
    [info] GettableDataToMappedTypeConverter
    [warn] there were two deprecation warnings
    [warn] there were 24 deprecation warnings (since 2.12.0)
    [warn] there were 26 deprecation warnings in total; re-run with -deprecation for details
    [warn] there were 10 feature warnings; re-run with -feature for details
    [warn] 7 warnings found
    [info] - should be Serializable
    [info] - should convert a CassandraRow to a case class object
    [info] - should convert a CassandraRow to a case class object after being serialized/deserialized
    [info] - should convert a CassandraRow to a tuple
    [info] - should convert a CassandraRow to a tuple in reversed order
    [info] - should convert a CassandraRow to a tuple with a subset of columns
    [info] - should convert a UDTValue to a case class object
    [info] - should convert a TupleValue to a Scala tuple
    [info] - should allow for nesting UDTValues inside of TupleValues
    [info] - should allow for nesting TupleValues inside of UDTValues
    [info] - should convert nulls to Scala Nones
    [info] - should convert using custom column aliases
    [info] - should set property values with setters
    [info] - should apply proper type conversions for columns
    [info] - should convert a CassandraRow with a UDTValue into nested case class objects
    [info] - should convert a CassandraRow with a UDTValue into a case class with a nested tuple
    [info] - should convert a CassandraRow with an optional UDTValue
    [info] - should convert a CassandraRow with a list of UDTValues
    [info] - should convert a CassandraRow with a set of UDTValues
    [info] - should convert a CassandraRow with a collection of UDTValues
    [info] - should convert a CassandraRow with a collection of tuples
    [info] - should convert a CassandraRow to a JavaBean
    [info] - should convert a CassandraRow with UDTs to nested JavaBeans
    [info] - should convert a CassandraRow with UDTs with Long null values to nested JavaBeans
    [info] - should throw a meaningful exception when a column type is not supported
    [info] - should throw a meaningful exception when a column value fails to be converted
    [info] - should throw NPE with a meaningful message when a column value is null
    [info] - should throw NPE when trying to access its targetTypeTag after serialization/deserialization
    [info] MultipleRetryPolicySpec:
    [info] MultipleRetryPolicy
    [info] - should retry always if maxRetry is -1
    [info] - should not retry past maxRetry
    [info] - should not retry authentication errors
    [info] - should retry all of our accepted exceptions
    [info] ColumnTypeSpec:
    [info] A ColumnType companion object
    [info] - should throw InvalidArgumentException if given unsupported type
    [info]   should allow to obtain a proper ColumnType
    [info]   - when given a Boolean should return BooleanType
    [info]   - when given a java.lang.Boolean should return BooleanType
    [info]   - when given an Int should return IntType
    [info]   - when given an java.lang.Integer should return IntType
    [info]   - when given a Long should return BigIntType
    [info]   - when given a java.lang.Long should return BigIntType
    [info]   - when given a Float should return FloatType
    [info]   - when given a java.lang.Float should return FloatType
    [info]   - when given a Double should return DoubleType
    [info]   - when given a java.lang.Double should return DoubleType
    [info]   - when given a String should return VarcharType
    [info]   - when given a java.lang.Short should return a SmallIntType
    [info]   - when given a Short should return a SmallIntType
    [info]   - when given a Byte should return a TinyIntType
    [info]   - when given a java.lang.Byte should return a TinyIntType
    [info]   - when given a java.lang.Short and PV3 should return a IntType
    [info]   - when given a Short and PV3 should return a IntType
    [info]   - when given a Byte and PV3 should return a IntType
    [info]   - when given a java.lang.Byte and PV3 should return a IntType
    [info]   - when given a java.util.Date should return TimestampType
    [info]   - when given a java.sql.Date should return DateType
    [info]   - when given a java.sql.Date and a pre V4 Protcol version should return a TimestampType
    [info]   - when given a ByteBuffer should return BlobType
    [info]   - when given an Array[Byte] should return BlobType
    [info]   - when given an UUID should return UUIDType
    [info]   - when given a List[String] should return ListType(VarcharType)
    [info]   - when given a Set[InetAddress] should return SetType(InetType)
    [info]   - when given a Map[Int, Date] should return MapType(IntType, TimestampType)
    [info]   - when given an Option[Int] should return IntType
    [info]   - when given an Option[Vector[Int]] should return ListType(IntType)
    [info] TableDefSpec:
    [info] A TableDef#cql method
    [info]   should produce valid CQL
    [info]   - when it contains no clustering columns
    [info]   - when it contains clustering columns
    [info]   - when it contains compound partition key and multiple clustering columns
    [info]   - when it contains a column of a collection type
    [info]   - when it contains compound partition key, if not exists, multiple clustering columns with sorting and options
    [info] MappedToGettableDataConverterSpec:
    [info] MappedToGettableDataConverter
    [info] - should be Serializable
    [info] - should convert a simple case class to a CassandraRow
    [info] - should convert a simple case class to a UDTValue
    [info] - should convert a Scala tuple to a TupleValue
    [info] - should convert nested classes
    [info] - should convert a nested UDTValue to a UDTValue
    [info] - should convert user defined types nested in collections
    [info] - should convert user defined types nested in tuples
    [info] - should convert tuples nested in user defined types
    [info] - should convert nulls to Scala Nones
    [info] - should convert None case class to null
    [info] - should convert Some case class to UDT
    [info] - should convert using custom column aliases
    [info] - should convert a java bean to a CassandraRow
    [info] - should convert nested JavaBeans
    [info] - should convert commons-lang3 Pairs to TupleValues
    [info] - should convert commons-lang3 Triples to TupleValues
    [info] - should throw a meaningful exception when a column has an incorrect type
    [info] - should throw a meaningful exception when a tuple field has an incorrect number of components
    [info] - should work after serialization/deserialization
    [info] ColumnRefSpec:
    [info] A FunctionCallRef should
    [info] - should generate its equivalent CQL code for: f()
    [info] - should generate its equivalent CQL code for: f(3)
    [info] - should generate its equivalent CQL code for: f("col01")
    [info] - should generate its equivalent CQL code for: f("col01","col02")
    [info] - should generate its equivalent CQL code for: f("col01",1,"hello")
    [info] - should generate its equivalent CQL code for: g("col01",f("col02",1,"hello"))
    [info] - should be able to provide a list of columns used as actual parameters by: f()
    [info] - should be able to provide a list of columns used as actual parameters by: f(3)
    [info] - should be able to provide a list of columns used as actual parameters by: f("col01")
    [info] - should be able to provide a list of columns used as actual parameters by: f("col01","col02")
    [info] - should be able to provide a list of columns used as actual parameters by: f("col01",1,"hello")
    [info] - should be able to provide a list of columns used as actual parameters by: g("col01",f("col02",1,"hello"))
    [info] ReflectionUtilSpec:
    [info] ReflectionUtil.findGlobalObject
    [info] - should be able to find a global object
    [info] - should be able to find a global object in a multi-threaded context
    [info] - should be able to instantiate a singleton object based on Java class name
    [info] - should cache Java class instances
    [info] - should throw IllegalArgumentException when asked for a Scala object of wrong type
    [info] - should throw IllegalArgumentException when asked for class instance of wrong type
    [info] - should throw IllegalArgumentException when object does not exist
    [info] ReflectionUtil.constructorParams
    [info] - should return proper constructor param names and types for a class with a single constructor
    [info] - should return main constructor's param names and types for a class with multiple constructors
    [info] ReflectionUtil.getters
    [info] - should return getter names and types
    [info] ReflectionUtil.setters
    [info] - should return setter names and types
    [info] ReflectionUtil.methodParamTypes
    [info] - should return method param types
    [info] - should return proper method param types for generic type
    [info] - should throw IllegalArgumentException if the requested method is missing
    [info] CollectionColumnTypeSpec:
    [info] ListType
    [info] - should mark nested UDT types as frozen
    [info] - should not mark non UDT types as frozen
    [info] SetType
    [info] - should mark nested UDT types as frozen
    [info] - should not mark non UDT types as frozen
    [info] MapType
    [info] - should mark key UDT types as frozen
    [info] - should mark value UDT types as frozen
    [info] Test run started
    [info] Test com.datastax.spark.connector.mapper.PropertyExtractorTest.testSimpleExtraction started
    [info] Test com.datastax.spark.connector.mapper.PropertyExtractorTest.testWrongPropertyName started
    [info] Test com.datastax.spark.connector.mapper.PropertyExtractorTest.testAvailableProperties started
    [info] Test run finished: 0 failed, 0 ignored, 3 total, 0.011s
    [info] Test run started
    [info] Test com.datastax.spark.connector.types.CanBuildFromTest.testBuild started
    [info] Test com.datastax.spark.connector.types.CanBuildFromTest.testSerializeAndBuild started
    [info] Test com.datastax.spark.connector.types.CanBuildFromTest.testSerializeAndBuildWithOrdering started
    [info] Test run finished: 0 failed, 0 ignored, 3 total, 0.006s
    [info] Test run started
    [info] Test com.datastax.spark.connector.mapper.TupleColumnMapperTest.testIncompleteConstructor started
    [info] Test com.datastax.spark.connector.mapper.TupleColumnMapperTest.testIncompleteGetters started
    [info] Test com.datastax.spark.connector.mapper.TupleColumnMapperTest.testGetters started
    [info] Test com.datastax.spark.connector.mapper.TupleColumnMapperTest.testSerialize started
    [info] Test com.datastax.spark.connector.mapper.TupleColumnMapperTest.testImplicit started
    [info] Test com.datastax.spark.connector.mapper.TupleColumnMapperTest.testConstructor started
    [info] Test com.datastax.spark.connector.mapper.TupleColumnMapperTest.testNewTable started
    [info] Test run finished: 0 failed, 0 ignored, 7 total, 0.022s
    [info] Test run started
    [info] Test com.datastax.spark.connector.types.TypeSerializationTest.testSerializationOfCollectionTypes started
    [info] Test com.datastax.spark.connector.types.TypeSerializationTest.testSerializationOfPrimitiveTypes started
    [info] Test run finished: 0 failed, 0 ignored, 2 total, 0.02s
    [info] Test run started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testJavaDouble started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testInetAddress started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testYearLocalDate started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testSerializeMapConverter started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testJavaInteger started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testChainedConverters started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testLocalTimeType started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testTreeMap started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testTreeSet started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testInt started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testMap started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testSet started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testByteArray started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testBigDecimal started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testFloat started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testDate started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testList started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testLong started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testPair started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testUUID started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testParsableDate started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testTypeAliases started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testCalendar1 started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testCalendar2 started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testLocalDate started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testJavaDurationTypeTag started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testJavaBigDecimal started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testJavaInstantTypeTag started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testBoolean started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testJavaFloat started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testUnsupportedType started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testRegisterCustomConverterExtension started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testJavaBigInteger started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testJavaList started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testJavaLong started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testCassandraOption started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testJavaBoolean started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testTimestamp started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testRegisterCustomConverter started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testSerializeCollectionConverter started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testCassandraOptionToNull started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testBigInt started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testChainedConverterSerializability started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testDouble started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testJavaHashMap started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testJavaHashSet started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testJavaMapping started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testOption started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testString started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testTriple started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testOptionToNullConverter started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testJavaArrayList started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testSqlDate started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testJavaMap started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testJavaSet started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testJavaLocalDate started
    [info] Test com.datastax.spark.connector.types.TypeConverterTest.testJavaLocalTime started
    [info] Test run finished: 0 failed, 0 ignored, 57 total, 0.146s
    [info] Test run started
    [info] Test com.datastax.spark.connector.mapper.JavaBeanColumnMapperTest.testWorkWithAliasesAndHonorOverrides started
    [info] Test com.datastax.spark.connector.mapper.JavaBeanColumnMapperTest.testSerializeColumnMap started
    [info] Test com.datastax.spark.connector.mapper.JavaBeanColumnMapperTest.testGetters started
    [info] Test com.datastax.spark.connector.mapper.JavaBeanColumnMapperTest.testColumnNameOverrideSetters started
    [info] Test com.datastax.spark.connector.mapper.JavaBeanColumnMapperTest.testImplicit started
    [info] Test com.datastax.spark.connector.mapper.JavaBeanColumnMapperTest.testSetters started
    [info] Test com.datastax.spark.connector.mapper.JavaBeanColumnMapperTest.testGettersWithUDT started
    [info] Test com.datastax.spark.connector.mapper.JavaBeanColumnMapperTest.testWorkWithAliases started
    [info] Test com.datastax.spark.connector.mapper.JavaBeanColumnMapperTest.testColumnNameOverrideGetters started
    [info] Test run finished: 0 failed, 0 ignored, 9 total, 0.019s
    [info] Test run started
    [info] Test com.datastax.spark.connector.mapper.DefaultColumnMapperTest.testSetters1 started
    [info] Test com.datastax.spark.connector.mapper.DefaultColumnMapperTest.testSetters2 started
    [info] Test com.datastax.spark.connector.mapper.DefaultColumnMapperTest.columnNameOverrideConstructor started
    [info] Test com.datastax.spark.connector.mapper.DefaultColumnMapperTest.testGetters1 started
    [info] Test com.datastax.spark.connector.mapper.DefaultColumnMapperTest.testGetters2 started
    [info] Test com.datastax.spark.connector.mapper.DefaultColumnMapperTest.testWorkWithAliasesAndHonorOverrides started
    [info] Test com.datastax.spark.connector.mapper.DefaultColumnMapperTest.columnNameOverrideGetters started
    [info] Test com.datastax.spark.connector.mapper.DefaultColumnMapperTest.testNotEnoughPropertiesForWriting started
    [info] Test com.datastax.spark.connector.mapper.DefaultColumnMapperTest.testNewTableForClassWithVars started
    [info] Test com.datastax.spark.connector.mapper.DefaultColumnMapperTest.testNewTableForEmptyClass started
    [info] Test com.datastax.spark.connector.mapper.DefaultColumnMapperTest.testConstructorParams1 started
    [info] Test com.datastax.spark.connector.mapper.DefaultColumnMapperTest.testConstructorParams2 started
    [info] Test com.datastax.spark.connector.mapper.DefaultColumnMapperTest.testNotEnoughColumnsSelectedForReading started
    [info] Test com.datastax.spark.connector.mapper.DefaultColumnMapperTest.testImplicit started
    [info] Test com.datastax.spark.connector.mapper.DefaultColumnMapperTest.columnNameOverrideSetters started
    [info] Test com.datastax.spark.connector.mapper.DefaultColumnMapperTest.testNewTableForClassWithUnsupportedPropertyType started
    [info] Test com.datastax.spark.connector.mapper.DefaultColumnMapperTest.testWorkWithAliases started
    [info] Test com.datastax.spark.connector.mapper.DefaultColumnMapperTest.testNewTableForCaseClass started
    [info] Test run finished: 0 failed, 0 ignored, 18 total, 0.046s
    [info] ScalaTest
    [info] Run completed in 6 seconds, 830 milliseconds.
    [info] Total number of tests run: 146
    [info] Suites: completed 12, aborted 0
    [info] Tests: succeeded 146, failed 0, canceled 0, ignored 0, pending 0
    [info] All tests passed.
    [info] Passed: Total 245, Failed 0, Errors 0, Passed 245
    [info] Note: /Users/madhavansridharan/Data/Tools/sperf_and_nibbler/spark-cassandra-connector/connector/src/main/java/com/datastax/spark/connector/japi/CassandraJavaUtil.java uses or overrides a deprecated API.
    [info] Note: Recompile with -Xlint:deprecation for details.
    [info] Done compiling.
    [info] Compiling 45 Scala sources and 17 Java sources to /Users/madhavansridharan/Data/Tools/sperf_and_nibbler/spark-cassandra-connector/connector/target/scala-2.12/test-classes ...
    [warn] /Users/madhavansridharan/Data/Tools/sperf_and_nibbler/spark-cassandra-connector/connector/src/test/scala/com/datastax/spark/connector/util/AnyObjectFactoryTest.scala:5:42: imported `JavaApiHelper' is permanently hidden by definition of object JavaApiHelper in package util
    [warn] import com.datastax.spark.connector.util.JavaApiHelper
    [warn]                                          ^
    [warn] /Users/madhavansridharan/Data/Tools/sperf_and_nibbler/spark-cassandra-connector/connector/src/test/scala/com/datastax/bdp/spark/DseAuthConfFactorySpec.scala:1:1: 
    [warn] Found names but no class, trait or object is defined in the compilation unit.
    [warn] The incremental compiler cannot record the dependency information in such case.
    [warn] Some errors like unused import referring to a non-existent class might not be reported.
    [warn]     
    [warn] /*
    [warn] ^
    [warn] /Users/madhavansridharan/Data/Tools/sperf_and_nibbler/spark-cassandra-connector/connector/src/test/scala/com/datastax/bdp/spark/DseByosAuthConfFactorySpec.scala:1:1: 
    [warn] Found names but no class, trait or object is defined in the compilation unit.
    [warn] The incremental compiler cannot record the dependency information in such case.
    [warn] Some errors like unused import referring to a non-existent class might not be reported.
    [warn]     
    [warn] /*
    [warn] ^
    [warn] there were two deprecation warnings (since 2.12.0); re-run with -deprecation for details
    [warn] there was one feature warning; re-run with -feature for details
    [warn] 5 warnings found
    [warn] Could not determine source for class com.datastax.spark.connector.mapper.JavaTestBeanHelper__MapperGenerated$2
    [warn] Could not determine source for class com.datastax.spark.connector.mapper.JavaTestBeanHelper__MapperGenerated
    [warn] Could not determine source for class com.datastax.spark.connector.mapper.JavaTestBeanHelper__MapperGenerated$1
    [info] Done compiling.
    [info] RandomPartitionerTokenFactorySpec:
    [info] RandomPartitionerTokenFactory
    [info] - should create a token from String
    [info] - should create a String representation of a token
    [info] - should calculate the distance between tokens if right > left
    [info] - should calculate the distance between tokens if right <= left
    [info] - should calculate ring fraction
    [info] InputMetricsUpdaterSpec:
    [info] - should create updater which uses task metrics
    [info] - should be thread-safe when it uses task metrics
    [info] - should create updater which does not use task metrics
    [info] - should create updater which uses Codahale metrics
    [info] - should be thread-safe when using Codahale metrics
    [info] - should create updater which doesn't use Codahale metrics
    [info] Murmur3TokenFactorySpec:
    [info] Murmur3TokenFactory
    [info] - should create a token from String
    [info] - should create a String representation of a token
    [info] - should calculate the distance between tokens if right > left
    [info] - should calculate the distance between tokens if right <= left
    [info] - should calculate ring fraction
    [info] WriteConfTest:
    [info] WriteConf
    [info] - should be configured with proper defaults
    [info] - should allow setting the rate limit as a decimal
    [info] - should allow to set consistency level
    [info] - should allow to set parallelism level
    [info] - should allow to set batch size in bytes
    [info] - should allow to set batch size in bytes when rows are set to auto
    [info] - should allow to set batch size in rows
    [info] - should allow to set batch level
    [info] - should allow to set batch buffer size
    [info] RateLimiterSpec:
    [info] RateLimiter
    [info] - should not cause delays if rate is not exceeded
    [info] - should sleep to not exceed the target rate
    [info] - should sleep and leak properly with different Rates
    [info] ColumnSelectorSpec:
    [info] A ColumnSelector#selectFrom method
    [info] - should return all columns
    [info] - should return partition key columns
    [info] - should return some columns
    [info] - should return selections with function calls
    [info] - should throw a NoSuchElementException when selected column name is invalid
    [info] - should throw a NoSuchElementException when a function call has a missing column as an actual parameter
    [info] OutputMetricsUpdaterSpec:
    [info] - should create updater which uses task metrics
    [info] - should create updater which does not use task metrics
    [info] - should create updater which uses Codahale metrics
    [info] - should create updater which doesn't use Codahale metrics
    [info] - should work correctly with multiple threads
    [info] DeprecationSpec:
    [info] The Spark Cassandra Connector
     WARN 14:53:33,580 com.datastax.spark.connector.util.Logging (Logging.scala:47) - spark.cassandra.input.reads_per_sec is deprecated (DSE 6.0.0) and has been automatically replaced with parameter spark.cassandra.input.readsPerSec. 
     WARN 14:53:33,582 com.datastax.spark.connector.util.Logging (Logging.scala:47) - spark.cassandra.connection.local_dc is deprecated (DSE 6.0.0) and has been automatically replaced with parameter spark.cassandra.connection.localDC. 
     WARN 14:53:33,582 com.datastax.spark.connector.util.Logging (Logging.scala:47) - spark.cassandra.input.split.size_in_mb is deprecated (DSE 6.0.0) and has been automatically replaced with parameter spark.cassandra.input.split.sizeInMB. 
     WARN 14:53:33,582 com.datastax.spark.connector.util.Logging (Logging.scala:47) - spark.cassandra.input.fetch.size_in_rows is deprecated (DSE 6.0.0) and has been automatically replaced with parameter spark.cassandra.input.fetch.sizeInRows. 
     WARN 14:53:33,582 com.datastax.spark.connector.util.Logging (Logging.scala:47) - spark.cassandra.connection.reconnection_delay_ms.max is deprecated (DSE 6.0.0) and has been automatically replaced with parameter spark.cassandra.connection.reconnectionDelayMS.max. 
     WARN 14:53:33,582 com.datastax.spark.connector.util.Logging (Logging.scala:47) - spark.cassandra.connection.reconnection_delay_ms.min is deprecated (DSE 6.0.0) and has been automatically replaced with parameter spark.cassandra.connection.reconnectionDelayMS.min. 
     WARN 14:53:33,582 com.datastax.spark.connector.util.Logging (Logging.scala:47) - spark.cassandra.read.timeout_ms is deprecated (DSE 6.0.0) and has been automatically replaced with parameter spark.cassandra.read.timeoutMS. 
     WARN 14:53:33,583 com.datastax.spark.connector.util.Logging (Logging.scala:47) - spark.sql.dse.solr.enable_optimization is deprecated (DSE 6.0.0) and has been automatically replaced with parameter spark.sql.dse.search.enableOptimization. 
     WARN 14:53:33,583 com.datastax.spark.connector.util.Logging (Logging.scala:47) - spark.cassandra.output.throughput_mb_per_sec is deprecated (DSE 6.0.0) and has been automatically replaced with parameter spark.cassandra.output.throughputMBPerSec. 
     WARN 14:53:33,583 com.datastax.spark.connector.util.Logging (Logging.scala:47) - spark.cassandra.connection.timeout_ms is deprecated (DSE 6.0.0) and has been automatically replaced with parameter spark.cassandra.connection.timeoutMS. 
     WARN 14:53:33,583 com.datastax.spark.connector.util.Logging (Logging.scala:47) - spark.cassandra.connection.keep_alive_ms is deprecated (DSE 6.0.0) and has been automatically replaced with parameter spark.cassandra.connection.keepAliveMS. 
    [info] - should deprecate ConnectionConf
    [info] - should deprecate ReadConf
    [info] - should deprecate WriteConf
    [info] - should deprecate SoureConf
    [info] WriteOptionTest:
    [info] TTLOption
    [info] - should properly create constant write option with duration in seconds
    [info] - should properly create constant write option with scala.concurrent.duration.Duration
    [info] - should properly create constant write option with scala.concurrent.duration.Duration.Infinite
    [info] - should properly create constant write option with org.joda.time.Duration
    [info] - should properly create infinite duration
    [info] - should properly create per-row duration placeholder
    [info] TimestampOption
    [info] - should properly create constant write option with timestamp in microseconds
    [info] - should properly create constant write option with DateTime
    [info] - should properly create constant write option with Date
    [info] ConsolidateSettingsSpec:
    [info] - should use SparkConf settings by default
    [info] - should override SparkConf settings by SQLContext settings
    [info] - should override global SQLContext settings by cluster level settings
    [info] - should override cluster level SQLContext settings by keyspace level settings
    [info] - should override keyspace level SQLContext settings by table level settings
    [info] - should be case insensitive in table conf options
    [info] AnyObjectFactoryTest:
    [info] AnyObjectFactory
    [info]   when instantiated for a bean class with a single, no-args constructor
    [info]   - should create an instance of that class with newInstance
    [info]   - should return 0 with argCount
    [info]   - should return empty collection with constructorParamTypes
    [info]   - should return that class with javaClass
    [info]   when instantiated for a bean class with multiple constructors which include no-args constructor
    [info]   - should create an instance of that class with newInstance
    [info]   - should return that class with javaClass
    [info]   when instantiated for an inner Java class
    [info]   - should create an instance of that class with newInstance
    [info]   - should return that class with javaClass
    [info]   when instantiated for a deeply nested inner Java class
    [info]   - should create an instance of that class with newInstance
    [info]   - should return that class with javaClass
    [info]   when tried to be instantiated for an unsupported bean class
    [info]   - should throw NoSuchMethodException if class does not have suitable constructor
    [info]   when instantiated for a Scala case class with 2 args constructor
    [info]   - should create an instance of that class with newInstance
    [info]   - should return 2 with argCount because the only constructor of this case class has two args
    [info]   - should return collection of {Int, String} types with constructorParamTypes
    [info]   - should return that class with javaClass
    [info]   when instantiated for a Scala case class with 2 args constructor which is defined inside an object
    [info]   - should create an instance of that class with newInstance
    [info]   - should return 2 with argCount because the only constructor of this case class has two args
    [info]   - should return collection of {Int, String} types with constructorParamTypes
    [info]   - should return that class with javaClass
    [info]   when instantiated for a Scala class with 2 args constructor
    [info]   - should create an instance of that class with newInstance
    [info]   - should return 2 with argCount because the only constructor of this class has 2 args
    [info]   - should return collection of {Int, String} types with constructorParamTypes
    [info]   - should return that class with javaClass
    [info]   when instantiated for a Scala class with 2 args constructor and without fields
    [info]   - should create an instance of that class with newInstance
    [info]   - should return 2 with argCount because the only constructor of this class has 2 args
    [info]   - should return collection of {Int, String} types with constructorParamTypes
    [info]   - should return that class with javaClass
    [info]   when instantiated for a Scala class with multiple constructors
    [info]   - should create an instance of that class with newInstance
    [info]   - should return that class with javaClass
    [info]   when instantiated for an inner Scala class with 2 args constructor
    [info]   - should create an instance of that class with newInstance
    [info]   - should return 2 with argCount
    [info]   - should return collection of {Int, String} types with constructorParamTypes
    [info]   - should return that class with javaClass
    [info]   when instantiated for a deeply nested inner Scala class
    [info]   - should create an instance of that class with newInstance
    [info]   - should return that class with javaClass
    [info]   when serialized
    [info]   - should allow to be deserialized and reused
    [info] BucketingRangeIndexSpec:
    [info] BucketingRangeIndex
    [info] - should find ranges containing given point when ranges do not overlap
    [info] - should find ranges containing given point when ranges do overlap
    [info] - should find proper ranges when they wrap around
    [info] LongTokenBucketing
    [info] - should respect the required bucket range
    [info] - should be weakly monotonic
    [info] BigIntTokenBucketing
    [info] - should respect the required bucket range
    [info] - should be weakly monotonic
    [info] Murmur3Bucketing
    [info] - should map all tokens to a single wrapping range
    [info] RandomBucketing
    [info] - should map all tokens to a single wrapping range
    [info] TokenRangeSpec:
    [info] LongRanges 
    [info] - should contain tokens with easy no wrapping bounds
    [info] - should contain tokens with wrapping bounds in
    [info] BigRanges 
    [info] - should contain tokens with easy no wrapping bounds
    [info] - should contain tokens with wrapping bounds in
    [info] InClausePredicateRulesSpec:
    [info] InClausePredicateRules
    [info] - should leave partition and clustering filters if 'IN' filters are absent
    [info] - should remove clustering filters if cartesian product of number of values is above threshold but partition values cartesian number is below the threshold
    [info] - should remove partition and clustering filters if cartesian product of number of values is above threshold
    [info] PredicatePushDownSpec:
    [info] BasicCassandraPredicatePushDown
    [info] - should push down all equality predicates restricting partition key columns
    [info] - should work if the user tries to use a TimeUUID on a fully handled predicate
    [info] - should work if the user tries to use a TimeUUID column in a eq predicate
    [info] - should not push down a partition key predicate for a part of the partition key
    [info] - should not push down a range partition key predicate
    [info] - should push down an IN partition key predicate on the last partition key column
    [info] - should push down an IN partition key predicate on the non-last partition key column
    [info] - should push down an IN partition key predicate on all partition key columns
    [info] - should not push down an IN partition key predicate on the non-last partition key column for V3 and older
    [info] - should push down the first clustering column predicate
    [info] - should push down the first and the second clustering column predicate
    [info] - should push down restrictions on only the initial clustering columns
    [info] - should push down only one range predicate restricting the first clustering column, if there are more range predicates on different clustering columns
    [info] - should push down multiple range predicates for the same clustering column
    [info] - should push down clustering column predicates when the last clustering column is restricted by IN
    [info] - should stop pushing down clustering column predicates on the first range predicate
    [info] - should not push down IN restriction on non-last column for V3 and older
    [info] - should push down IN restriction on non-last clustering column
    [info] - should push down IN restriction on all clustering columns
    [info] - should not push down any clustering column predicates, if the first clustering column is missing
    [info] - should not push down partition key index equality predicates in P3
    [info] - should push down partition key index equality predicates
    [info] - should push down equality predicates on regular indexed columns
    [info] - should not push down range predicates on regular indexed columns
    [info] - should not push down IN predicates on regular indexed columns
    [info] - should push down predicates on regular non-indexed and indexed columns
    [info] - should not push down predicates on regular non-indexed columns if indexed ones are not included
    [info] - should prefer to push down equality predicates over range predicates
    [info] - should not push down unsupported predicates
    [info] DsePredicateRulesSpec:
    [info] DSE Predicate Rules
    [info] - should un-push all other predicates if solr_query exists
    [info] it
    [info] - should do nothing if solr_query is not present in a query
    [info] CassandraConnectorConfSpec:
    [info] - should be serializable
    [info] - should match a conf with the same settings
    [info] - should resolve default SSL settings correctly
    [info] - should resolve provided SSL settings correctly
    [info] - should produce serializedConfString that disregards names in hosts
    [info] - should be equal to a conf with the same settings and hosts
    [info] - should be not equal to a conf with the same settings and different hosts
    [info] - should be equal to a conf with the same hosts in different order
    [info] - should be not equal to a conf with the same hosts but different settings
    [info] - should not be equal to a conf with the same settings and different hosts if no host is common
    [info] CqlWhereParserTest:
    [info] CqlWhereParser
    [info] - should parse 'and' operations
    [info] - should parse equality predicates
    [info] - should parse range predicates
    [info] - should parse IN predicates
    [info] - should parse quoted names
    [info] - should return lowercase names
    [info] - should parse strings
    [info] - should distinguish '?' from ?
    [info] - should accept >=
    [info] - should accept ?
    [info] - should accept name with quotes and other special symbols
    [info] - should accept param with quotes and other special symbols
    [info] - should accept uuid param
    [info] - should accept float param
    [info] - should parse case insensitive 'aNd' operations
    [info] - should parse case insensitive 'iN' operations
    [info] - should parse case insensitive 'IN' operations ?
    [info] - should handle long string requests
    [info] MergeJoinIteratorSpec:
    [info] MergeJoinIterator
    [info] - should group an empty collection
    [info] - should group two sequences with the same key into a single item and preserve order
    [info] - should group a sequence of elements with distinct keys the same number of groups
    [info] - should group a sequence of elements with two keys into two groups
    [info] - should be lazy and work with infinite streams
    [info] - should take from two unabalanced but ordered streams
    [info] - should work with more complicated keys
    [info] CqlWhereClauseSpec:
    [info] - should produce a string for each predicate
    [info] - should produce empty predicate string for empty predicate list
    [info] - should produce valid string for IN clause predicate
    [info] - should complain when the number of values doesn't match the number of placeholders '?'
    [info] SolrPredicateRulesSpec:
    [info] Solr Predicate Rules
    [info] - should convert easy predicates to a solr query
    [info] - should convert an OR filter
    [info] - should convert a large conjugated tree
    [info] - should not convert conjunctions with non solr indexed attributes
    [info] - should be able to convert only some filters if some are non indexed
    [info] - should be able to convert string like filters
    [info] - should be able to convert string contains filters
    [info] - should be able to convert compound NOT IN clauses
    [info] - should be able to convert Null predicates
    [info] - should be able to convert GreaterThanEquals and LessThanEquals
    [info] Murmur3PartitionerTokenRangeSplitterSpec:
    [info] Murmur3PartitionerSplitter
    [info] - should split tokens
    [info] - should split token sequences
    [info] BufferedIterator2Spec:
    [info] BufferedIterator
    [info] - should return the same items as the standard Iterator
    [info] - should be convertible to a Seq
    [info] - should wrap an empty iterator
    [info] - should offer the head element without consuming the underlying iterator
    [info] - should offer takeWhile that consumes only the elements matching the predicate
    [info] - should offer appendWhile that copies elements to ArrayBuffer and consumes only the elements matching the predicate
    [info] - should throw NoSuchElementException if trying to get next() element that doesn't exist
    [info] ConfigCheckSpec:
    [info] ConfigCheck
    [info] - should throw an exception when the configuration contains a invalid spark.cassandra prop
    [info] - should suggest alternatives if you have a slight misspelling
    [info] - should suggest alternatives if you miss a word
    [info] - should not throw an exception if you have a random variable not in the spark.cassandra space
    [info] - should not list all options as suggestions
    [info] - should not give suggestions when the variable is very strange
    [info] - should accept custom ConnectionFactory properties
    [info] - should accept custom AuthConfFactory properties
    [info] DefaultConnectionFactoryTest:
    [info] - should complain when a malformed URL is provided
    [info] - should complain when an URL with unrecognized scheme is provided
    [info] SpanningIteratorSpec:
    [info] SpanningIterator
    [info] - should group an empty collection
    [info] - should group a sequence of elements with the same key into a single item and should preserve order
    [info] - should group a sequence of elements with distinct keys the same number of groups
    [info] - should group a sequence of elements with two keys into two groups
    [info] - should be lazy and work with infinite streams
    [info] PriorityHashMapSpec:
    [info] A PriorityHashMap
    [info] - should support adding elements (simple)
    [info] - should support adding elements ascending by value
    [info] - should support adding elements descending by value
    [info] - should support adding elements in random order of values
    [info] - should support adding elements in random order of values and keys
    [info] - should support removing elements in ascending order
    [info] - should support removing elements in descending order
    [info] - should support removing elements in random order from a sorted map
    [info] - should support removing elements from a randomly created map in random order
    [info] - should allow to heapsort an array of integers
    [info] - should allow to update item priority
    [info] - should be able to store multiple items with the same priority
    [info] - should return false when removing a non-existing key
    [info] - should have capacity rounded up to the nearest power of two
    [info] - should throw NoSuchElement exception if requested a head of empty map
    [info] - should throw NoSuchElement exception if requested a non-existing key
    [info] - should throw IllegalStateException exception if trying to exceed allowed capacity
    [info] RandomPartitionerTokenRangeSplitterSpec:
    [info] RandomPartitionerSplitter
    [info] - should split tokens
    [info] - should split token sequences
    [info] Test run started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaPairRDDTest.testWithConnector started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaPairRDDTest.testWithReadConf started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaPairRDDTest.testWithAscOrder started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaPairRDDTest.testSelectColumnNames started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaPairRDDTest.testLimit started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaPairRDDTest.testWhere started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaPairRDDTest.testSelectColumns started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaPairRDDTest.testSelectedColumnRefs started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaPairRDDTest.testSelectedColumnNames started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaPairRDDTest.testWithDescOrder started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaPairRDDTest.testPerPartitionLimit started
    [info] Test run finished: 0 failed, 0 ignored, 11 total, 0.112s
    [info] Test run started
    [info] Test com.datastax.spark.connector.writer.DefaultRowWriterTest.testTypeConversionsInUDTValuesAreApplied started
    [info] Test com.datastax.spark.connector.writer.DefaultRowWriterTest.testTypeConversionsAreApplied started
    [info] Test com.datastax.spark.connector.writer.DefaultRowWriterTest.testSerializability started
    [info] Test com.datastax.spark.connector.writer.DefaultRowWriterTest.testCustomTypeConvertersAreUsed started
    [info] Test run finished: 0 failed, 0 ignored, 4 total, 0.249s
    [info] Test run started
    [info] Test com.datastax.spark.connector.japi.SparkContextJavaFunctionsTest.testReadConfPopulating started
    [info] Test run finished: 0 failed, 0 ignored, 1 total, 0.179s
    [info] Test run started
    [info] Test com.datastax.spark.connector.rdd.reader.ClassBasedRowReaderTest.testSerialize started
    [info] Test run finished: 0 failed, 0 ignored, 1 total, 0.073s
    [info] Test run started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testMapColumnToListOf started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testJavaFunctions started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testMapColumnToMapOf started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testMapColumnToSetOf started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testMapColumnTo1 started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testMapColumnTo2 started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testMapColumnTo3 started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testTypeConverter1 started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testTypeConverter2 started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testTypeConverter3 started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testTypeConverter4 started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testTypeTag1 started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testTypeTag2 started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testTypeTag3 started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testJavaFunctions1 started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testJavaFunctions4 started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testJavaFunctions5 started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testMapRowTo1 started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testMapRowTo2 started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testMapRowTo3 started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testMapRowTo4 started
    [info] Test com.datastax.spark.connector.CassandraJavaUtilTest.testConvertToMap started
    [info] Test run finished: 0 failed, 0 ignored, 22 total, 0.097s
    [info] Test run started
    [info] Test com.datastax.spark.connector.japi.CassandraRowTest.testGetBytes started
    [info] Test com.datastax.spark.connector.japi.CassandraRowTest.testGetFloat started
    [info] Test com.datastax.spark.connector.japi.CassandraRowTest.testGetShort started
    [info] Test com.datastax.spark.connector.japi.CassandraRowTest.testGet started
    [info] Test com.datastax.spark.connector.japi.CassandraRowTest.testToMap started
    [info] Test com.datastax.spark.connector.japi.CassandraRowTest.testGetByte started
    [info] Test com.datastax.spark.connector.japi.CassandraRowTest.testGetDate started
    [info] Test com.datastax.spark.connector.japi.CassandraRowTest.testGetInet started
    [info] Test com.datastax.spark.connector.japi.CassandraRowTest.testGetList started
    [info] Test com.datastax.spark.connector.japi.CassandraRowTest.testGetLong started
    [info] Test com.datastax.spark.connector.japi.CassandraRowTest.testGetUUID started
    [info] Test com.datastax.spark.connector.japi.CassandraRowTest.testGetObjectAndApply started
    [info] Test com.datastax.spark.connector.japi.CassandraRowTest.testGetBoolean started
    [info] Test com.datastax.spark.connector.japi.CassandraRowTest.testGetDouble started
    [info] Test com.datastax.spark.connector.japi.CassandraRowTest.testGetInt started
    [info] Test com.datastax.spark.connector.japi.CassandraRowTest.testGetMap started
    [info] Test com.datastax.spark.connector.japi.CassandraRowTest.testGetSet started
    [info] Test com.datastax.spark.connector.japi.CassandraRowTest.testGetString started
    [info] Test com.datastax.spark.connector.japi.CassandraRowTest.testGetVarInt started
    [info] Test com.datastax.spark.connector.japi.CassandraRowTest.testGetDecimal started
    [info] Test run finished: 0 failed, 0 ignored, 20 total, 0.047s
    [info] Test run started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJoinJavaRDDTest.testOn started
    [info] Test run finished: 0 failed, 0 ignored, 1 total, 0.035s
    [info] Test run started
    [info] Test com.datastax.spark.connector.writer.AsyncExecutorTest.test started
    [info] Test run finished: 0 failed, 0 ignored, 1 total, 0.44s
    [info] Test run started
    [info] Test com.datastax.spark.connector.rdd.partitioner.TokenRangeClustererTest.testTrivialClustering started
    [info] Test com.datastax.spark.connector.rdd.partitioner.TokenRangeClustererTest.testMaxGroupSize started
    [info] Test com.datastax.spark.connector.rdd.partitioner.TokenRangeClustererTest.testMultipleEndpoints started
    [info] Test com.datastax.spark.connector.rdd.partitioner.TokenRangeClustererTest.testEmpty started
    [info] Test com.datastax.spark.connector.rdd.partitioner.TokenRangeClustererTest.testSplitByHost started
    [info] Test com.datastax.spark.connector.rdd.partitioner.TokenRangeClustererTest.testSplitByCount started
    [info] Test run finished: 0 failed, 0 ignored, 6 total, 0.012s
    [info] Test run started
    [info] Test com.datastax.spark.connector.CassandraStreamingJavaUtilTest.testJavaFunctions2 started
    [info] Test com.datastax.spark.connector.CassandraStreamingJavaUtilTest.testJavaFunctions3 started
    [info] Test com.datastax.spark.connector.CassandraStreamingJavaUtilTest.testJavaFunctions6 started
    [info] Test com.datastax.spark.connector.CassandraStreamingJavaUtilTest.testJavaFunctions7 started
    [info] Test run finished: 0 failed, 0 ignored, 4 total, 0.074s
    [info] Test run started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaRDDTest.testWithConnector started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaRDDTest.testWithReadConf started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaRDDTest.testWithAscOrder started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaRDDTest.testSelectColumnNames started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaRDDTest.testLimit started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaRDDTest.testWhere started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaRDDTest.testSelectColumns started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaRDDTest.testSelectedColumnRefs started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaRDDTest.testSelectedColumnNames started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaRDDTest.testWithDescOrder started
    [info] Test com.datastax.spark.connector.japi.rdd.CassandraJavaRDDTest.testPerPartitionLimit started
    [info] Test run finished: 0 failed, 0 ignored, 11 total, 0.004s
    [info] ScalaTest
    [info] Run completed in 6 seconds, 804 milliseconds.
    [info] Total number of tests run: 233
    [info] Suites: completed 28, aborted 0
    [info] Tests: succeeded 233, failed 0, canceled 0, ignored 0, pending 0
    [info] All tests passed.
    [info] Passed: Total 315, Failed 0, Errors 0, Passed 315
    [success] Total time: 51 s, completed Jun 30, 2021 2:53:36 PM
    ```
</details>

# Checklist:

- [ x] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/projects/SPARKC)
- [ x] I have performed a self-review of my own code
- [ x] Locally all tests pass (make sure tests fail without your patch)
