### PR TITLE
Compatibility with Spark 3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Currently the following branches are actively supported: 3.1.x ([master](https:/
 
 | Connector | Spark         | Cassandra | Cassandra Java Driver | Minimum Java Version | Supported Scala Versions |
 | --------- | ------------- | --------- | --------------------- | -------------------- | -----------------------  |
+| 3.2       | 3.2           | 2.1.5*, 2.2, 3.x, 4.0 | 4.13             | 8             | 2.12                     |
 | 3.1       | 3.1           | 2.1.5*, 2.2, 3.x, 4.0 | 4.12             | 8             | 2.12                     |
 | 3.0       | 3.0           | 2.1.5*, 2.2, 3.x, 4.0 | 4.12             | 8             | 2.12                     |
 | 2.5       | 2.4           | 2.1.5*, 2.2, 3.x, 4.0 | 4.12             | 8             | 2.11, 2.12               |

--- a/connector/src/it/scala/com/datastax/bdp/spark/search/SearchAnalyticsIntegrationSpec.scala
+++ b/connector/src/it/scala/com/datastax/bdp/spark/search/SearchAnalyticsIntegrationSpec.scala
@@ -498,27 +498,6 @@ class SearchAnalyticsIntegrationSpec extends SparkCassandraITFlatSpecBase with D
     testType("m = '10000000-0000-0000-0000-000000000000'", """"m:10000000\\-0000\\-0000\\-0000\\-000000000000"""")
   }
 
-  it should "work with weird column names" in dseOnly {
-    val df: DataFrame = spark
-      .read
-      .cassandraFormat(weirdTable, ks)
-      .load()
-
-    val filtered = df.filter(df("key") === 1)
-      .filter(df("~~funcolumn") === "hello")
-      .filter(df("MixEdCol") === "world")
-
-    val whereClause = filtered.getUnderlyingCqlWhereClause()
-    val predicates = whereClause.predicates.head
-    val values: String = whereClause.values.head.toString
-    predicates should include("""solr_query""")
-    values should include("funcolumn")
-    values should include("MixEdCol")
-    val rows = filtered.collect
-    rows.head.getAs[String]("~~funcolumn") should be("hello")
-    rows.head.getAs[String]("MixEdCol") should be("world")
-  }
-
   "Automatic Solr Optimization" should "occur when the selected amount of data is less than the threshold" in dseOnly {
     val df = spark.sql(s"SELECT COUNT(*) from $tableAutoSolr.$ks.$table where key < 5")
     val whereClause = df.getUnderlyingCqlWhereClause()

--- a/connector/src/it/scala/com/datastax/bdp/spark/search/SearchAnalyticsIntegrationSpec.scala
+++ b/connector/src/it/scala/com/datastax/bdp/spark/search/SearchAnalyticsIntegrationSpec.scala
@@ -498,6 +498,27 @@ class SearchAnalyticsIntegrationSpec extends SparkCassandraITFlatSpecBase with D
     testType("m = '10000000-0000-0000-0000-000000000000'", """"m:10000000\\-0000\\-0000\\-0000\\-000000000000"""")
   }
 
+  it should "work with weird column names" in dseOnly {
+    val df: DataFrame = spark
+      .read
+      .cassandraFormat(weirdTable, ks)
+      .load()
+
+    val filtered = df.filter(df("key") === 1)
+      .filter(df("~~funcolumn") === "hello")
+      .filter(df("MixEdCol") === "world")
+
+    val whereClause = filtered.getUnderlyingCqlWhereClause()
+    val predicates = whereClause.predicates.head
+    val values: String = whereClause.values.head.toString
+    predicates should include("""solr_query""")
+    values should include("funcolumn")
+    values should include("MixEdCol")
+    val rows = filtered.collect
+    rows.head.getAs[String]("~~funcolumn") should be("hello")
+    rows.head.getAs[String]("MixEdCol") should be("world")
+  }
+
   "Automatic Solr Optimization" should "occur when the selected amount of data is less than the threshold" in dseOnly {
     val df = spark.sql(s"SELECT COUNT(*) from $tableAutoSolr.$ks.$table where key < 5")
     val whereClause = df.getUnderlyingCqlWhereClause()

--- a/connector/src/it/scala/com/datastax/spark/connector/SparkCassandraITFlatSpecBase.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/SparkCassandraITFlatSpecBase.scala
@@ -247,7 +247,7 @@ trait SparkCassandraITSpecBase
 
   def getCassandraScan(plan: SparkPlan): CassandraScan = {
     plan.collectLeaves.collectFirst{
-      case BatchScanExec(_, cassandraScan: CassandraScan) => cassandraScan
+      case BatchScanExec(_, cassandraScan: CassandraScan, _) => cassandraScan
     }.getOrElse(throw new IllegalArgumentException("No Cassandra Scan Found"))
   }
 

--- a/connector/src/it/scala/com/datastax/spark/connector/cql/sai/SaiBaseSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/cql/sai/SaiBaseSpec.scala
@@ -47,7 +47,7 @@ trait SaiBaseSpec extends Matchers with SparkCassandraITSpecBase {
 
   def findCassandraScan(plan: SparkPlan): CassandraScan = {
     plan match {
-      case BatchScanExec(_, scan: CassandraScan) => scan
+      case BatchScanExec(_, scan: CassandraScan, _) => scan
       case filter: FilterExec => findCassandraScan(filter.child)
       case project: ProjectExec => findCassandraScan(project.child)
       case _ => throw new NoSuchElementException("RowDataSourceScanExec was not found in the given plan")

--- a/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
@@ -286,7 +286,7 @@ class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase with DefaultC
   private def assertOnAbsenceOfCassandraInJoin(df: DataFrame): Unit =
     withClue(s"Given Dataframe plan contains CassandraInJoin in its predecessors.\n${df.queryExecution.sparkPlan.toString()}") {
       df.queryExecution.executedPlan.collectLeaves().collectFirst{
-        case a@BatchScanExec(_, _: CassandraInJoin) => a
+        case a@BatchScanExec(_, _: CassandraInJoin, _) => a
       } shouldBe empty
     }
 

--- a/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
@@ -10,6 +10,7 @@ import org.apache.spark.sql.SaveMode._
 import org.apache.spark.sql.cassandra.CassandraSourceRelation.InClauseToJoinWithTableConversionThreshold
 import org.apache.spark.sql.cassandra.{AnalyzedPredicates, CassandraPredicateRules, CassandraSourceRelation}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.sources.{EqualTo, Filter}
 import org.scalatest.BeforeAndAfterEach
 
@@ -125,7 +126,7 @@ class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase with DefaultC
   }
 
   // This test is just to make sure at runtime the implicit for RDD[Row] can be found
-  it should "implicitly generate a rowWriter from it's RDD form" in {
+  it should "implicitly generate a rowWriter from its RDD form" in {
     spark.sql(s"SELECT a, b from $ks.test1").rdd.saveToCassandra(ks, "test_rowwriter")
   }
 
@@ -269,9 +270,13 @@ class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase with DefaultC
 
   private def assertOnCassandraInJoinPresence(df: DataFrame): Unit = {
     if (pushDown)
-      withClue(s"Given Dataframe plan does not contain CassandraInJoin in it's predecessors.\n${df.queryExecution.sparkPlan.toString()}") {
+      withClue(s"Given Dataframe plan does not contain CassandraInJoin in its predecessors.\n${df.queryExecution.sparkPlan.toString()}") {
         df.queryExecution.executedPlan.collectLeaves().collectFirst{
           case a@BatchScanExec(_, _: CassandraInJoin, _) => a
+          case b@AdaptiveSparkPlanExec(_, _, _, _, _) =>
+            b.executedPlan.collectLeaves().collectFirst{
+              case a@BatchScanExec(_, _: CassandraInJoin, _) => a
+            }
         } shouldBe defined
      }
     else
@@ -279,9 +284,9 @@ class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase with DefaultC
   }
 
   private def assertOnAbsenceOfCassandraInJoin(df: DataFrame): Unit =
-    withClue(s"Given Dataframe plan contains CassandraInJoin in it's predecessors.\n${df.queryExecution.sparkPlan.toString()}") {
+    withClue(s"Given Dataframe plan contains CassandraInJoin in its predecessors.\n${df.queryExecution.sparkPlan.toString()}") {
       df.queryExecution.executedPlan.collectLeaves().collectFirst{
-        case a@BatchScanExec(_, _: CassandraInJoin, _) => a
+        case a@BatchScanExec(_, _: CassandraInJoin) => a
       } shouldBe empty
     }
 

--- a/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataSourceSpec.scala
@@ -271,7 +271,7 @@ class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase with DefaultC
     if (pushDown)
       withClue(s"Given Dataframe plan does not contain CassandraInJoin in it's predecessors.\n${df.queryExecution.sparkPlan.toString()}") {
         df.queryExecution.executedPlan.collectLeaves().collectFirst{
-          case a@BatchScanExec(_, _: CassandraInJoin) => a
+          case a@BatchScanExec(_, _: CassandraInJoin, _) => a
         } shouldBe defined
      }
     else
@@ -281,7 +281,7 @@ class CassandraDataSourceSpec extends SparkCassandraITFlatSpecBase with DefaultC
   private def assertOnAbsenceOfCassandraInJoin(df: DataFrame): Unit =
     withClue(s"Given Dataframe plan contains CassandraInJoin in it's predecessors.\n${df.queryExecution.sparkPlan.toString()}") {
       df.queryExecution.executedPlan.collectLeaves().collectFirst{
-        case a@BatchScanExec(_, _: CassandraInJoin) => a
+        case a@BatchScanExec(_, _: CassandraInJoin, _) => a
       } shouldBe empty
     }
 

--- a/connector/src/it/scala/com/datastax/spark/connector/util/CatalystUtil.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/util/CatalystUtil.scala
@@ -7,6 +7,6 @@ import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 object CatalystUtil {
 
   def findCassandraScan(sparkPlan: SparkPlan): Option[CassandraScan] = {
-    sparkPlan.collectFirst{ case BatchScanExec(_, scan: CassandraScan) => scan}
+    sparkPlan.collectFirst{ case BatchScanExec(_, scan: CassandraScan, _) => scan}
   }
 }

--- a/connector/src/main/scala/com/datastax/spark/connector/cql/AuthConf.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/cql/AuthConf.scala
@@ -1,7 +1,7 @@
 package com.datastax.spark.connector.cql
 
 import com.datastax.oss.driver.api.core.auth.AuthProvider
-import com.datastax.oss.driver.internal.core.auth.ProgrammaticPlainTextAuthProvider
+import com.datastax.oss.driver.api.core.auth.ProgrammaticPlainTextAuthProvider
 import com.datastax.spark.connector.util.{ConfigParameter, ReflectionUtil}
 import org.apache.spark.SparkConf
 

--- a/connector/src/main/scala/org/apache/spark/sql/cassandra/SolrPredicateRules.scala
+++ b/connector/src/main/scala/org/apache/spark/sql/cassandra/SolrPredicateRules.scala
@@ -325,8 +325,9 @@ class SolrPredicateRules(searchOptimizationEnabled: DseSearchOptimizationSetting
 
     val possibleSolrPredicates = allPredicates -- pkRestriction
 
+    val solrEscapedIndexedFields = solrIndexedFields.map(f => '`' + f + '`')
     val (solrConvertibleFilters, sparkFilters) = possibleSolrPredicates
-      .partition(isConvertibleToSolr(_, solrIndexedFields))
+      .partition(isConvertibleToSolr(_, solrIndexedFields ++ solrEscapedIndexedFields))
 
     logDebug(s"Converting $solrConvertibleFilters to Solr Predicates")
     val solrFilters = solrConvertibleFilters.map(convertToSolrFilter)
@@ -422,6 +423,3 @@ class SolrPredicateRules(searchOptimizationEnabled: DseSearchOptimizationSetting
   }
 
 }
-
-
-

--- a/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinExec.scala
+++ b/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinExec.scala
@@ -219,4 +219,6 @@ case class CassandraDirectJoinExec(
 
     s"Cassandra Direct Join [${joinString}] $keyspace.$table - $selectString${pushedWhere} "
   }
+
+  override protected def withNewChildInternal(newChild: SparkPlan): CassandraDirectJoinExec = copy(child = newChild)
 }

--- a/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinStrategy.scala
+++ b/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinStrategy.scala
@@ -147,7 +147,7 @@ object CassandraDirectJoinStrategy extends Logging {
     */
   def getScanExec(plan: SparkPlan): Option[BatchScanExec] = {
     plan.collectFirst {
-      case exec @ BatchScanExec(_, _: CassandraScan) => exec
+      case exec @ BatchScanExec(_, _: CassandraScan, _) => exec
     }
   }
 
@@ -205,7 +205,7 @@ object CassandraDirectJoinStrategy extends Logging {
   def hasCassandraChild[T <: QueryPlan[T]](plan: T): Boolean = {
     plan.children.size == 1 && plan.children.exists {
       case DataSourceV2ScanRelation(DataSourceV2Relation(_: CassandraTable, _, _, _, _), _, _) => true
-      case BatchScanExec(_, _: CassandraScan) => true
+      case BatchScanExec(_, _: CassandraScan, _) => true
       case _ => false
     }
   }
@@ -235,7 +235,7 @@ object CassandraDirectJoinStrategy extends Logging {
   def reorderPlan(plan: SparkPlan, directJoin: CassandraDirectJoinExec): SparkPlan = {
     val reordered = plan match {
       //This may be the only node in the Plan
-      case BatchScanExec(_, _: CassandraScan) => directJoin
+      case BatchScanExec(_, _: CassandraScan, _) => directJoin
       // Plan has children
       case normalPlan => normalPlan.transform {
         case penultimate if hasCassandraChild(penultimate) =>

--- a/doc/14_data_frames.md
+++ b/doc/14_data_frames.md
@@ -255,16 +255,16 @@ range.join(joinTarget, joinTarget("k") === range("key")).explain()
 
 Through Cassandra Spark Extensions special functions are added to SparkSQL.
 
-* writetime(col) - If the column represents an actual C* column this will be replaced
-with the writetime of that column as in cql.
+* `writetime(col)` - If the column represents an actual C* column this will be replaced
+with the WriteTime of that column as in CQL.
 
-* ttl(col) - Similar to writetime, this will replace a valid C* column reference with a
-ttl value instead.
+* `ttl(col)` - Similar to writetime, this will replace a valid C* column reference with a
+TTL value instead.
 
 Read Example
 
 ```sql
-SELECT TTL(v) as t, WRITETIME(t) FROM casscatalog.ksname.testTable WHERE k = -1"
+SELECT TTL(v) as t, WRITETIME(t) FROM casscatalog.ksname.testTable WHERE k = 1
 ```
 
 There are specific write options which can be used to assign WriteTime and TTL. 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,11 +1,11 @@
 object Versions {
 
   val CommonsExec     = "1.3"
-  val CommonsIO       = "2.6"
+  val CommonsIO       = "2.8.0"
   val CommonsLang3    = "3.10"
   val Paranamer       = "2.8"
 
-  val DataStaxJavaDriver = "4.12.0"
+  val DataStaxJavaDriver = "4.13.0"
 
   val ScalaCheck      = "1.14.0"
   val ScalaTest       = "3.0.8"
@@ -21,7 +21,7 @@ object Versions {
   // and install in a local Maven repository. This is all done automatically, however it will work
   // only on Unix/OSX operating system. Windows users have to build and install Spark manually if the
   // desired version is not yet published into a public Maven repository.
-  val ApacheSpark     = "3.1.1"
+  val ApacheSpark     = "3.2.0"
   val SparkJetty      = "9.3.27.v20190418"
   val SolrJ           = "8.3.0"
 


### PR DESCRIPTION
Continuing @alexott 's work from [1333](https://github.com/datastax/spark-cassandra-connector/pull/1333). There were tests failing and I believe the reason was the new adaptive query execution, which was [enabled by default](https://issues.apache.org/jira/browse/SPARK-33679) in 3.2.

I resolved a few tests by simply handling the case of `AdaptiveSparkPlanExec` (the `BatchScanExec` object was nested within it), and another test by including `spark_catalog` as a valid cassandra catalog name (not 100% sure this is the desired handling of this test, let me know what you think).

# Checklist:

- [x] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/projects/SPARKC)
- [x] I have performed a self-review of my own code
- [x] Locally all tests pass (make sure tests fail without your patch)
