### PR TITLE
SPARKC-707: Remove references to DataStax Academy

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,7 @@ See [Building And Artifacts](doc/12_building_and_artifacts.md)
 
 ## Online Training
 
-### DataStax Academy
-
-DataStax Academy provides free online training for Apache Cassandra and DataStax Enterprise. In [DS320: Analytics with Spark](https://academy.datastax.com/courses/ds320-analytics-with-apache-spark), you will learn how to effectively and efficiently solve analytical problems with Apache Spark, Apache Cassandra, and DataStax Enterprise. You will learn about Spark API, Spark-Cassandra Connector, Spark SQL, Spark Streaming, and crucial performance optimization techniques.
+In [DS320: Analytics with Spark](https://www.youtube.com/watch?v=D6PMEQAfjeU&list=PL2g2h-wyI4Sp0bqsw_IRYu1M4aPkt045x), you will learn how to effectively and efficiently solve analytical problems with Apache Spark, Apache Cassandra, and DataStax Enterprise. You will learn about Spark API, Spark-Cassandra Connector, Spark SQL, Spark Streaming, and crucial performance optimization techniques.
 
 ## Community
 

--- a/doc/16_partitioning.md
+++ b/doc/16_partitioning.md
@@ -18,8 +18,7 @@ a CQL Row and uses it to determine what node in the Cassandra cluster should hos
 partitioner generates a `Token` which directly maps to the `TokenRange` of the CassandraCluster.
 Each node in the Cassandra Cluster is responsible for a specific section of the full `TokenRange`.
 
-For more information on Cassandra Data Modeling check out the resources on 
-[DataStax Academy](https://academy.datastax.com/courses/ds220-data-modeling).
+For more information on Cassandra Data Modeling check out [DS220 Data Modeling](https://www.youtube.com/watch?v=jYvKiewV-5Q&list=PL2g2h-wyI4SqIigskyJNAeL2vSTJZU_Qp).
 
 ### How to take advantage of Cassandra Partitioning in Spark
 


### PR DESCRIPTION
# Description

Removes two references to DS Academy courses and replaces them with links to the same courses on YouTube.

## How did the Spark Cassandra Connector Work or Not Work Before this Patch

Two markdown files contained references to DataStax Academy courses that no longer exist at the referenced URLs.

## General Design of the patch

I replaced the DS Academy course URLs with links to the same courses on YouTube 

Fixes: [SPARKC-707](https://datastax-oss.atlassian.net/browse/SPARKC-707)

# How Has This Been Tested?

Links in rendered markdown successfully open the correct video playlists in YouTube.

# Checklist:

- [x] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/projects/SPARKC)
- [x] I have performed a self-review of my own code
- [x] Locally all tests pass (make sure tests fail without your patch)


[SPARKC-707]: https://datastax-oss.atlassian.net/browse/SPARKC-707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ