### PR TITLE
CASSANALYTICS-68: Optimise byte array to hex string conversion

### DIFF
--- a/driver/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
+++ b/driver/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
@@ -270,7 +270,18 @@ object TypeConverter {
     }
   }
 
-  private def byteArrayToString (x: Array[Byte])  = "0x" + x.map("%02x" format _).mkString
+  private val HEX_CHARS = Array(
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
+  )
+  private def byteArrayToString (x: Array[Byte]) : String = {
+    val result = new StringBuilder(x.length * 2) 
+    x.foreach { b =>
+      val v = b & 0xFF
+      result.append(HEX_CHARS(v >>> 4))
+      result.append(HEX_CHARS(v & 0x0F))
+    }
+    "0x" + result.toString()
+  }
   private def stringToByteArray (x: String)  = new BigInteger(x.substring(2), 16).toByteArray
 
   private val ByteBufferTypeTag = implicitly[TypeTag[ByteBuffer]]

--- a/driver/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
+++ b/driver/src/main/scala/com/datastax/spark/connector/types/TypeConverter.scala
@@ -274,13 +274,13 @@ object TypeConverter {
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
   )
   private def byteArrayToString (x: Array[Byte]) : String = {
-    val result = new StringBuilder(x.length * 2) 
+    val result = new StringBuilder(x.length * 2 + 2).append("0x")
     x.foreach { b =>
       val v = b & 0xFF
       result.append(HEX_CHARS(v >>> 4))
       result.append(HEX_CHARS(v & 0x0F))
     }
-    "0x" + result.toString()
+    result.toString()
   }
   private def stringToByteArray (x: String)  = new BigInteger(x.substring(2), 16).toByteArray
 

--- a/driver/src/test/scala/com/datastax/spark/connector/types/TypeConverterTest.scala
+++ b/driver/src/test/scala/com/datastax/spark/connector/types/TypeConverterTest.scala
@@ -154,6 +154,13 @@ class TypeConverterTest {
   }
 
   @Test
+  def testByteArrayToString() {
+    val c = TypeConverter.forType[String]
+    val byteArray : Array[Byte] = Array(1,3,-56,45,23,67)
+    assertEquals("0x0103c82d1743", c.convert(byteArray))
+  }
+
+  @Test
   def testDate() {
     val c = TypeConverter.forType[Date]
     val dateStr = "2014-04-23 11:21:32+0100"


### PR DESCRIPTION
# Description
This change optimises byte array to hex string conversion 
Current implementation uses string formatting which needs to parse the format for every byte. This takes a lot of time and CPU.
New implementation uses bit operations.

## How did the Spark Cassandra Connector Work or Not Work Before this Patch

Below code demonstrates the time taken by the two implementations (>600ms to <20ms for 1Million bytearray)

```
//create random byte array of 1 Million bytes
val byteArray = (1 to 1000000).map(x => ((x%128). * ( if x%2 == 0 then -1 else 1)).toByte).toArray

// Time taken by current code ~ 800ms
var start = System.currentTimeMillis();
var hexString = "0x" + byteArray.map("%02x" format _).mkString
var end = System.currentTimeMillis()
print("time taken : " + (end - start)) // time taken : 854


//Time taken by new code ~ 15 ms 
start = System.currentTimeMillis();
hexString = byteArrayToHexString(byteArray)
end = System.currentTimeMillis()
print("time taken : " + (end - start)) // time taken : 14
```	


## General Design of the patch

Why pursue this particular fix?
We found lots of threads busy/occupied  parsing the format while converting the byteArray to String in our application. 


Fixes: [CASSANALYTICS-68](https://issues.apache.org/jira/browse/CASSANALYTICS-68)

# How Has This Been Tested?

Unit Tests.

# Checklist:

- [x] I have a ticket in the [JIRA](https://issues.apache.org/jira/projects/CASSANALYTICS)
- [x] I have performed a self-review of my own code
- [x] Locally all tests pass (make sure tests fail without your patch)
