### PR TITLE
SPARKC-682 Support mixed case Cassandra column names when performing DF join

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ outputLocation defaults to doc/reference.md
 
 ## License
 
-Copyright 2014-2017, DataStax, Inc.
+Copyright 2014-2022, DataStax, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSpec.scala
@@ -82,6 +82,13 @@ class CassandraDataFrameSpec extends SparkCassandraITFlatSpecBase with DefaultCl
             s"""
                |CREATE TABLE $ks.timeuuidtable (k INT, v TIMEUUID, PRIMARY KEY (k))
                |""".stripMargin)
+        },
+
+        Future {
+          session.execute(
+            s"""
+               |CREATE TABLE $ks.camelcasecolumns (k INT, \"camelCase\" INT, PRIMARY KEY (k))
+               |""".stripMargin)
         }
       )
       executor.waitForCurrentlyExecutingTasks()
@@ -407,6 +414,25 @@ class CassandraDataFrameSpec extends SparkCassandraITFlatSpecBase with DefaultCl
     withClue("Test auth factory was not used during the test") {
       TestAuthFactory.used shouldBe true
     }
+  }
+
+  it should "properly join tables with mixed case column names" in {
+    val df1 = spark
+      .read
+      .format("org.apache.spark.sql.cassandra")
+      .options(Map("table" -> "camelcasecolumns", "keyspace" -> ks))
+      .option("directJoinSetting", "on")
+      .load
+
+    val df2 = spark
+      .read
+      .format("org.apache.spark.sql.cassandra")
+      .options(Map("table" -> "camelcasecolumns", "keyspace" -> ks))
+      .option("directJoinSetting", "on")
+      .load
+
+    val other = df1.join(df2, df1.col("camelCase").equalTo(df2.col("camelCase")))
+    other.count should be >= 0L
   }
 }
 

--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/JoinHelper.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/JoinHelper.scala
@@ -58,7 +58,7 @@ object JoinHelper extends Logging {
     logDebug("Generating Single Key Query Prepared Statement String")
     logDebug(s"SelectedColumns : ${queryParts.selectedColumnRefs} -- JoinColumnNames : $joinColumnNames")
     val columns = queryParts.selectedColumnRefs.map(_.cql).mkString(", ")
-    val joinWhere = joinColumnNames.map(name => s"${CqlIdentifier.fromInternal(name)} = :$name")
+    val joinWhere = joinColumnNames.map(name => s"${CqlIdentifier.fromInternal(name).asCql(true)} = :$name")
     val limitClause = CassandraLimit.limitToClause(queryParts.limitClause)
     val orderBy = queryParts.clusteringOrder.map(_.toCql(tableDef)).getOrElse("")
     val filter = (queryParts.whereClause.predicates ++ joinWhere).mkString(" AND ")

--- a/doc/developers.md
+++ b/doc/developers.md
@@ -31,7 +31,7 @@ Cassandra and Spark nodes and are the core of our test coverage.
 
 ### Merge Path
 
-b2.5 => b3.0 => master
+b2.5 => b3.0 => b3.1 => master
 
 New features can be considered for 2.5 as long as they do not break apis.
 Once a feature is ready for b2.5, create a feature branch for b3.0 and merge


### PR DESCRIPTION
[SPARKC-682](https://datastax-oss.atlassian.net/browse/SPARKC-682) Support mixed case Cassandra column names when performing a DF join operation

# Description
When performing a DF join operation, Cassandra column names with mixed case is not handled properly leading to a column not found exception.

## How did the Spark Cassandra Connector Work or Not Work Before this Patch
See description above. Without this patch, column names with mixed case will not be found during a DF join operation.

## General Design of the patch

How the fix is accomplished, were new parameters or classes added? Why did you
pursue this particular fix?

Per @jtgrabowski's suggestion, implement `.asCql(true)` to the join operation.

Fixes: [SPARKC-682](https://datastax-oss.atlassian.net/browse/SPARKC-682)

# How Has This Been Tested?

Almost all changes and especially bug fixes will require a test to be added to either the integration or Unit Tests. Any tests added will be automatically run on travis when the pull request is pushed to github. Be sure to run suites locally as well.

# Checklist:

- [ x] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/projects/SPARKC)
- [x ] I have performed a self-review of my own code
- [x ] Locally all tests pass (make sure tests fail without your patch)
