### PR TITLE
JAVA-3166: Enhanced exception handling of C* driver executeAsync()

### DIFF
--- a/connector/src/test/scala/com/datastax/spark/connector/writer/AsyncExecutorTest.scala
+++ b/connector/src/test/scala/com/datastax/spark/connector/writer/AsyncExecutorTest.scala
@@ -1,5 +1,7 @@
 package com.datastax.spark.connector.writer
 
+import com.datastax.oss.driver.api.core.cql.{AsyncResultSet, SimpleStatement, Statement}
+
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{Callable, CompletableFuture, CompletionStage}
 
@@ -54,5 +56,21 @@ class AsyncExecutorTest {
     maxParallelCounter.get() should be <= maxParallel
     totalFinishedExecutionsCounter.get() shouldBe taskCount
     asyncExecutor.getLatestException() shouldBe None
+  }
+
+  @Test
+  def testGracefullyHandleCqlSessionExecuteExceptions() {
+    val executor = new AsyncExecutor[Statement[_], AsyncResultSet](
+      _ => {
+        // simulate exception returned by session.executeAsync() (not future)
+        throw new IllegalStateException("something bad happened")
+      }, 10, None, None
+    )
+    val stmt = SimpleStatement.newInstance("INSERT INTO table1 (key, value) VALUES (1, '100')");
+    val future = executor.executeAsync(stmt)
+    assertTrue(future.isCompleted)
+    val value = future.value.get
+    assertTrue(value.isInstanceOf[Failure[_]])
+    assertTrue(value.asInstanceOf[Failure[_]].exception.isInstanceOf[IllegalStateException])
   }
 }


### PR DESCRIPTION
Handling of exceptions that may be thrown by `CqlSession#executeAsync()`. Otherwise semaphore in `AsyncExecutor` is not released and processing of further tasks blocked.

Fixes: [JAVA-3166](https://datastax-oss.atlassian.net/jira/software/c/projects/JAVA/issues/JAVA-3166)

- [ ] Shall I create a new ticket under SPARKC project?
- [X] I have performed a self-review of my own code
- [X] Locally all tests pass (make sure tests fail without your patch)


[JAVA-3166]: https://datastax-oss.atlassian.net/browse/JAVA-3166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ