### PR TITLE
SPARKC-657 Bump DSE & OSS C* versions to current patch/RC releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         scala:  [2.12.10]
-        db-version: [6.8.9, 3.11.9, 4.0-beta4]
+        db-version: [6.8.13, 5.1.24, 3.11.10, 4.0-rc2]
 
     steps:
       - uses: actions/checkout@v2

--- a/doc/developers.md
+++ b/doc/developers.md
@@ -22,7 +22,7 @@ The most common commands to use when developing the connector are
 1. `test` - Runs the the unit tests for the project.
 2. `it:test` - Runs the integration tests with Cassandra (started by CCM) and Spark
 3. `package` - Builds the project and produces a runtime jar
-4. `publishM2` - Publishes a snapshot of the project to your local maven repository allowing for usage with --packages in the spark-shell
+4. `publishM2` - Publishes a snapshot of the project to your local maven repository allowing for usage with `--packages` in the spark-shell
 
 The integration tests located in `connector/src/it` should
 probably be the first place to look for anyone considering adding code.
@@ -39,7 +39,7 @@ b2.5 feature branch to b3.0 feature branch. Repeat for master.
 
 Example for imaginary SPARKC-9999.
 
-Let's assume that `datastax` is git@github.com:datastax/spark-cassandra-connector.git remote 
+Let's assume that `datastax` is `git@github.com:datastax/spark-cassandra-connector.git` remote 
 and origin is your personal clone.
 ```shell
 $ git remote -v
@@ -95,11 +95,11 @@ run and the parallelization used while running tests.
 ### Test Parallelization
 
 In order to limit the number of test groups running simultaneously use the
-`TEST_PARALLEL_TASKS` environment variable. Only applies to sbt test tasks.
+`TEST_PARALLEL_TASKS` environment variable. Only applies to `sbt test` tasks.
 
 ### Set Cassandra Test Target
 Our CI Build runs through the Datastax Infrastructure and tests on all the builds
-listed in build.yaml. In addition the test-support module supports Cassandra
+listed in build.yaml. In addition the _test-support_ module supports Cassandra
 or other CCM Compatible installations.
 
 If using SBT you can set

--- a/project/Testing.scala
+++ b/project/Testing.scala
@@ -45,11 +45,11 @@ object Testing {
 
   /**
     * Guesses if the given version is DSE or not.
-    * Internally it checks if the major version component is ge 6 which should suffice for a long time.
+    * Internally it checks if the major version component is ge 5 which should suffice for a long time.
     * CCM_IS_DSE env setting takes precedence over this guess.
     */
   private def isDse(version: Option[String]): Boolean = {
-    version.flatMap(v => Try(v.split('.').head.toInt >= 6).toOption).getOrElse(false)
+    version.flatMap(v => Try(v.split('.').head.toInt >= 5).toOption).getOrElse(false)
   }
 
   def getCCMJvmOptions = {


### PR DESCRIPTION
# Description

## How did the Spark Cassandra Connector Work or Not Work Before this Patch
N/A as it worked correctly on older patch/RC versions of DSE & OSS C*

Describe the problem, or state of the project that this patch fixes. Explain
why this is a problem if this isn't obvious.
Testing the latest patch release versions for compatibility

Example: 
  "When I read from tables with 3 INTS I get a ThreeIntException(). This is a problem because I often want to read from a table with three integers."

## General Design of the patch
N/A

How the fix is accomplished, were new parameters or classes added? Why did you
pursue this particular fix?
Updated the GHA to test with latest versions

Example: "I removed the incorrect assertion which would throw the ThreeIntException. This exception was incorrectly added and the assertion is not actually needed."

Fixes: [SPARKC-657](https://datastax-oss.atlassian.net/browse/SPARKC-657)

# How Has This Been Tested?

Almost all changes and especially bug fixes will require a test to be added to either the integration or Unit Tests. Any tests added will be automatically run on travis when the pull request is pushed to github. Be sure to run suites locally as well.

# Checklist:

- [ x] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/projects/SPARKC)
- [ x] I have performed a self-review of my own code
- [x ] Locally all tests pass (make sure tests fail without your patch)
---
* `b2.5` PR is https://github.com/datastax/spark-cassandra-connector/pull/1321
* `master` PR is https://github.com/datastax/spark-cassandra-connector/pull/1323