### PR TITLE
SPARKC-695: Fix projection collapse on CassandraDirectJoinStrategy

### DIFF
--- a/connector/src/it/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinSpec.scala
+++ b/connector/src/it/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinSpec.scala
@@ -98,7 +98,6 @@ class CassandraDirectJoinSpec extends SparkCassandraITFlatSpecBase with DefaultC
                |})""".stripMargin)
         },
         Future {
-          session.execute(s"CREATE TYPE $ks.address (street text, city text, residents set<frozen<tuple<text, text>>>) ")
           session.execute(s"CREATE TYPE $ks.user (address frozen <address>) ")
           session.execute(s"CREATE TABLE $ks.members (id text, user frozen <user>, PRIMARY KEY (id))")
           session.execute(

--- a/connector/src/it/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinSpec.scala
+++ b/connector/src/it/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinSpec.scala
@@ -96,8 +96,6 @@ class CassandraDirectJoinSpec extends SparkCassandraITFlatSpecBase with DefaultC
                |  city: 'New Orleans',
                |  residents:{('sundance', 'dog'), ('cara', 'dog')}
                |})""".stripMargin)
-        },
-        Future {
           session.execute(s"CREATE TYPE $ks.user (address frozen <address>) ")
           session.execute(s"CREATE TABLE $ks.members (id text, user frozen <user>, PRIMARY KEY (id))")
           session.execute(

--- a/connector/src/it/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinSpec.scala
+++ b/connector/src/it/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinSpec.scala
@@ -622,6 +622,14 @@ class CassandraDirectJoinSpec extends SparkCassandraITFlatSpecBase with DefaultC
     left.join(right, left("id") === right("id"))
   }
 
+  it should "work with field extractor after join" in compareDirectOnDirectOff{ spark =>
+    val left = spark.createDataset(Seq(IdRow("test")))
+    val right = spark.read.cassandraFormat("location", ks).load()
+    left.join(right, left("id") === right("id"))
+      .select($"address.*")
+      .select($"street", $"city")
+  }
+
   it should "work on a timestamp PK join" in compareDirectOnDirectOff { spark =>
     val left = spark.createDataset(
       (1 to 100).map(value => TimestampRow(new Timestamp(value.toLong)))

--- a/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinStrategy.scala
+++ b/connector/src/main/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinStrategy.scala
@@ -5,7 +5,7 @@ import com.datastax.spark.connector.util.Logging
 import org.apache.spark.sql.{SparkSession, Strategy}
 import org.apache.spark.sql.cassandra.{AlwaysOff, AlwaysOn, Automatic, CassandraSourceRelation}
 import org.apache.spark.sql.cassandra.CassandraSourceRelation._
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, ExprId, Expression, ExtractValue, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, ExprId, Expression, NamedExpression}
 import org.apache.spark.sql.catalyst.planning.{ExtractEquiJoinKeys, PhysicalOperation}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.plans._


### PR DESCRIPTION
# Description

## How did the Spark Cassandra Connector Work or Not Work Before this Patch


`CassandraDirectJoinStrategy` doesn't consider the case that there are projections of direct join outputs. For example, `address` is a complex type field in cassandra table which is joined with other table:

```
left.join(right, left("id") === right("id"))
  .select($"address.*")
  .select($"street", $"city")
```

The extractors on `address` will be collapsed. So while building alias map in `CassandraDirectJoinStrategy`, it will fail by:

```
scala.MatchError: address#6337.street AS _extract_street#6354 (of class org.apache.spark.sql.catalyst.expressions.Alias)                                                                                                      
[info]   at org.apache.spark.sql.cassandra.execution.CassandraDirectJoinStrategy$.$anonfun$aliasMap$1(CassandraDirectJoinStrategy.scala:316)         
```

## General Design of the patch

Beside fixing this by providing correct alias map, `reorderPlan` is also incorrect for such case. `reorderPlan` now takes direct join output as final output that replaces original plan's output. However, direct output only contains cassandra table scan outputs and other joining side's output. For above example, the outputs are ['id', 'id', 'address'] so it don't match with original plan's output ['street', 'city'].

This patch also fixes incorrect output issue and verifies it by the added integration test.

# How Has This Been Tested?

Added an integration test and verified it locally.

# Checklist:

- [x] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/projects/SPARKC)
- [x] I have performed a self-review of my own code
- [x] Locally all tests pass (make sure tests fail without your patch)
