### PR TITLE
SPARKC-704 - spark 3.5.0 support (Draft)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+3.5.0
+* Support for Apache Spark 3.5
+
 3.4.0
  * Spark 3.4.x support (SPARKC-702)
  * Fix complex field extractor after join on CassandraDirectJoinStrategy (SPARKC-700)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Spark RDDs and Datasets/DataFrames to Cassandra tables, and execute arbitrary CQ
 in your Spark applications.
 
  - Compatible with Apache Cassandra version 2.1 or higher (see table below)
- - Compatible with Apache Spark 1.0 through 3.4 ([see table below](#version-compatibility))
+ - Compatible with Apache Spark 1.0 through 3.5 ([see table below](#version-compatibility))
  - Compatible with Scala 2.11 and 2.12
  - Exposes Cassandra tables as Spark RDDs and Datasets/DataFrames
  - Maps table rows to CassandraRow objects or tuples
@@ -45,7 +45,8 @@ corresponds to the 1.6 release. The "master" branch will normally contain
 development for the next connector release in progress.
 
 Currently, the following branches are actively supported: 
-3.4.x ([master](https://github.com/datastax/spark-cassandra-connector/tree/master)),
+3.5.x ([master](https://github.com/datastax/spark-cassandra-connector/tree/master)),
+3.4.x ([b3.4](https://github.com/datastax/spark-cassandra-connector/tree/master/b3.4)),
 3.3.x ([b3.2](https://github.com/datastax/spark-cassandra-connector/tree/b3.3)),
 3.2.x ([b3.2](https://github.com/datastax/spark-cassandra-connector/tree/b3.2)),
 3.1.x ([b3.1](https://github.com/datastax/spark-cassandra-connector/tree/b3.1)),
@@ -54,6 +55,7 @@ Currently, the following branches are actively supported:
 
 | Connector | Spark         | Cassandra             | Cassandra Java Driver | Minimum Java Version | Supported Scala Versions |
 |-----------|---------------|-----------------------| --------------------- | -------------------- | -----------------------  |
+| 3.5      | 3.5           | 2.1.5*, 2.2, 3.x, 4.x | 4.13             | 8             | 2.12  
 | 3.4       | 3.4           | 2.1.5*, 2.2, 3.x, 4.x | 4.13             | 8             | 2.12                     |
 | 3.3       | 3.3           | 2.1.5*, 2.2, 3.x, 4.x | 4.13             | 8             | 2.12                     |
 | 3.2       | 3.2           | 2.1.5*, 2.2, 3.x, 4.0 | 4.13             | 8             | 2.12                     |
@@ -105,7 +107,7 @@ This project is available on the Maven Central Repository.
 For SBT to download the connector binaries, sources and javadoc, put this in your project
 SBT config:
 
-    libraryDependencies += "com.datastax.spark" %% "spark-cassandra-connector" % "3.4.0"
+    libraryDependencies += "com.datastax.spark" %% "spark-cassandra-connector" % "3.5.0"
 
 * The default Scala version for Spark 3.0+ is 2.12 please choose the appropriate build. See the
 [FAQ](doc/FAQ.md) for more information.

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,8 @@ ThisBuild / version := Publishing.Version
 
 Global / resolvers ++= Seq(
   DefaultMavenRepository,
-  Resolver.sonatypeRepo("public")
+  Resolver.sonatypeRepo("public"),
+  "Spark-RC-350-Voting-Candidate-1" at "https://repository.apache.org/content/repositories/orgapachespark-1444"
 )
 
 lazy val IntegrationTest = config("it") extend Test

--- a/doc/0_quick_start.md
+++ b/doc/0_quick_start.md
@@ -15,14 +15,14 @@ Configure a new Scala project with the Apache Spark and dependency.
 
 The dependencies are easily retrieved via Maven Central 
 
-    libraryDependencies += "com.datastax.spark" % "spark-cassandra-connector_2.12" % "3.4.0"
+    libraryDependencies += "com.datastax.spark" % "spark-cassandra-connector_2.12" % "3.5.0"
  
 The spark-packages libraries can also be used with spark-submit and spark shell, these
 commands will place the connector and all of its dependencies on the path of the
 Spark Driver and all Spark Executors.
    
-    $SPARK_HOME/bin/spark-shell --packages com.datastax.spark:spark-cassandra-connector_2.12:3.4.0
-    $SPARK_HOME/bin/spark-submit --packages com.datastax.spark:spark-cassandra-connector_2.12:3.4.0
+    $SPARK_HOME/bin/spark-shell --packages com.datastax.spark:spark-cassandra-connector_2.12:3.5.0
+    $SPARK_HOME/bin/spark-submit --packages com.datastax.spark:spark-cassandra-connector_2.12:3.5.0
    
 For the list of available versions, see:
 - https://repo1.maven.org/maven2/com/datastax/spark/spark-cassandra-connector_2.12/
@@ -42,7 +42,7 @@ and *all* of its dependencies on the Spark Class PathTo configure
 the default Spark Configuration pass key value pairs with `--conf`
 
     $SPARK_HOME/bin/spark-shell --conf spark.cassandra.connection.host=127.0.0.1 \
-                                --packages com.datastax.spark:spark-cassandra-connector_2.12:3.4.0
+                                --packages com.datastax.spark:spark-cassandra-connector_2.12:3.5.0
                                 --conf spark.sql.extensions=com.datastax.spark.connector.CassandraSparkExtensions
 
 This command would set the Spark Cassandra Connector parameter 

--- a/doc/13_spark_shell.md
+++ b/doc/13_spark_shell.md
@@ -18,7 +18,7 @@ Find additional versions at [Spark Packages](https://repo1.maven.org/maven2/com/
 ```bash
 cd spark/install/dir
 #Include the --master if you want to run against a spark cluster and not local mode
-./bin/spark-shell [--master sparkMasterAddress] --jars yourAssemblyJar --packages com.datastax.spark:spark-cassandra-connector_2.12:3.4.0 --conf spark.cassandra.connection.host=yourCassandraClusterIp
+./bin/spark-shell [--master sparkMasterAddress] --jars yourAssemblyJar --packages com.datastax.spark:spark-cassandra-connector_2.12:3.5.0 --conf spark.cassandra.connection.host=yourCassandraClusterIp
 ```
 
 By default spark will log everything to the console and this may be a bit of an overload. To change this copy and modify the `log4j.properties` template file

--- a/doc/15_python.md
+++ b/doc/15_python.md
@@ -14,7 +14,7 @@ shell similarly to how the spark shell is started. The preferred method is now t
 
 ```bash
 ./bin/pyspark \
-  --packages com.datastax.spark:spark-cassandra-connector_2.12:3.4.0 \
+  --packages com.datastax.spark:spark-cassandra-connector_2.12:3.5.0 \
   --conf spark.sql.extensions=com.datastax.spark.connector.CassandraSparkExtensions
 ```
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -13,8 +13,8 @@ object Versions {
   val JUnitInterface  = "0.11"
   val Mockito         = "1.10.19"
 
-  val ApacheSpark     = "3.4.1"
-  val SparkJetty      = "9.4.50.v20221201"
+  val ApacheSpark     = "3.5.0"
+  val SparkJetty      = "9.4.51.v20230217"
   val SolrJ           = "8.3.0"
 
   val ScalaCompat         = "2.11.0"


### PR DESCRIPTION
# Description

Upgrades core dependencies ready for spark 3.5.0.

## How did the Spark Cassandra Connector Work or Not Work Before this Patch

N.A - clean upgrade path

## General Design of the patch

How the fix is accomplished, were new parameters or classes added? Why did you
pursue this particular fix?

This has been persued to aid the community in preparing a release, with a goal that we can rapidly deliver an update on the 3.5.* stream, as I am an eager adopter.

Provides: [SPARKC-704](https://datastax-oss.atlassian.net/jira/software/c/projects/SPARKC/issues/SPARKC-704)

# How Has This Been Tested?

The upgrade has been tested via unit tests, and a limited run of external integration tests; clearly more validation is appreciated during RC stages by other users to extend the scope. The staging repository was used to fetch Spark 3.5* release candidate builds. As this progresses from a draft state, we should seek to remove that registry from the set of resolvers for the project.

```
sbt/sbt test ...


[info] Test run finished: 0 failed, 0 ignored, 18 total, 0.067s
[info] ScalaTest
[info] Run completed in 7 seconds, 415 milliseconds.
[info] Total number of tests run: 146
[info] Suites: completed 12, aborted 0
[info] Tests: succeeded 146, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 245, Failed 0, Errors 0, Passed 245
```

# Checklist:

- [x] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/projects/SPARKC)
- [x] I have performed a self-review of my own code
- [x] Locally all tests pass (make sure tests fail without your patch)
