### PR TITLE
SPARKC-700: Fix complex field extractor after join on CassandraDirectJoinStrategy

### DIFF
--- a/connector/src/it/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinSpec.scala
+++ b/connector/src/it/scala/org/apache/spark/sql/cassandra/execution/CassandraDirectJoinSpec.scala
@@ -649,6 +649,15 @@ class CassandraDirectJoinSpec extends SparkCassandraITFlatSpecBase with DefaultC
       .select($"street", $"city")
   }
 
+  it should "work with complex field extractor after join" in compareDirectOnDirectOff { spark =>
+    val left = spark.createDataset(Seq(IdRow("test")))
+    val right = spark.read.cassandraFormat("location", ks).load()
+      .select($"id", struct("address.street", "address.city") as "struct")
+    left.join(right, left("id") === right("id"))
+      .select($"struct.*")
+      .select($"street", $"city")
+  }
+
   it should "work on a timestamp PK join" in compareDirectOnDirectOff { spark =>
     val left = spark.createDataset(
       (1 to 100).map(value => TimestampRow(new Timestamp(value.toLong)))


### PR DESCRIPTION
# Description

## How did the Spark Cassandra Connector Work or Not Work Before this Patch

We fixed projection collapse on `CassandraDirectJoinStrategy` in https://datastax-oss.atlassian.net/browse/SPARKC-695. But one incorrect assumption during collecting alias mappings is there is only one attribute under the extractor. If users build a struct before the join, and try to extract a field with an extractor, the assert will fail:

## General Design of the patch

The incorrect assumption was fixed in this patch by collecting all attributes under aliased extractor.


Fixes: [SPARKC-700](https://datastax-oss.atlassian.net/browse/SPARKC-700)

# How Has This Been Tested?

Almost all changes and especially bug fixes will require a test to be added to either the integration or Unit Tests. Any tests added will be automatically run on travis when the pull request is pushed to github. Be sure to run suites locally as well.

# Checklist:

- [x] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/projects/SPARKC)
- [x] I have performed a self-review of my own code
- [x] Locally all tests pass (make sure tests fail without your patch)


[SPARKC-700]: https://datastax-oss.atlassian.net/browse/SPARKC-700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ