### PR TITLE
SPARKC-667 Fix Cassandra Direct Join doesn't quote keyspace and table names (b3.0)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+3.0.2
+ * Fix: Cassandra Direct Join doesn't quote keyspace and table names (SPARKC-667)
+
 3.0.1
  * Fix: repeated metadata refresh with the Spark connector (SPARKC-633)
 

--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/JoinHelper.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/JoinHelper.scala
@@ -62,8 +62,8 @@ object JoinHelper extends Logging {
     val limitClause = CassandraLimit.limitToClause(queryParts.limitClause)
     val orderBy = queryParts.clusteringOrder.map(_.toCql(tableDef)).getOrElse("")
     val filter = (queryParts.whereClause.predicates ++ joinWhere).mkString(" AND ")
-    val quotedKeyspaceName = CqlIdentifier.fromInternal(tableDef.keyspaceName)
-    val quotedTableName = CqlIdentifier.fromInternal(tableDef.tableName)
+    val quotedKeyspaceName = CqlIdentifier.fromInternal(tableDef.keyspaceName).asCql(true)
+    val quotedTableName = CqlIdentifier.fromInternal(tableDef.tableName).asCql(true)
     val query =
       s"SELECT $columns " +
         s"FROM $quotedKeyspaceName.$quotedTableName " +


### PR DESCRIPTION
# Description

## How did the Spark Cassandra Connector Work or Not Work Before this Patch
Cassandra Direct Join doesn't quote keyspace and table names causing issues in special cases, such as when the keyspace name starts with a number. See the [linked issue](https://datastax-oss.atlassian.net/browse/SPARKC-667).

## General Design of the patch

Using the `asCql` method of `CqlIdentifier` to quote keyspace and table name in `JoinHelper`.

Fixes: [SPARKC-667](https://datastax-oss.atlassian.net/browse/SPARKC-667)

# How Has This Been Tested?

Add integration test in `CassandraDirectJoinSpec` to verify the resolution of the issue. The test fails without the fix.
It creates a new keyspace with the name starting with a digit, a simple key-value table, and tries to perform a direct join on that table.

# Checklist:

- [x] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/projects/SPARKC)
- [x] I have performed a self-review of my own code
- [x] Locally all tests pass (make sure tests fail without your patch)
