### PR TITLE
SPARKC-712: Update metrics for read and writes via DSV2

### DIFF
--- a/connector/src/main/scala/com/datastax/spark/connector/datasource/CasssandraDriverDataWriterFactory.scala
+++ b/connector/src/main/scala/com/datastax/spark/connector/datasource/CasssandraDriverDataWriterFactory.scala
@@ -7,6 +7,8 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.write.streaming.StreamingDataWriterFactory
 import org.apache.spark.sql.connector.write.{DataWriter, DataWriterFactory, WriterCommitMessage}
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.metrics.OutputMetricsUpdater
+import org.apache.spark.TaskContext
 
 case class CassandraDriverDataWriterFactory(
   connector: CassandraConnector,
@@ -36,22 +38,31 @@ case class CassandraDriverDataWriter(
 
   private val columns = SomeColumns(inputSchema.fieldNames.map(name => ColumnName(name)): _*)
 
-  private val writer =
+  private lazy val metricsUpdater = OutputMetricsUpdater(TaskContext.get(), writeConf)
+
+  private val asycWriter =
     TableWriter(connector, tableDef, columns, writeConf, false)(unsafeRowWriterFactory)
       .getAsyncWriter()
+
+  private val writer = asycWriter.copy(
+      successHandler = Some(metricsUpdater.batchFinished(success = true, _, _, _)),
+      failureHandler = Some(metricsUpdater.batchFinished(success = false, _, _, _)))
 
   override def write(record: InternalRow): Unit = writer.write(record)
 
   override def commit(): WriterCommitMessage = {
+    metricsUpdater.finish()
     writer.close()
     CassandraCommitMessage()
   }
 
   override def abort(): Unit = {
+    metricsUpdater.finish()
     writer.close()
   }
 
   override def close(): Unit = {
+    metricsUpdater.finish()
     //Our proxy Session Handler handles double closes by ignoring them so this is fine
     writer.close()
   }


### PR DESCRIPTION
# Description

## How did the Spark Cassandra Connector Work or Not Work Before this Patch

> Describe the problem, or state of the project that this patch fixes. Explain
> why this is a problem if this isn't obvious.
>
> Example: 
>  "When I read from tables with 3 INTS I get a ThreeIntException(). This is a problem because I often want to read from a > table with three integers."

Metrics are not updated for read and writes performed via DSV2. The values returned are all 0s.

## General Design of the patch

> How the fix is accomplished, were new parameters or classes added? Why did you
> pursue this particular fix?
> 
> Example: "I removed the incorrect assertion which would throw the ThreeIntException. This exception was incorrectly added and the assertion is not actually needed."
> 
> Fixes: Put JIRA Reference

InputMetricsUpdater and OutputMetricsUpdater are used in the DSV2 read (including joins and counts) and write paths.

Fixes: [SPARKC-712](https://datastax-oss.atlassian.net/browse/SPARKC-712)

# How Has This Been Tested?

> Almost all changes and especially bug fixes will require a test to be added to either the integration or Unit Tests. Any tests added will be automatically run on travis when the pull request is pushed to github. Be sure to run suites locally as well.

Using the following CQL schema:
```
CREATE KEYSPACE test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 };
CREATE TABLE test.students (name text PRIMARY KEY, age int);
```

Running Spark with `spark.cassandra.sql.inClauseToJoinConversionThreshold=2`:
```
./spark-3.5.1-bin-hadoop3/bin/spark-shell   \
        --jars ./spark-cassandra-connector/connector/target/scala-2.12/spark-cassandra-connector-assembly-3.5.0-*.jar  \
        --conf spark.sql.extensions=com.datastax.spark.connector.CassandraSparkExtensions \
        --conf spark.metrics.conf.executor.source.cassandra-connector.class=org.apache.spark.metrics.CassandraConnectorSource \
        --conf spark.metrics.conf.driver.source.cassandra-connector.class=org.apache.spark.metrics.CassandraConnectorSource \
        --conf 'spark.executor.extraJavaOptions=-javaagent:./jmx_prometheus_javaagent-0.19.0.jar=9091:./cassandra_spark_prom_jmx_executor.yaml' \
        --conf 'spark.driver.extraJavaOptions=-javaagent:./jmx_prometheus_javaagent-0.19.0.jar=9091:./cassandra_spark_prom_jmx_executor.yaml' \
        --conf 'spark.metrics.conf.*.sink.jmx.class=org.apache.spark.metrics.sink.JmxSink'
```

Here are a few tests and the count by which metrics were incremented:

### Write
```scala
val df = Seq(("student1", 20)).toDF("name", "age");
df.write.format("org.apache.spark.sql.cassandra").mode("append").options(Map("table" -> "students", "keyspace" -> "test")).save()
```

- write_batch_size_histogram +1
- write_batch_timer +1
- write_batch_wait_timer +1
- write_byte_meter +12
- write_row_meter +1
- write_success_counter +1
- write_task_timer +2

### Read

```scala
val df = spark.read.format("org.apache.spark.sql.cassandra").options(Map("table" -> "students", "keyspace" -> "test")).load()
df.show(1)
```

- read_byte_meter +12
- read_row_meter +1
- read_task_timer +17


### Count
```scala
val df = spark.read.format("org.apache.spark.sql.cassandra").options(Map("table" -> "students", "keyspace" -> "test")).load()
df.count()
```

- read_byte_meter +136
- read_row_meter +17
- read_task_timer +17

### Count using DSV1, for comparison
```scala
import com.datastax.spark.connector._
val sparkMasterHost = "127.0.0.1"
val cassandraHost = "127.0.0.1"
val keyspace = "test"
val table = "students"
val conf = new org.apache.spark.SparkConf(true).set("spark.cassandra.connection.host", cassandraHost)
val rdd = sc.cassandraTable(keyspace, table)
rdd.cassandraCount()
```
- read_byte_meter +136
- read_row_meter +17
- read_task_timer +14

# Checklist:

- [x] I have a ticket in the [OSS JIRA](https://datastax-oss.atlassian.net/projects/SPARKC): https://datastax-oss.atlassian.net/browse/SPARKC-712
- [x] I have performed a self-review of my own code
- [x] Locally all tests pass (make sure tests fail without your patch)


[SPARKC-712]: https://datastax-oss.atlassian.net/browse/SPARKC-712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


