### PR TITLE
[SPARKC-670] Make SCC compatible with Spark 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Currently the following branches are actively supported: 3.1.x ([master](https:/
 
 | Connector | Spark         | Cassandra | Cassandra Java Driver | Minimum Java Version | Supported Scala Versions |
 | --------- | ------------- | --------- | --------------------- | -------------------- | -----------------------  |
+| 3.2       | 3.2           | 2.1.5*, 2.2, 3.x, 4.0 | 4.13             | 8             | 2.12                     |
 | 3.1       | 3.1           | 2.1.5*, 2.2, 3.x, 4.0 | 4.12             | 8             | 2.12                     |
 | 3.0       | 3.0           | 2.1.5*, 2.2, 3.x, 4.0 | 4.12             | 8             | 2.12                     |
 | 2.5       | 2.4           | 2.1.5*, 2.2, 3.x, 4.0 | 4.12             | 8             | 2.11, 2.12               |

--- a/connector/src/it/scala/com/datastax/spark/connector/SparkCassandraITFlatSpecBase.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/SparkCassandraITFlatSpecBase.scala
@@ -247,7 +247,7 @@ trait SparkCassandraITSpecBase
 
   def getCassandraScan(plan: SparkPlan): CassandraScan = {
     plan.collectLeaves.collectFirst{
-      case BatchScanExec(_, cassandraScan: CassandraScan) => cassandraScan
+      case BatchScanExec(_, cassandraScan: CassandraScan, _) => cassandraScan
     }.getOrElse(throw new IllegalArgumentException("No Cassandra Scan Found"))
   }
 

--- a/connector/src/it/scala/com/datastax/spark/connector/cql/sai/SaiBaseSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/cql/sai/SaiBaseSpec.scala
@@ -47,7 +47,7 @@ trait SaiBaseSpec extends Matchers with SparkCassandraITSpecBase {
 
   def findCassandraScan(plan: SparkPlan): CassandraScan = {
     plan match {
-      case BatchScanExec(_, scan: CassandraScan) => scan
+      case BatchScanExec(_, scan: CassandraScan, _) => scan
       case filter: FilterExec => findCassandraScan(filter.child)
       case project: ProjectExec => findCassandraScan(project.child)
       case _ => throw new NoSuchElementException("RowDataSourceScanExec was not found in the given plan")

--- a/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
@@ -271,7 +271,7 @@ class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase with DefaultC
     if (pushDown)
       withClue(s"Given Dataframe plan does not contain CassandraInJoin in it's predecessors.\n${df.queryExecution.sparkPlan.toString()}") {
         df.queryExecution.executedPlan.collectLeaves().collectFirst{
-          case a@BatchScanExec(_, _: CassandraInJoin) => a
+          case a@BatchScanExec(_, _: CassandraInJoin, _) => a
         } shouldBe defined
      }
     else
@@ -281,7 +281,7 @@ class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase with DefaultC
   private def assertOnAbsenceOfCassandraInJoin(df: DataFrame): Unit =
     withClue(s"Given Dataframe plan contains CassandraInJoin in it's predecessors.\n${df.queryExecution.sparkPlan.toString()}") {
       df.queryExecution.executedPlan.collectLeaves().collectFirst{
-        case a@BatchScanExec(_, _: CassandraInJoin) => a
+        case a@BatchScanExec(_, _: CassandraInJoin, _) => a
       } shouldBe empty
     }
 

--- a/connector/src/it/scala/com/datastax/spark/connector/util/CatalystUtil.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/util/CatalystUtil.scala
@@ -7,6 +7,6 @@ import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 object CatalystUtil {
 
   def findCassandraScan(sparkPlan: SparkPlan): Option[CassandraScan] = {
-    sparkPlan.collectFirst{ case BatchScanExec(_, scan: CassandraScan) => scan}
+    sparkPlan.collectFirst{ case BatchScanExec(_, scan: CassandraScan, _) => scan}
   }
 }

--- a/connector/src/main/scala/com/datastax/spark/connector/cql/AuthConf.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/cql/AuthConf.scala
@@ -1,7 +1,7 @@
 package com.datastax.spark.connector.cql
 
 import com.datastax.oss.driver.api.core.auth.AuthProvider
-import com.datastax.oss.driver.internal.core.auth.ProgrammaticPlainTextAuthProvider
+import com.datastax.oss.driver.api.core.auth.ProgrammaticPlainTextAuthProvider
 import com.datastax.spark.connector.util.{ConfigParameter, ReflectionUtil}
 import org.apache.spark.SparkConf
 

--- a/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinExec.scala
+++ b/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinExec.scala
@@ -219,4 +219,6 @@ case class CassandraDirectJoinExec(
 
     s"Cassandra Direct Join [${joinString}] $keyspace.$table - $selectString${pushedWhere} "
   }
+
+  override protected def withNewChildInternal(newChild: SparkPlan): CassandraDirectJoinExec = copy(child = newChild)
 }

--- a/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinStrategy.scala
+++ b/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinStrategy.scala
@@ -147,7 +147,7 @@ object CassandraDirectJoinStrategy extends Logging {
     */
   def getScanExec(plan: SparkPlan): Option[BatchScanExec] = {
     plan.collectFirst {
-      case exec @ BatchScanExec(_, _: CassandraScan) => exec
+      case exec @ BatchScanExec(_, _: CassandraScan, _) => exec
     }
   }
 
@@ -205,7 +205,7 @@ object CassandraDirectJoinStrategy extends Logging {
   def hasCassandraChild[T <: QueryPlan[T]](plan: T): Boolean = {
     plan.children.size == 1 && plan.children.exists {
       case DataSourceV2ScanRelation(DataSourceV2Relation(_: CassandraTable, _, _, _, _), _, _) => true
-      case BatchScanExec(_, _: CassandraScan) => true
+      case BatchScanExec(_, _: CassandraScan, _) => true
       case _ => false
     }
   }
@@ -235,7 +235,7 @@ object CassandraDirectJoinStrategy extends Logging {
   def reorderPlan(plan: SparkPlan, directJoin: CassandraDirectJoinExec): SparkPlan = {
     val reordered = plan match {
       //This may be the only node in the Plan
-      case BatchScanExec(_, _: CassandraScan) => directJoin
+      case BatchScanExec(_, _: CassandraScan, _) => directJoin
       // Plan has children
       case normalPlan => normalPlan.transform {
         case penultimate if hasCassandraChild(penultimate) =>

--- a/doc/14_data_frames.md
+++ b/doc/14_data_frames.md
@@ -255,16 +255,16 @@ range.join(joinTarget, joinTarget("k") === range("key")).explain()
 
 Through Cassandra Spark Extensions special functions are added to SparkSQL.
 
-* writetime(col) - If the column represents an actual C* column this will be replaced
-with the writetime of that column as in cql.
+* `writetime(col)` - If the column represents an actual C* column this will be replaced
+with the WriteTime of that column as in CQL.
 
-* ttl(col) - Similar to writetime, this will replace a valid C* column reference with a
-ttl value instead.
+* `ttl(col)` - Similar to writetime, this will replace a valid C* column reference with a
+TTL value instead.
 
 Read Example
 
 ```sql
-SELECT TTL(v) as t, WRITETIME(t) FROM casscatalog.ksname.testTable WHERE k = -1"
+SELECT TTL(v) as t, WRITETIME(t) FROM casscatalog.ksname.testTable WHERE k = 1
 ```
 
 There are specific write options which can be used to assign WriteTime and TTL. 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,11 +1,11 @@
 object Versions {
 
   val CommonsExec     = "1.3"
-  val CommonsIO       = "2.6"
+  val CommonsIO       = "2.8.0"
   val CommonsLang3    = "3.10"
   val Paranamer       = "2.8"
 
-  val DataStaxJavaDriver = "4.12.0"
+  val DataStaxJavaDriver = "4.13.0"
 
   val ScalaCheck      = "1.14.0"
   val ScalaTest       = "3.0.8"
@@ -21,7 +21,7 @@ object Versions {
   // and install in a local Maven repository. This is all done automatically, however it will work
   // only on Unix/OSX operating system. Windows users have to build and install Spark manually if the
   // desired version is not yet published into a public Maven repository.
-  val ApacheSpark     = "3.1.1"
+  val ApacheSpark     = "3.2.0"
   val SparkJetty      = "9.3.27.v20190418"
   val SolrJ           = "8.3.0"
 


### PR DESCRIPTION
Due the changes in internals of Spark, SCC 3.1.0 is not compatible with Spark 3.2.0 in
some areas:
- functions `writetime` & `ttl` are crashing
- `DirectJoin` is crashing as well

This PR fixes that problem, and also update some dependencies to match Spark 3.2.0, and
also bumps Java Driver version to 4.13.0

- [X] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/projects/SPARKC)
- [X] I have performed a self-review of my own code
- [X] Locally all tests pass (make sure tests fail without your patch), some integration tests are failing looks like the problem with CCM start timeout.
