### PR TITLE
Fix for SPARKC-699: Projection of Sub Elements

### DIFF
--- a/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSelectUdtSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSelectUdtSpec.scala
@@ -3,6 +3,7 @@ package com.datastax.spark.connector.sql
 import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
 import com.datastax.spark.connector.cluster.DefaultCluster
 import com.datastax.spark.connector.cql.CassandraConnector
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions.col
 import org.scalatest.Matchers
 import org.scalatest.concurrent.Eventually
@@ -25,15 +26,25 @@ class CassandraDataFrameSelectUdtSpec extends SparkCassandraITFlatSpecBase with 
         |        id INT,
         |        embeddeds LIST<FROZEN<embedded>>,
         |        single embedded,
+        |        embedded_map MAP<INT, FROZEN<embedded>>,
+        |        embedded_set SET<FROZEN<embedded>>,
         |        PRIMARY KEY (id)
         |    )""".stripMargin
     )
 
     session.execute(
-      s"""INSERT INTO ${ks}.crash_test JSON '{"id": 1, "embeddeds": []}'"""
+      s"""INSERT INTO ${ks}.crash_test JSON '{"id": 1, "embeddeds": [], "embedded_map": {}, "embedded_set": []}'"""
     )
     session.execute(
-      s"""INSERT INTO ${ks}.crash_test JSON '{"id": 2, "single": {"a": "a1", "b": 1}, "embeddeds": [{"a": "x1", "b": 1}, {"a": "x2", "b": 2}]}'"""
+      s"""INSERT INTO ${ks}.crash_test JSON
+         |'{
+         |  "id": 2,
+         |  "single": {"a": "a1", "b": 1},
+         |  "embeddeds": [{"a": "x1", "b": 1}, {"a": "x2", "b": 2}],
+         |  "embedded_map": {"1": {"a": "x1", "b": 1}, "2": {"a": "x2", "b": 2}},
+         |  "embedded_set": [{"a": "x1", "b": 1}, {"a": "x2", "b": 2}]
+         |}'
+         |""".stripMargin
     )
   }
 
@@ -53,13 +64,15 @@ class CassandraDataFrameSelectUdtSpec extends SparkCassandraITFlatSpecBase with 
 
   it should "allow selecting single elements" in new Env {
     val elements = df.select(col("id"), col("single.b")).collect().map { row =>
-      if (row.isNullAt(1)) {
-        0
-      } else {
-        row.getInt(1)
-      }
+      optionalInt(row, 1).getOrElse(0)
     }
     elements should contain theSameElementsAs Seq(0, 1)
+  }
+
+  it should "allow selecting single elements with renaming" in new Env {
+    df.select(col("single.b").as("x")).collect().map { row =>
+      optionalInt(row, 0).getOrElse(0)
+    } should contain theSameElementsAs Seq(0,1)
   }
 
   it should "allow selecting projections in lists" in new Env {
@@ -67,5 +80,25 @@ class CassandraDataFrameSelectUdtSpec extends SparkCassandraITFlatSpecBase with 
       row.getAs[Seq[Int]](1).sum
     }
     elements should contain theSameElementsAs Seq(0, 3)
+  }
+
+  it should "allow selecting projections in maps" in new Env {
+    val elements = df.select("embedded_map.value.b")
+    elements.show()
+  }
+
+  it should "allow selecting projections in sets" in new Env {
+    val elements = df.select("embedded_set.b").collect().map { row =>
+      row.getAs[Seq[Int]](0).sum
+    }
+    elements should contain theSameElementsAs Seq(0, 3)
+  }
+
+  private def optionalInt(row: Row, idx: Int): Option[Int] = {
+    if (row.isNullAt(idx)) {
+      None
+    } else {
+      Some(row.getInt(idx))
+    }
   }
 }

--- a/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSelectUdtSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSelectUdtSpec.scala
@@ -1,0 +1,62 @@
+package com.datastax.spark.connector.sql
+
+import com.datastax.spark.connector.SparkCassandraITFlatSpecBase
+import com.datastax.spark.connector.cluster.DefaultCluster
+import com.datastax.spark.connector.cql.CassandraConnector
+import org.apache.spark.sql.functions.col
+import org.scalatest.Matchers
+import org.scalatest.concurrent.Eventually
+
+class CassandraDataFrameSelectUdtSpec extends SparkCassandraITFlatSpecBase with DefaultCluster with Eventually with Matchers {
+  override lazy val conn = CassandraConnector(defaultConf)
+
+  conn.withSessionDo { session =>
+    createKeyspace(session)
+
+    session.execute(
+      s"""CREATE TYPE ${ks}.embedded(
+        |        a TEXT,
+        |        b INT
+        |    )""".stripMargin
+    )
+
+    session.execute(
+      s"""CREATE TABLE ${ks}.crash_test(
+        |        id INT,
+        |        embeddeds LIST<FROZEN<embedded>>,
+        |        PRIMARY KEY (id)
+        |    )""".stripMargin
+    )
+
+    session.execute(
+      s"""INSERT INTO ${ks}.crash_test JSON '{"id": 1, "embeddeds": []}'"""
+    )
+    session.execute(
+      s"""INSERT INTO ${ks}.crash_test JSON '{"id": 1, "embeddeds": [{"a": "x1", "b": 1}, {"a": "x2", "b": 2}]}'"""
+    )
+  }
+
+
+  it should "allow selecting projections" in {
+    val df = spark
+      .read
+      .format("org.apache.spark.sql.cassandra")
+      .options(
+        Map(
+          "table" -> "crash_test",
+          "keyspace" -> ks
+        )
+      )
+      .load()
+
+    val elements = df.select(col("embeddeds.b")).collect().flatMap { row =>
+      if (row.isNullAt(0)) {
+        None
+      } else {
+        Some(row.getInt(0))
+      }
+    }
+    elements shouldBe Seq(2)
+  }
+
+}

--- a/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSelectUdtSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSelectUdtSpec.scala
@@ -59,7 +59,6 @@ class CassandraDataFrameSelectUdtSpec extends SparkCassandraITFlatSpecBase with 
         )
       )
       .load()
-      // .cache() // this works
   }
 
   it should "allow selecting single elements" in new Env {

--- a/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSelectUdtSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSelectUdtSpec.scala
@@ -83,8 +83,10 @@ class CassandraDataFrameSelectUdtSpec extends SparkCassandraITFlatSpecBase with 
   }
 
   it should "allow selecting projections in maps" in new Env {
-    val elements = df.select("embedded_map.value.b")
-    elements.show()
+    val elements = df.select("embedded_map.1.b").collect().map { row =>
+      optionalInt(row, 0).getOrElse(0)
+    }
+    elements should contain theSameElementsAs Seq(0, 1)
   }
 
   it should "allow selecting projections in sets" in new Env {

--- a/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSelectUdtSpec.scala
+++ b/connector/src/it/scala/com/datastax/spark/connector/sql/CassandraDataFrameSelectUdtSpec.scala
@@ -32,7 +32,7 @@ class CassandraDataFrameSelectUdtSpec extends SparkCassandraITFlatSpecBase with 
       s"""INSERT INTO ${ks}.crash_test JSON '{"id": 1, "embeddeds": []}'"""
     )
     session.execute(
-      s"""INSERT INTO ${ks}.crash_test JSON '{"id": 1, "embeddeds": [{"a": "x1", "b": 1}, {"a": "x2", "b": 2}]}'"""
+      s"""INSERT INTO ${ks}.crash_test JSON '{"id": 2, "embeddeds": [{"a": "x1", "b": 1}, {"a": "x2", "b": 2}]}'"""
     )
   }
 
@@ -48,15 +48,11 @@ class CassandraDataFrameSelectUdtSpec extends SparkCassandraITFlatSpecBase with 
         )
       )
       .load()
+      // .cache()
 
-    val elements = df.select(col("embeddeds.b")).collect().flatMap { row =>
-      if (row.isNullAt(0)) {
-        None
-      } else {
-        Some(row.getInt(0))
-      }
+    val elements = df.select(col("id"), col("embeddeds.b")).collect().map { row =>
+      row.getAs[Seq[Int]](1).sum
     }
-    elements shouldBe Seq(2)
+    elements should contain theSameElementsAs Seq(0, 3)
   }
-
 }

--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/UnsafeRowReaderFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/UnsafeRowReaderFactory.scala
@@ -3,26 +3,37 @@ package com.datastax.spark.connector.datasource
 import com.datastax.oss.driver.api.core.cql.Row
 import com.datastax.spark.connector.cql.TableDef
 import com.datastax.spark.connector.rdd.reader.{RowReader, RowReaderFactory}
-import com.datastax.spark.connector.{CassandraRow, CassandraRowMetadata, ColumnRef}
+import com.datastax.spark.connector.{CassandraRow, CassandraRowMetadata, ColumnRef, UDTValue}
 import org.apache.spark.sql.cassandra.CassandraSQLRow.toUnsafeSqlType
 import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructField, StructType}
 import org.apache.spark.sql.{Row => SparkRow}
 
 class UnsafeRowReaderFactory(schema: StructType) extends RowReaderFactory[UnsafeRow] {
 
   override def rowReader(table: TableDef, selectedColumns: IndexedSeq[ColumnRef]):
-  RowReader[UnsafeRow] = new UnsafeRowReader(schema)
+  RowReader[UnsafeRow] = new UnsafeRowReader(selectedColumns, schema)
 
   override def targetClass: Class[UnsafeRow] = classOf[UnsafeRow]
 }
 
-class UnsafeRowReader(schema: StructType)
+class UnsafeRowReader(selectedColumns: IndexedSeq[ColumnRef], schema: StructType)
   extends RowReader[UnsafeRow] {
+
+  println(s"Schema: ${schema}")
+  println(s"SelectedColumns: ${selectedColumns}")
+  private val selectionSchema = StructType(
+    selectedColumns.map { columnRef =>
+      schema(columnRef.selectedAs)
+    }
+  )
+  println(s"SelectionSchema: ${selectionSchema}")
 
   @transient private lazy val projection = UnsafeProjection.create(schema)
   private val converter = CatalystTypeConverters.createToCatalystConverter(schema)
+
+  val projectionDecoder = UdtProjectionDecoder.build(schema)
 
   /** Reads column values from low-level `Row` and turns them into higher level representation.
     *
@@ -31,9 +42,10 @@ class UnsafeRowReader(schema: StructType)
   override def read(row: Row, rowMetaData: CassandraRowMetadata): UnsafeRow = {
     val data = CassandraRow.dataFromJavaDriverRow(row, rowMetaData)
     val sparkRow = SparkRow(data.map(toUnsafeSqlType): _*)
+    val projectionDecoded = projectionDecoder(sparkRow)
     // TODO: SparkRow muss auf die Teilelemente heruntergebrochen werden
     val converterOutput = converter
-      .apply(sparkRow)
+      .apply(projectionDecoded)
       .asInstanceOf[InternalRow]
 
     projection.apply(converterOutput)
@@ -42,4 +54,83 @@ class UnsafeRowReader(schema: StructType)
   /** List of columns this `RowReader` is going to read.
     * Useful to avoid fetching the columns that are not needed. */
   override def neededColumns: Option[Seq[ColumnRef]] = None
+}
+
+/** Helper for decoding sub selections of Cassandra UDTs. */
+object UdtProjectionDecoder {
+
+  def build(schema: StructType): SparkRow => SparkRow = {
+    if (!hasProjections(schema)) {
+      return identity
+    }
+
+    buildRootDecoder(schema)
+    /*
+    val modified = input.get(1) match {
+      case null => null
+      case udt: UDTValue =>
+        UDTValue(udt.columnNames.drop(1), udt.columnValues.drop(1))
+      case unknown =>
+        println(s"What is this? ${unknown}")
+        unknown
+    }
+    SparkRow.apply(input.get(0), modified)
+     */
+  }
+
+  def buildRootDecoder(schema: StructType): SparkRow => SparkRow = {
+    val childEncoders = schema.fields.map(field => buildDataTypeDecoder(field.dataType))
+    row => {
+      val updated = Array.tabulate[Any](childEncoders.size) { idx =>
+        childEncoders(idx)(row.get(idx))
+      }
+      SparkRow(updated: _*)
+    }
+  }
+
+  def buildDataTypeDecoder(dataType: DataType): Any => Any = {
+    dataType match {
+      case s: StructType =>
+        val childDecoders = s.fields.map(field => buildDataTypeDecoder(field.dataType)).toIndexedSeq
+        input => {
+          input match {
+            case null => null
+            case udt: UDTValue =>
+              val selectedValues = s.fields.zipWithIndex.map { case (field, idx) =>
+                val originalIndex = udt.indexOf(field.name)
+                val decoded = childDecoders(idx)(udt.columnValues(originalIndex))
+                decoded.asInstanceOf[AnyRef]
+              }
+              UDTValue.apply(s.fieldNames.toIndexedSeq, selectedValues.toIndexedSeq)
+            case other =>
+              // ??
+              other
+          }
+        }
+      case a: ArrayType =>
+        val keyDecoder = buildDataTypeDecoder(a.elementType)
+        ???
+      case m: MapType =>
+        val keyDecoder = buildDataTypeDecoder(m.keyType)
+        val valueDecoder = buildDataTypeDecoder(m.valueType)
+        ???
+      case _ =>
+        identity
+    }
+  }
+
+  private def hasProjections(schema: StructType): Boolean = {
+    schema.fields.exists { structField =>
+      hasStructTypes(structField.dataType)
+    }
+  }
+
+  private def hasStructTypes(dataType: DataType): Boolean = {
+    dataType match {
+      case _: StructType => true
+      case a: ArrayType => hasStructTypes(a.elementType)
+      case m: MapType => hasStructTypes(m.keyType) || hasStructTypes(m.valueType)
+      case _ => false
+    }
+  }
 }

--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/UnsafeRowReaderFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/UnsafeRowReaderFactory.scala
@@ -30,8 +30,10 @@ class UnsafeRowReader(schema: StructType)
     * @param rowMetaData column names and codec available in the `row`*/
   override def read(row: Row, rowMetaData: CassandraRowMetadata): UnsafeRow = {
     val data = CassandraRow.dataFromJavaDriverRow(row, rowMetaData)
+    val sparkRow = SparkRow(data.map(toUnsafeSqlType): _*)
+    // TODO: SparkRow muss auf die Teilelemente heruntergebrochen werden
     val converterOutput = converter
-      .apply(SparkRow(data.map(toUnsafeSqlType): _*))
+      .apply(sparkRow)
       .asInstanceOf[InternalRow]
 
     projection.apply(converterOutput)

--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/UnsafeRowReaderFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/UnsafeRowReaderFactory.scala
@@ -60,7 +60,7 @@ object UdtProjectionDecoder {
   def buildRootDecoder(schema: StructType): SparkRow => SparkRow = {
     val childEncoders = schema.fields.map(field => buildDataTypeDecoder(field.dataType))
     row => {
-      val updated = Array.tabulate[Any](childEncoders.size) { idx =>
+      val updated = Array.tabulate[Any](childEncoders.length) { idx =>
         childEncoders(idx)(row.get(idx))
       }
       SparkRow(updated: _*)

--- a/test-support/src/main/scala/com/datastax/spark/connector/ccm/ClusterMode.scala
+++ b/test-support/src/main/scala/com/datastax/spark/connector/ccm/ClusterMode.scala
@@ -1,6 +1,6 @@
 package com.datastax.spark.connector.ccm
 
-import com.datastax.spark.connector.ccm.mode.{ClusterModeExecutor, DebugModeExecutor, DeveloperModeExecutor, StandardModeExecutor}
+import com.datastax.spark.connector.ccm.mode.{ClusterModeExecutor, DebugModeExecutor, DeveloperModeExecutor, ExistingModeExecutor, StandardModeExecutor}
 
 sealed trait ClusterMode {
   def executor(config: CcmConfig): ClusterModeExecutor
@@ -37,9 +37,13 @@ object ClusterModes {
     def executor(config: CcmConfig): ClusterModeExecutor = new DeveloperModeExecutor(config)
   }
 
+  case object Existing extends ClusterMode {
+    override def executor(config: CcmConfig): ClusterModeExecutor = new ExistingModeExecutor(config)
+  }
+
   def fromEnvVar: ClusterMode = {
     // we could use Reflection lib or scala-reflect (both are not present on CP at the moment)
-    val knownModes = Seq(Standard, Debug, Developer)
+    val knownModes = Seq(Standard, Debug, Developer, Existing)
 
     sys.env.get("CCM_CLUSTER_MODE").flatMap { modeName =>
       knownModes.collectFirst {

--- a/test-support/src/main/scala/com/datastax/spark/connector/ccm/mode/ExistingModeExecutor.scala
+++ b/test-support/src/main/scala/com/datastax/spark/connector/ccm/mode/ExistingModeExecutor.scala
@@ -3,6 +3,10 @@ import com.datastax.spark.connector.ccm.CcmConfig
 
 import java.nio.file.{Files, Path}
 
+/**
+ * A special ClusterModeExecutor which bypasses ccm and assumes a Cassandra instance on localhost
+ * with default ports and no authentication.
+ * */
 private[ccm] class ExistingModeExecutor(val config: CcmConfig) extends ClusterModeExecutor {
   override protected val dir: Path = Files.createTempDirectory("test")
 

--- a/test-support/src/main/scala/com/datastax/spark/connector/ccm/mode/ExistingModeExecutor.scala
+++ b/test-support/src/main/scala/com/datastax/spark/connector/ccm/mode/ExistingModeExecutor.scala
@@ -1,0 +1,20 @@
+package com.datastax.spark.connector.ccm.mode
+import com.datastax.spark.connector.ccm.CcmConfig
+
+import java.nio.file.{Files, Path}
+
+private[ccm] class ExistingModeExecutor(val config: CcmConfig) extends ClusterModeExecutor {
+  override protected val dir: Path = Files.createTempDirectory("test")
+
+  override def create(clusterName: String): Unit = {
+    // do nothing
+  }
+
+  override def start(nodeNo: Int): Unit = {
+    // do nothing
+  }
+
+  override def remove(): Unit = {
+    // do nothing
+  }
+}


### PR DESCRIPTION
# Description

## How did the Spark Cassandra Connector Work or Not Work Before this Patch

Spark Cassandra Connector was crashing with ClassCastExceptions when selecting UDT fields on pushed down Selections.

The cassandra calls always select whole fields. To my knowledge, cassandra has no possibility to select UDT fields directly. However the the decoder to spark expects only the selected UDT field to be presented. During decoding, it always decodes the first element (which may be of a different type) and thus failing with class cast exception, or in case of same types with a wrong value.

## General Design of the patch

- UnsafeRowReader has now an extra decoder step which fulfils the decoding of projected UDT fields.
- The decoding is done by a new class `UdtProjectionDecoder`
- Added a new Cluster Mode "EXISTING" so that I can run integration tests on a locally running cassandra instance without relying on ccm.

Fixes: [SPARKC-699](https://datastax-oss.atlassian.net/browse/SPARKC-699)

# How Has This Been Tested?

There is a new Integration Test `CassandraDataFrameSelectUdtSpec`

# Checklist:

- [x] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/projects/SPARKC)
- [x] I have performed a self-review of my own code
- [x] Locally all tests pass (make sure tests fail without your patch)



[SPARKC-699]: https://datastax-oss.atlassian.net/browse/SPARKC-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ