### PR TITLE
CASSANALYTICS-54: Upgrade Cassandra driver to 4.19.0

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -23,7 +23,7 @@ object Versions {
   val CommonsLang3    = "3.10"
   val Paranamer       = "2.8"
 
-  val CassandraJavaDriver = "4.18.1"
+  val CassandraJavaDriver = "4.19.0"
   val EsriGeometry        = "2.2.4"
 
   val ScalaCheck      = "1.14.0"


### PR DESCRIPTION
# Description

## How did the Spark Cassandra Connector Work or Not Work Before this Patch

Cassandra driver 4.19.0 brings a a lot of improvements and bugfixes (see https://github.com/apache/cassandra-java-driver/releases/tag/4.19.0 ) which the connector can benefit from. In particular [JAVA-3168](https://datastax-oss.atlassian.net/browse/JAVA-3168) brings a fix to unlock connecting to Cassandra running on Kubernetes behind a LB reliably.

## General Design of the patch

Fixes: [CASSANALYTICS-54](https://issues.apache.org/jira/browse/CASSANALYTICS-54)

# How Has This Been Tested?

Unit and integration tests locally.

# Checklist:

- [X] I have a ticket in the [CASSANALYTICS-54](https://issues.apache.org/jira/browse/CASSANALYTICS-54)
- [X] I have performed a self-review of my own code
- [ ] Locally all tests pass (make sure tests fail without your patch)
