### PR TITLE
SPARKC-673 Fix invalid call to CodecRegistry

### DIFF
--- a/connector/src/it/scala/com/datastax/spark/connector/types/TupleTypeSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/types/TupleTypeSpec.scala
@@ -1,0 +1,80 @@
+package com.datastax.spark.connector.types
+
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
+import com.datastax.spark.connector.cluster.DefaultCluster
+import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector._
+import org.apache.spark.sql.cassandra._
+import org.scalatest.matchers.{MatchResult, Matcher}
+
+case class Ingredients(id: Int, ingredient: (String, Array[Byte]))
+
+case class Recipes(id: Int, ingredients: ((String, Array[Byte]), (String, Array[Byte])))
+
+class TupleTypeSpec extends SparkCassandraITFlatSpecBase with DefaultCluster {
+
+  override lazy val conn = CassandraConnector(sparkConf)
+
+  val IngredientsTable = "ingredients"
+  val RecipesTable = "recipes"
+
+  def makeTupleTables(session: CqlSession): Unit = {
+    session.execute(
+      s"""CREATE TABLE IF NOT EXISTS $ks.$IngredientsTable
+         |(id int PRIMARY KEY, ingredient tuple<text, blob>);""".stripMargin)
+
+    session.execute(
+      s"""CREATE TABLE IF NOT EXISTS $ks.$RecipesTable
+         |(id int PRIMARY KEY, ingredients tuple<tuple<text, blob>, tuple<text, blob>>)""".stripMargin)
+  }
+
+  override def beforeClass {
+    conn.withSessionDo { session =>
+      session.execute(
+        s"""CREATE KEYSPACE IF NOT EXISTS $ks
+           |WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }"""
+          .stripMargin)
+      makeTupleTables(session)
+    }
+  }
+
+  private val beTheSameIngredientAs = (expected: (String, Array[Byte])) =>
+    Matcher { (left: (String, Array[Byte])) =>
+      MatchResult(
+        (left._1 equals expected._1) && (left._2 sameElements expected._2),
+        s"$left equals $expected",
+        s"$left does not equal $expected",
+      )
+    }
+
+  "SparkSql" should "write tuples with BLOB elements" in {
+    val expected = ("fish", "><>".getBytes)
+    spark.createDataFrame(Seq(Ingredients(1, expected)))
+      .write
+      .cassandraFormat(IngredientsTable, ks)
+      .mode("append")
+      .save()
+    val row = spark.sparkContext
+      .cassandraTable[Ingredients](ks, IngredientsTable)
+      .collect()
+      .head
+    row.ingredient should beTheSameIngredientAs(expected)
+  }
+
+  it should "write nested tuples" in {
+    val expected = (("fish", "><>".getBytes), ("poisson", "»<>".getBytes))
+    spark.createDataFrame(Seq(Recipes(1, expected)))
+      .write
+      .cassandraFormat(RecipesTable, ks)
+      .mode("append")
+      .save()
+    val row = spark.sparkContext
+      .cassandraTable[Recipes](ks, RecipesTable)
+      .collect()
+      .head
+    row.ingredients._1 should beTheSameIngredientAs(expected._1)
+    row.ingredients._2 should beTheSameIngredientAs(expected._2)
+  }
+
+}

--- a/connector/src/it/scala/com/datastax/spark/connector/types/UserDefinedTypeSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/types/UserDefinedTypeSpec.scala
@@ -1,0 +1,78 @@
+package com.datastax.spark.connector.types
+
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
+import com.datastax.spark.connector.cluster.DefaultCluster
+import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector._
+import org.apache.spark.sql.cassandra._
+
+// UDTs
+case class File(data: Array[Byte])
+
+case class Profile(name: String, picture: File)
+
+// Tables
+case class Files(id: Int, file: File)
+
+case class Profiles(id: Int, profile: Profile)
+
+class UserDefinedTypeSpec extends SparkCassandraITFlatSpecBase with DefaultCluster {
+
+  override lazy val conn = CassandraConnector(sparkConf)
+
+  val FilesTable = "files"
+  val ProfilesTable = "profiles"
+
+  def makeUdtTables(session: CqlSession): Unit = {
+    session.execute(s"""CREATE TYPE IF NOT EXISTS $ks.file (data blob);""")
+    session.execute(
+      s"""CREATE TABLE IF NOT EXISTS $ks.$FilesTable
+         |(id int PRIMARY KEY, file frozen<file>);""".stripMargin)
+
+    session.execute(s"""CREATE TYPE IF NOT EXISTS $ks.profile (name text, picture frozen<file>)""")
+    session.execute(
+      s"""CREATE TABLE IF NOT EXISTS $ks.$ProfilesTable
+         |(id int PRIMARY KEY, profile frozen<profile>)""".stripMargin)
+  }
+
+  override def beforeClass {
+    conn.withSessionDo { session =>
+      session.execute(
+        s"""CREATE KEYSPACE IF NOT EXISTS $ks
+           |WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 }"""
+          .stripMargin)
+      makeUdtTables(session)
+    }
+  }
+
+  "SparkSql" should "write UDTs with BLOB fields" in {
+    val expected = File(":)".getBytes)
+    spark.createDataFrame(Seq(Files(1, expected)))
+      .write
+      .cassandraFormat(FilesTable, ks)
+      .mode("append")
+      .save()
+    val row = spark.sparkContext
+      .cassandraTable[Files](ks, FilesTable)
+      .collect()
+      .head
+    row.file.data shouldEqual expected.data
+  }
+
+  it should "write nested UDTs" in {
+    val expected = Profile("John Smith", File(":)".getBytes))
+    spark.createDataFrame(Seq(Profiles(1, expected)))
+      .write
+      .cassandraFormat(ProfilesTable, ks)
+      .mode("append")
+      .save()
+    val row = spark.sparkContext
+      .cassandraTable[Profiles](ks, ProfilesTable)
+      .collect()
+      .head
+    row.profile.name shouldEqual expected.name
+    row.profile.picture.data shouldEqual expected.picture.data
+  }
+
+}

--- a/driver/src/main/scala/com/datastax/spark/connector/types/UserDefinedType.scala
+++ b/driver/src/main/scala/com/datastax/spark/connector/types/UserDefinedType.scala
@@ -3,6 +3,7 @@ package com.datastax.spark.connector.types
 import java.io.ObjectOutputStream
 
 import com.datastax.oss.driver.api.core.`type`.{DataType, UserDefinedType => DriverUserDefinedType}
+import com.datastax.oss.driver.api.core.`type`.codec.registry.CodecRegistry
 import com.datastax.oss.driver.api.core.data.{UdtValue => DriverUDTValue}
 import com.datastax.spark.connector.cql.{FieldDef, StructDef}
 import com.datastax.spark.connector.types.ColumnType.fromDriverType
@@ -96,7 +97,7 @@ object UserDefinedType {
           if (fieldValue == null) {
             toSave.setToNull(i)
           } else {
-            toSave.set(i, fieldValue, fieldValue.getClass.asInstanceOf[Class[AnyRef]])
+            toSave.set(i, fieldValue, CodecRegistry.DEFAULT.codecFor(fieldTypes(i), fieldValue))
           }
         }
         toSave


### PR DESCRIPTION
# Description
 
## How did the Spark Cassandra Connector Work or Not Work Before this Patch
 
For types containing `BLOB`s, the low-level Cassandra driver returned `fieldValue: HeapByteBuffer`. The `set` method that takes `Class<ValueT>` as the third parameter does not accept covariant classes (so it was unable to find the `BLOB <-> ByteBuffer` codec).
 
https://github.com/datastax/java-driver/pull/1555#issuecomment-855236502
 
## General Design of the patch
 
Reverts to usage of the default registry implementation that is covariant with regard to type.
 
Fixes: [SPARKC-673](https://datastax-oss.atlassian.net/browse/SPARKC-673)
 
# How Has This Been Tested?
 
This is the previous working implementation from before f1f666cc650d638f0dcc7bf23737274476b63eaa.
 
# Checklist:
 
- [X] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/projects/SPARKC)
- [X] I have performed a self-review of my own code
- [X] Locally all tests pass (make sure tests fail without your patch)
