### PR TITLE
Improve language around project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Spark Cassandra Connector
+# DataStax Connector for Apache Spark to Apache Cassandra
+
+*Lightning-fast cluster computing with Apache Spark&trade; and Apache Cassandra&reg;.*
 
 [![CI](https://github.com/datastax/spark-cassandra-connector/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/datastax/spark-cassandra-connector/actions?query=branch%3Amaster)
 
@@ -6,13 +8,11 @@
 
 | What       | Where                                                                                                                                                                                                                                                                                                                                 |
 | ---------- |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Community  | Chat with us at [Datastax and Cassandra Q&A](https://community.datastax.com/index.html)                                                                                                                                                                                                                                               |
-| Scala Docs | Most Recent Release (3.4.0): [Spark-Cassandra-Connector](https://datastax.github.io/spark-cassandra-connector/ApiDocs/3.4.0/connector/com/datastax/spark/connector/index.html), [Spark-Cassandra-Connector-Driver](https://datastax.github.io/spark-cassandra-connector/ApiDocs/3.4.0/driver/com/datastax/spark/connector/index.html) |
+| Community  | Chat with us at [Apache Cassandra](https://cassandra.apache.org/_/community.html#discussions)                                                                                                                                                                                                                                               |
+| Scala Docs | Most Recent Release (3.4.0): [Connector API docs](https://datastax.github.io/spark-cassandra-connector/ApiDocs/3.4.0/connector/com/datastax/spark/connector/index.html), [Connector Driver docs](https://datastax.github.io/spark-cassandra-connector/ApiDocs/3.4.0/driver/com/datastax/spark/connector/index.html) |
 | Latest Production Release | [3.4.0](https://search.maven.org/artifact/com.datastax.spark/spark-cassandra-connector_2.12/3.4.0/jar)                                                                                                                                                                                                                                |
  
 ## Features
-
-*Lightning-fast cluster computing with Apache Spark&trade; and Apache Cassandra&reg;.*
 
 This library lets you expose Cassandra tables as Spark RDDs and Datasets/DataFrames, write
 Spark RDDs and Datasets/DataFrames to Cassandra tables, and execute arbitrary CQL queries

--- a/connector/src/main/java/com/datastax/spark/connector/japi/RDDAndDStreamCommonJavaFunctions.java
+++ b/connector/src/main/java/com/datastax/spark/connector/japi/RDDAndDStreamCommonJavaFunctions.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 import static com.datastax.spark.connector.japi.CassandraJavaUtil.allColumns;
 
 /**
- * Java API wrapper over either {@code RDD} or {@code DStream} to provide Spark Cassandra Connector functionality.
+ * Java API wrapper over either {@code RDD} or {@code DStream} for the DataStax Connector for Apache Spark to Apache Cassandra.
  *
  * <p>To obtain an instance of the specific wrapper, use one of the factory methods in {@link
  * com.datastax.spark.connector.japi.CassandraJavaUtil} class.</p>

--- a/connector/src/main/scala/com/datastax/spark/connector/package.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/package.scala
@@ -9,7 +9,7 @@ import org.apache.spark.sql.{DataFrame, Dataset, Encoder, Row}
 import scala.language.implicitConversions
 
 /**
- * The root package of Cassandra connector for Apache Spark.
+ * The root package of the DataStax Connector for Apache Spark to Apache Cassandra.
  * Offers handy implicit conversions that add Cassandra-specific methods to
  * [[org.apache.spark.SparkContext SparkContext]] and [[org.apache.spark.rdd.RDD RDD]].
  *

--- a/rootdoc.txt
+++ b/rootdoc.txt
@@ -1,2 +1,2 @@
-Cassandra connector for Apache Spark.
+DataStax Connector for Apache Spark to Apache Cassandra.
 See documentation of package [[com.datastax.spark.connector]].


### PR DESCRIPTION
# Description

Addresses trademark violations against Apache projects.
Update community links to work, using the Apache Cassandra community page.
